### PR TITLE
Hotfix - API - Se corrige el número de puerto usado en el log

### DIFF
--- a/eda/eda_api/lib/server.ts
+++ b/eda/eda_api/lib/server.ts
@@ -32,7 +32,7 @@ app.use(function(err: IError, req, res, next) {
 });
 
 app.listen(PORT, () => {
-    console.log('\n\x1b[34m=====\x1b[0m Server start on port \x1b[32m[8666] \x1b[0m \x1b[34m=====\x1b[0m\n');
+    console.log('\n\x1b[34m=====\x1b[0m Server start on port \x1b[32m['+PORT+'] \x1b[0m \x1b[34m=====\x1b[0m\n');
 });
 
 /**


### PR DESCRIPTION
## Descripción

Este Pull Request actualiza el mensaje de inicio del servidor para mostrar el puerto en el que se está ejecutando la aplicación mostrando el puerto real en lugar de la cadena fija `8666`

## Pruebas
Reiniciar la api y comprobar que el log realmente muestra el puerto definido en la constante `PORT`