### PR TITLE
Sda #171   preparación para traducción a gallego

### DIFF
--- a/eda/eda_app/angular.json
+++ b/eda/eda_app/angular.json
@@ -18,6 +18,9 @@
                     },
                     "pl": {
                         "translation": "src/locale/messages.pl.xlf"
+                    }, 
+                    "gl": {
+                        "translation": "src/locale/messages.gl.xlf"
                     }
                 }
             },
@@ -75,6 +78,10 @@
                             "localize": [
                                 "pl"
                             ]
+                        },"gl": {
+                            "localize": [
+                                "gl"
+                            ]
                         },
                         "production": {
                             "fileReplacements": [
@@ -122,6 +129,9 @@
                         },
                         "pl": {
                             "browserTarget": "app-eda:build:pl"
+                        },
+                        "gl": {
+                            "browserTarget": "app-eda:build:gl"
                         }
                     }
                 },

--- a/eda/eda_app/src/app/core/pages/login/login.component.ts
+++ b/eda/eda_app/src/app/core/pages/login/login.component.ts
@@ -100,7 +100,9 @@ export class LoginComponent implements OnInit {
         if( baseUrl.slice(-4) ==  '/es/'  || 
             baseUrl.slice(-4) ==  '/ca/'  ||  
             baseUrl.slice(-4) ==  '/pl/'  ||  
-            baseUrl.slice(-4) ==  '/en/'   ){
+            baseUrl.slice(-4) ==  '/en/'  ||
+            baseUrl.slice(-4) ==  '/gl/'
+             ){
                 baseUrl  = baseUrl.slice(0, baseUrl.length -3)
             }
         switch(lan){
@@ -108,6 +110,7 @@ export class LoginComponent implements OnInit {
             case 'CAT' : window.location.href = baseUrl + 'ca/#/'; break;
             case 'ES'  : window.location.href = baseUrl + 'es/#/'; break;
             case 'PL'  : window.location.href = baseUrl + 'pl/#/'; break;
+            case 'GL'  : window.location.href = baseUrl + 'gl/#/'; break;
         }
     }
 }

--- a/eda/eda_app/src/app/shared/components/sidebar/sidebar.component.html
+++ b/eda/eda_app/src/app/shared/components/sidebar/sidebar.component.html
@@ -129,6 +129,10 @@
                         <li>
                             <a  style="cursor: pointer;" (click)="redirectLocale('PL')" >Polski</a>
                         </li>
+                        <li>
+                            <a  style="cursor: pointer;" (click)="redirectLocale('GL')" >Galego</a>
+                        </li>
+                        
                     </ul>
                 </li>
                 <li class="nav-devider"></li>

--- a/eda/eda_app/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/eda/eda_app/src/app/shared/components/sidebar/sidebar.component.ts
@@ -156,7 +156,9 @@ export class SidebarComponent implements OnInit {
         if (baseUrl.slice(-4) == '/es/' ||
             baseUrl.slice(-4) == '/ca/' ||
             baseUrl.slice(-4) == '/pl/' ||
-            baseUrl.slice(-4) == '/en/') {
+            baseUrl.slice(-4) == '/en/' ||
+            baseUrl.slice(-4) == '/gl/' ) 
+            {
             baseUrl = baseUrl.slice(0, baseUrl.length - 3)
         }
         switch (lan) {
@@ -164,6 +166,7 @@ export class SidebarComponent implements OnInit {
             case 'CAT': window.location.href = baseUrl + 'ca/#/home'; break;
             case 'ES': window.location.href = baseUrl + 'es/#/home'; break;
             case 'PL'  : window.location.href = baseUrl + 'pl/#/home'; break;
+            case 'GL'  : window.location.href = baseUrl + 'gl/#/home'; break;
         }
     }
     public checkNotSaved(){

--- a/eda/eda_app/src/index_locale.html
+++ b/eda/eda_app/src/index_locale.html
@@ -10,6 +10,8 @@
                 window.location.href = window.location.href.replace('/index.html','')+'/ca';
         }else if(userLang.indexOf('pl') >=0){
                 window.location.href = window.location.href.replace('/index.html','')+'/pl';
+        }else if(userLang.indexOf('gl') >=0){
+                window.location.href = window.location.href.replace('/index.html','')+'/gl';
         }else{
                 window.location.href = window.location.href.replace('/index.html','')+'/en';
         }

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -1,0 +1,3935 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2"
+  xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en-US" datatype="plaintext" original="ng2.template">
+    <body>
+      <trans-unit id="placeholderInputUsuario" datatype="html">
+        <source>Usuario</source>
+        <target>User</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/pages/login/login.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="placeholderInputPassword" datatype="html">
+        <source>Contraseña</source>
+        <target>Password</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/pages/login/login.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="spanRememberme" datatype="html">
+        <source>Recuérdame</source>
+        <target>Remember me</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/pages/login/login.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="signinBtn" datatype="html">
+        <source>Ingresar</source>
+        <target>Login</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/pages/login/login.component.html</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="e369e13629132e32dcd958b82261059243f21d58" datatype="html">
+        <source>Contraseña</source>
+        <target>Password</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/pages/register/register.component.html</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="d554461cfe5e5317e9257ceb0f9f96bec13c86c4" datatype="html">
+        <source>Confirma contraseña</source>
+        <target>Confirm password</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/core/pages/register/register.component.html</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="terms1" datatype="html">
+        <source> Estoy de acuerdo con los <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>
+términos<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>
+      </source>
+      <target> I'm agree with <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>
+terms<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>
+    </target>
+    <context-group purpose="location">
+      <context context-type="sourcefile">app/core/pages/register/register.component.html</context>
+      <context context-type="linenumber">42</context>
+    </context-group>
+  </trans-unit>
+  <trans-unit id="haveAccount" datatype="html">
+    <source>
+							¿Tienes una cuenta? <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>
+    <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>
+Ingresa ahora<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/>
+  <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>
+</source>
+<target>
+							Have an account? <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>
+<x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>
+Login<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/>
+<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/core/pages/register/register.component.html</context>
+<context context-type="linenumber">54</context>
+</context-group>
+</trans-unit>
+<trans-unit id="sidebarProfile" datatype="html">
+<source>Perfil</source>
+<target>Profile</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/shared/components/sidebar/sidebar.component.html</context>
+<context context-type="linenumber">42</context>
+</context-group>
+</trans-unit>
+<trans-unit id="sidebarUserManagement" datatype="html">
+<source>Gestión de
+                                    Usuarios</source>
+<target>Users management</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/shared/components/sidebar/sidebar.component.html</context>
+<context context-type="linenumber">47</context>
+</context-group>
+</trans-unit>
+<trans-unit id="sidebarGroupManagement" datatype="html">
+<source>Gestión de
+                                    Grupos</source>
+<target>Groups management</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/shared/components/sidebar/sidebar.component.html</context>
+<context context-type="linenumber">51</context>
+</context-group>
+</trans-unit>
+<trans-unit id="sidebarLogOut" datatype="html">
+<source>Cerrar sesión</source>
+<target>Close session</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/shared/components/sidebar/sidebar.component.html</context>
+<context context-type="linenumber">57</context>
+</context-group>
+</trans-unit>
+<trans-unit id="sidebarMyDashboards" datatype="html">
+<source>Mis informes</source>
+<target>My dashboards</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/shared/components/sidebar/sidebar.component.html</context>
+<context context-type="linenumber">68</context>
+</context-group>
+</trans-unit>
+<trans-unit id="sidebarDataFonts" datatype="html">
+<source>Fuente de Datos</source>
+<target>Datasources</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/shared/components/sidebar/sidebar.component.html</context>
+<context context-type="linenumber">77</context>
+</context-group>
+</trans-unit>
+<trans-unit id="sidebarNewDb" datatype="html">
+<source>Nueva Fuente</source>
+<target>New datasource</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/shared/components/sidebar/sidebar.component.html</context>
+<context context-type="linenumber">82</context>
+</context-group>
+</trans-unit>
+<trans-unit id="sidebarEditDb" datatype="html">
+<source>Editar Fuente</source>
+<target>Edit datasource</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/shared/components/sidebar/sidebar.component.html</context>
+<context context-type="linenumber">87</context>
+</context-group>
+</trans-unit>
+<trans-unit id="conditionsP1" datatype="html">
+<source>Esta aplicación es una demo.</source>
+<target>This app is a demo.</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/core/pages/conditions/conditions.component.html</context>
+<context context-type="linenumber">3</context>
+</context-group>
+</trans-unit>
+<trans-unit id="conditionsP2" datatype="html">
+<source>No ofrece ninguna garantía y no somos responsables del uso que se haga de la misma.</source>
+<target>It does not offer any guarantee and we are not responsible for its use.</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/core/pages/conditions/conditions.component.html</context>
+<context context-type="linenumber">4</context>
+</context-group>
+</trans-unit>
+<trans-unit id="conditionsP3" datatype="html">
+<source>Usala bajo tu responsabilidad.</source>
+<target>Use it at your own risk.</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/core/pages/conditions/conditions.component.html</context>
+<context context-type="linenumber">5</context>
+</context-group>
+</trans-unit>
+<trans-unit id="cerrarBtn" datatype="html">
+<source>Cerrar</source>
+<target>Close</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/core/pages/conditions/conditions.component.html</context>
+<context context-type="linenumber">10</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/home/create-dashboard/create-dashboard.component.html</context>
+<context context-type="linenumber">26</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/users-management/users-detail/users-detail.component.html</context>
+<context context-type="linenumber">33</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/table-relations-dialog/table-relations-dialog.component.html</context>
+<context context-type="linenumber">30</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/column-permissions-dialog/column-permission-dialog.component.html</context>
+<context context-type="linenumber">27</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/calculatedColumn-dialog/calculated-column-dialog.component.html</context>
+<context context-type="linenumber">28</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/mapsDialog/maps-dialog.component.html</context>
+<context context-type="linenumber">81</context>
+</context-group>
+</trans-unit>
+<trans-unit id="publicDashboardTitle" datatype="html">
+<source> Informe público EDA</source>
+<target> Public EDA dashboard</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/anonimous-login/anonymous-login.component.html</context>
+<context context-type="linenumber">1</context>
+</context-group>
+</trans-unit>
+<trans-unit id="agregacionesH4" datatype="html">
+<source>
+                Agregaciones
+</source>
+<target>
+                Aggregations
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html</context>
+<context context-type="linenumber">7</context>
+</context-group>
+</trans-unit>
+<trans-unit id="ordenacionH4" datatype="html">
+<source>
+                Ordenación
+</source>
+<target>
+                Ordenation
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html</context>
+<context context-type="linenumber">27</context>
+</context-group>
+</trans-unit>
+<trans-unit id="filtrarH4" datatype="html">
+<source>
+                Filtrar
+</source>
+<target>
+                Filter
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html</context>
+<context context-type="linenumber">47</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.html</context>
+<context context-type="linenumber">6</context>
+</context-group>
+</trans-unit>
+<trans-unit id="tiposFiltrosLabel" datatype="html">
+<source>
+                            Tipos de filtro
+</source>
+<target>
+                            Filter type
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html</context>
+<context context-type="linenumber">62</context>
+</context-group>
+</trans-unit>
+<trans-unit id="fechaLabel" datatype="html">
+<source>
+                                    Fecha
+</source>
+<target>
+                                    Date
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html</context>
+<context context-type="linenumber">78</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.html</context>
+<context context-type="linenumber">38</context>
+</context-group>
+</trans-unit>
+<trans-unit id="valorFiltrarLabel" datatype="html">
+<source>
+                                    Valor a filtrar
+</source>
+<target>
+                                    Filter value
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html</context>
+<context context-type="linenumber">97</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html</context>
+<context context-type="linenumber">116</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.html</context>
+<context context-type="linenumber">56</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.html</context>
+<context context-type="linenumber">74</context>
+</context-group>
+</trans-unit>
+<trans-unit id="fechaInicioLabel" datatype="html">
+<source>
+                                    Fecha inicio
+</source>
+<target>
+                                    Start date
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html</context>
+<context context-type="linenumber">137</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.html</context>
+<context context-type="linenumber">95</context>
+</context-group>
+</trans-unit>
+<trans-unit id="fechaFinalLabel" datatype="html">
+<source>
+                                    Fecha final
+</source>
+<target>
+                                   End date
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html</context>
+<context context-type="linenumber">153</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.html</context>
+<context context-type="linenumber">111</context>
+</context-group>
+</trans-unit>
+<trans-unit id="valor1Label" datatype="html">
+<source>
+                                    Valor 1
+</source>
+<target>
+                                    Value 1
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html</context>
+<context context-type="linenumber">176</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html</context>
+<context context-type="linenumber">209</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.html</context>
+<context context-type="linenumber">133</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.html</context>
+<context context-type="linenumber">164</context>
+</context-group>
+</trans-unit>
+<trans-unit id="valor2Label" datatype="html">
+<source>
+                                    Valor 2
+</source>
+<target>
+                                    Value 2
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html</context>
+<context context-type="linenumber">192</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html</context>
+<context context-type="linenumber">229</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.html</context>
+<context context-type="linenumber">147</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.html</context>
+<context context-type="linenumber">184</context>
+</context-group>
+</trans-unit>
+<trans-unit id="optionsLabel" datatype="html">
+<source>
+                                Opciones
+</source>
+<target>
+                                Options
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html</context>
+<context context-type="linenumber">254</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.html</context>
+<context context-type="linenumber">209</context>
+</context-group>
+</trans-unit>
+<trans-unit id="addFilterBtn" datatype="html">
+<source>Añadir filtro</source>
+<target>Add filter</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html</context>
+<context context-type="linenumber">273</context>
+</context-group>
+</trans-unit>
+<trans-unit id="dateFormatH4" datatype="html">
+<source>
+                        Formato
+</source>
+<target>
+                        Format
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html</context>
+<context context-type="linenumber">291</context>
+</context-group>
+</trans-unit>
+<trans-unit id="guardarButton" datatype="html">
+<source>Confirmar</source>
+<target>Confirm</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html</context>
+<context context-type="linenumber">364</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/chart-dialog/chart-dialog.component.html</context>
+<context context-type="linenumber">54</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/table-dialog/table-dialog.component.html</context>
+<context context-type="linenumber">18</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/maps-dialog/mapedit-dialog.component.html</context>
+<context context-type="linenumber">35</context>
+</context-group>
+</trans-unit>
+<trans-unit id="tiposFiltroLabel" datatype="html">
+<source>
+                        Tipos de filtro
+</source>
+<target>
+                        Filter types
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.html</context>
+<context context-type="linenumber">22</context>
+</context-group>
+</trans-unit>
+<trans-unit id="addFilterButton" datatype="html">
+<source>Añadir filtro</source>
+<target>Add filter</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.html</context>
+<context context-type="linenumber">228</context>
+</context-group>
+</trans-unit>
+<trans-unit id="guardarBtn" datatype="html">
+<source>Confirmar</source>
+<target>Confirm</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.html</context>
+<context context-type="linenumber">292</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/alert-dialog/alert-dialog.component.html</context>
+<context context-type="linenumber">10</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">360</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/home/create-dashboard/create-dashboard.component.html</context>
+<context context-type="linenumber">25</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/profile/profile.component.html</context>
+<context context-type="linenumber">37</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-sources.component.html</context>
+<context context-type="linenumber">94</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/table-relations-dialog/table-relations-dialog.component.html</context>
+<context context-type="linenumber">26</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/groups-management/group-detail/group-detail.component.html</context>
+<context context-type="linenumber">31</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/filter-dialog/dashboard-filter-dialog.component.html</context>
+<context context-type="linenumber">77</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/column-permissions-dialog/column-permission-dialog.component.html</context>
+<context context-type="linenumber">26</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/calculatedColumn-dialog/calculated-column-dialog.component.html</context>
+<context context-type="linenumber">25</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/mapsDialog/maps-dialog.component.html</context>
+<context context-type="linenumber">79</context>
+</context-group>
+</trans-unit>
+<trans-unit id="colorsChartH6" datatype="html">
+<source>
+                Colores
+</source>
+<target>
+                Colors
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/chart-dialog/chart-dialog.component.html</context>
+<context context-type="linenumber">19</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/maps-dialog/mapedit-dialog.component.html</context>
+<context context-type="linenumber">17</context>
+</context-group>
+</trans-unit>
+<trans-unit id="cancelarButton" datatype="html">
+<source>Cancelar</source>
+<target>Cancel</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/chart-dialog/chart-dialog.component.html</context>
+<context context-type="linenumber">58</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/table-dialog/table-dialog.component.html</context>
+<context context-type="linenumber">22</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/maps-dialog/mapedit-dialog.component.html</context>
+<context context-type="linenumber">38</context>
+</context-group>
+</trans-unit>
+<trans-unit id="dangerQuery" datatype="html">
+<source>¡Cuidado!</source>
+<target>Warning!</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/alert-dialog/alert-dialog.component.html</context>
+<context context-type="linenumber">3</context>
+</context-group>
+</trans-unit>
+<trans-unit id="dangerQueryText1" datatype="html">
+<source>La consulta que estás a punto de realizar es potencialmente pesada y puede tardar mas de lo normal en
+      ejecutarse.
+</source>
+<target>The query you are about to perform is potentially heavy and may take longer than normal to
+      run.
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/alert-dialog/alert-dialog.component.html</context>
+<context context-type="linenumber">4</context>
+</context-group>
+</trans-unit>
+<trans-unit id="dangerQueryText2" datatype="html">
+<source>Puedes añadir filtros o agregaciones para reducir el número de registros</source>
+<target>Try to add filters or aggregations to reduce the number of records</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/alert-dialog/alert-dialog.component.html</context>
+<context context-type="linenumber">7</context>
+</context-group>
+</trans-unit>
+<trans-unit id="dangerQueryText3" datatype="html">
+<source>¿Deseas continuar?</source>
+<target>Do you want to continue?</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/alert-dialog/alert-dialog.component.html</context>
+<context context-type="linenumber">8</context>
+</context-group>
+</trans-unit>
+<trans-unit id="cancelarBtn" datatype="html">
+<source>Cancelar</source>
+<target>Cancel</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/alert-dialog/alert-dialog.component.html</context>
+<context context-type="linenumber">14</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">364</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/filter-dialog/dashboard-filter-dialog.component.html</context>
+<context context-type="linenumber">80</context>
+</context-group>
+</trans-unit>
+<trans-unit id="LogarithmicScaleH6" datatype="html">
+<source> ¿Escala logarítmica?    </source>
+<target> Logarithmic scale?    </target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/maps-dialog/mapedit-dialog.component.html</context>
+<context context-type="linenumber">29</context>
+</context-group>
+</trans-unit>
+<trans-unit id="entidadesH4" datatype="html">
+<source>
+                            Entidades
+</source>
+<target>
+                            Entities
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">41</context>
+</context-group>
+</trans-unit>
+<trans-unit id="atributosH4" datatype="html">
+<source>
+                            Atributos
+</source>
+<target>
+                            Attributes
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">61</context>
+</context-group>
+</trans-unit>
+<trans-unit id="seleccionH4" datatype="html">
+<source>
+                            Mostrar los siguientes atributos:
+</source>
+<target>
+                            Show the following attributes:
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">86</context>
+</context-group>
+</trans-unit>
+<trans-unit id="filtrosH4" datatype="html">
+<source>
+                            Filtrar los resultados por:
+</source>
+<target>
+                            Filter the results by:
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">109</context>
+</context-group>
+</trans-unit>
+<trans-unit id="consultaH4" datatype="html">
+<source>
+                                Mi consulta
+</source>
+<target>
+                               My query
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">131</context>
+</context-group>
+</trans-unit>
+<trans-unit id="resumenAtrH6" datatype="html">
+<source>
+                                    Resumen de atributos
+</source>
+<target>
+                                    Attribute summary
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">137</context>
+</context-group>
+</trans-unit>
+<trans-unit id="resumenFiltrosPanelH6" datatype="html">
+<source>
+                                        Resumen de filtros del panel
+</source>
+<target>
+                                        Panel filters summary
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">155</context>
+</context-group>
+</trans-unit>
+<trans-unit id="resumenFiltrosInformeH6" datatype="html">
+<source>
+                                        Resumen de filtros del informe
+</source>
+<target>
+                                        Dashboard filters summary
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">166</context>
+</context-group>
+</trans-unit>
+<trans-unit id="sqlExpresionH6" datatype="html">
+<source>Expresión SQL</source>
+<target>SQL Expression</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">182</context>
+</context-group>
+</trans-unit>
+<trans-unit id="originTable" datatype="html">
+<source>Tabla origen</source>
+<target>Origin table</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">187</context>
+</context-group>
+</trans-unit>
+<trans-unit id="placeholderTables" datatype="html">
+<source>Tablas</source>
+<target>Tables</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">191</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/filter-dialog/dashboard-filter-dialog.component.html</context>
+<context context-type="linenumber">39</context>
+</context-group>
+</trans-unit>
+<trans-unit id="indicaciones" datatype="html">
+<source>Indicaciones</source>
+<target>Indications</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">198</context>
+</context-group>
+</trans-unit>
+<trans-unit id="indicaciones1" datatype="html">
+<source> Puedes realizar consultas SQL sobre el esquema definido en tu modelo. 
+                                    Para ello introduce la consulta en el cuadro de texto y selecciona la tabla principal 
+                                    (puede ser cualquiera de las que aparecen en la consulta).
+                                    Usaremos esta tabla para vincular la consulta a los filtros del informe. </source>
+<target>  You can perform SQL queries on the schema defined in your model. 
+                                    To do this, enter the query in the text box and select the main table
+                                    (It can be any of those that appear in the query).
+                                    We will use this table to link the query to the report filters. </target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">202</context>
+</context-group>
+</trans-unit>
+<trans-unit id="indicaciones2" datatype="html">
+<source> Limitaciones: </source>
+<target> Limitations: </target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">206</context>
+</context-group>
+</trans-unit>
+<trans-unit id="indicaciones3" datatype="html">
+<source>
+                                        Solo es posible usar las tablas del esquema definido en el modelo (si lo hay)
+</source>
+<target>It is only possible to use the tables of the schema defined in the model (if any).
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">209</context>
+</context-group>
+</trans-unit>
+<trans-unit id="indicaciones4" datatype="html">
+<source>
+                                        Debes utilizar alias para todas las tablas de la consulta ( select a,b from tabla t where c )
+</source>
+<target>
+                                        You must use aliases for all tables in the query (select a, b from table t where c)
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">212</context>
+</context-group>
+</trans-unit>
+<trans-unit id="indicaciones5" datatype="html">
+<source> Puedes vincular los filtros del informe con la consulta</source>
+<target> You can link the report filters with the query</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">218</context>
+</context-group>
+</trans-unit>
+<trans-unit id="indicaciones6" datatype="html">
+<source> Para hacerlo sólo tienes que añadir:
+<x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>
+ AND
+<x id="INTERPOLATION" equiv-text="{{&apos; ${alias_tabla.columna_filtrada} &apos;}}"/>
+<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/>
+ en la cláusula &apos;WHERE&apos; de la consulta donde quieras inyectar el filtro
+</source>
+<target> To do it you just have to add::
+<x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>
+ AND
+<x id="INTERPOLATION" equiv-text="{{&apos; ${alias_tabla.columna_filtrada} &apos;}}"/>
+<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/>
+ in &apos;WHERE&apos; clause from query
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">220</context>
+</context-group>
+</trans-unit>
+<trans-unit id="indicaciones7" datatype="html">
+<source> Si no has añadido ningúna cláusula WHERE, añádela a la
+                                        consulta y haz los joins necesarios,
+                                        junto con el filtro en el formato
+<x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>
+<x id="INTERPOLATION" equiv-text="{{&apos; ${alias_tabla.columna_filtrada} &apos;}}"/>
+<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/>
+</source>
+<target> If you haven't added any WHERE clause, add it to the query and make the necessary joins,
+                                        together with the filter in the format
+<x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>
+<x id="INTERPOLATION" equiv-text="{{&apos; ${alias_tabla.columna_filtrada} &apos;}}"/>
+<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/>
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">225</context>
+</context-group>
+</trans-unit>
+<trans-unit id="indicaciones8" datatype="html">
+<source>Si la tabla por la que filtramos no está en la consulta, recuerda que debes
+                                        añadir las cláusulas JOIN necesarias
+                                        para poder vicular la tabla del filtro con tu consulta
+</source>
+<target>If the table by which we filter is not in the query, remember that you must
+                                        add the necessary JOIN clauses
+                                        in order to link the filter table with your query
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">229</context>
+</context-group>
+</trans-unit>
+<trans-unit id="indicaciones9" datatype="html">
+<source>Consulta simple</source>
+<target>Simple query</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">237</context>
+</context-group>
+</trans-unit>
+<trans-unit id="indicaciones10" datatype="html">
+<source>Consulta con los filtros del informe vinculados</source>
+<target>Query with linked report filters</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">246</context>
+</context-group>
+</trans-unit>
+<trans-unit id="indicaciones11" datatype="html">
+<source> Tenemos un filtro en el informe para el campo &apos;city&apos; de la tabla CUSTOMERS</source>
+<target> We have a filter in the report for the &apos;city&apos; field from CUSTOMERS table</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">248</context>
+</context-group>
+</trans-unit>
+<trans-unit id="indicaciones12" datatype="html">
+<source> Consulta sin filtros vinculados</source>
+<target> Query without linked filters</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">249</context>
+</context-group>
+</trans-unit>
+<trans-unit id="indicaciones13" datatype="html">
+<source> Consulta con filtros vinculados</source>
+<target> Query with linked filters</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">254</context>
+</context-group>
+</trans-unit>
+<trans-unit id="indicaciones14" datatype="html">
+<source> Tenemos un filtro en el informe para el campo &apos;office_id&apos; de la tabla OFFICES
+</source>
+<target> We have a filter in the report for the field &apos;office_id&apos; from OFFICES table
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">262</context>
+</context-group>
+</trans-unit>
+<trans-unit id="indicaciones15" datatype="html">
+<source> Consulta sin filtros vinculados</source>
+<target> Query without linked filters</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">265</context>
+</context-group>
+</trans-unit>
+<trans-unit id="indicaciones16" datatype="html">
+<source> Consulta con filtros vinculados</source>
+<target> Query with linked filters</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">271</context>
+</context-group>
+</trans-unit>
+<trans-unit id="vistaSeleccionador" datatype="html">
+<source>
+<x id="INTERPOLATION" equiv-text="{{!modeSQL ? editQuery : editSQLQuery}}"/>
+</source>
+<target>
+<x id="INTERPOLATION" equiv-text="{{!modeSQL ? editQuery : editSQLQuery}}"/>
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">37</context>
+</context-group>
+</trans-unit>
+<trans-unit id="vistaPrevia" datatype="html">
+<source>VISTA PREVIA</source>
+<target>PREVIEW</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">291</context>
+</context-group>
+</trans-unit>
+<trans-unit id="ejecutarBtn" datatype="html">
+<source>Ejecutar</source>
+<target>Execute</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">356</context>
+</context-group>
+</trans-unit>
+<trans-unit id="tituloNuevoInforme" datatype="html">
+<source>
+                    CREAR UN NUEVO INFORME
+</source>
+<target>
+                    CREATE A NEW DASHBOARD
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/home/home.component.html</context>
+<context context-type="linenumber">7</context>
+</context-group>
+</trans-unit>
+<trans-unit id="tituloGrupoPublicos" datatype="html">
+<source>
+                PUBLICOS
+</source>
+<target>
+                PUBLIC
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/home/home.component.html</context>
+<context context-type="linenumber">20</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/home/home.component.html</context>
+<context context-type="linenumber">44</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/calculatedColumn-dialog/calculated-column-dialog.component.html</context>
+<context context-type="linenumber">3</context>
+</context-group>
+</trans-unit>
+<trans-unit id="tituloGrupoMisGrupos" datatype="html">
+<source>
+                MIS GRUPOS
+</source>
+<target>
+                MY GROUPS
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/home/home.component.html</context>
+<context context-type="linenumber">68</context>
+</context-group>
+</trans-unit>
+<trans-unit id="tituloGrupoPersonales" datatype="html">
+<source>
+                PRIVADOS
+</source>
+<target>
+                PRIVATE
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/home/home.component.html</context>
+<context context-type="linenumber">101</context>
+</context-group>
+</trans-unit>
+<trans-unit id="labelDameNombre" datatype="html">
+<source>Dame un nombre *</source>
+<target>Give me a name *</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/home/create-dashboard/create-dashboard.component.html</context>
+<context context-type="linenumber">7</context>
+</context-group>
+</trans-unit>
+<trans-unit id="buscarPorNombre" datatype="html">
+<source>Buscar por nombre del informe</source>
+<target>Search by report name</target>
+</trans-unit>
+<trans-unit id="buscar" datatype="html">
+<source>Buscar</source>
+<target>Search</target>
+</trans-unit>
+<trans-unit id="selectFuenteDatos" datatype="html">
+<source>Selecciona una fuente de datos *</source>
+<target>Select datasource *</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/home/create-dashboard/create-dashboard.component.html</context>
+<context context-type="linenumber">11</context>
+</context-group>
+</trans-unit>
+<trans-unit id="deleteDates" datatype="html">
+<source> Todas </source>
+<target> All </target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/dashboard.component.html</context>
+<context context-type="linenumber">36</context>
+</context-group>
+</trans-unit>
+<trans-unit id="yesterday" datatype="html">
+<source> Ayer </source>
+<target> Yesterday </target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/dashboard.component.html</context>
+<context context-type="linenumber">38</context>
+</context-group>
+</trans-unit>
+<trans-unit id="thisWeek" datatype="html">
+<source> Ésta semana </source>
+<target> This week </target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/dashboard.component.html</context>
+<context context-type="linenumber">39</context>
+</context-group>
+</trans-unit>
+<trans-unit id="thisMonth" datatype="html">
+<source> Éste mes </source>
+<target> This month </target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/dashboard.component.html</context>
+<context context-type="linenumber">40</context>
+</context-group>
+</trans-unit>
+<trans-unit id="thisYear" datatype="html">
+<source> Éste año </source>
+<target> This year </target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/dashboard.component.html</context>
+<context context-type="linenumber">41</context>
+</context-group>
+</trans-unit>
+<trans-unit id="opcionPanel" datatype="html">
+<source>NUEVO PANEL</source>
+<target>NEW PANEL</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/dashboard.component.html</context>
+<context context-type="linenumber">130</context>
+</context-group>
+</trans-unit>
+<trans-unit id="opcionTitulo" datatype="html">
+<source>NUEVO TEXTO</source>
+<target>NEW TEXT</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/dashboard.component.html</context>
+<context context-type="linenumber">137</context>
+</context-group>
+</trans-unit>
+<trans-unit id="opcionFiltro" datatype="html">
+<source>NUEVO FILTRO</source>
+<target>NEW FILTER</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/dashboard.component.html</context>
+<context context-type="linenumber">144</context>
+</context-group>
+</trans-unit>
+<trans-unit id="opcionInforme" datatype="html">
+<source>RECARGAR INFORME</source>
+<target>RELOAD DASHBOARD</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/dashboard.component.html</context>
+<context context-type="linenumber">153</context>
+</context-group>
+</trans-unit>
+<trans-unit id="opcionGuardar" datatype="html">
+<source>GUARDAR</source>
+<target>SAVE</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/dashboard.component.html</context>
+<context context-type="linenumber">160</context>
+</context-group>
+</trans-unit>
+<trans-unit id="opcionPdf" datatype="html">
+<source>DESCARGAR PDF</source>
+<target>DOWNLOAD PDF</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/dashboard.component.html</context>
+<context context-type="linenumber">167</context>
+</context-group>
+</trans-unit>
+<trans-unit id="opcionImagen" datatype="html">
+<source>DESCARGAR IMAGEN</source>
+<target>DOWNLOAD IMAGE</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/dashboard.component.html</context>
+<context context-type="linenumber">174</context>
+</context-group>
+</trans-unit>
+<trans-unit id="temasColors" datatype="html">
+<source>Temas</source>
+<target>Themes</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/account-settings/account-settings.component.html</context>
+<context context-type="linenumber">5</context>
+</context-group>
+</trans-unit>
+<trans-unit id="menuClaro" datatype="html">
+<source>Con el menu claro</source>
+<target>Light theme</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/account-settings/account-settings.component.html</context>
+<context context-type="linenumber">9</context>
+</context-group>
+</trans-unit>
+<trans-unit id="menuOscuro" datatype="html">
+<source>Con el menu oscuro</source>
+<target>Dark theme</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/account-settings/account-settings.component.html</context>
+<context context-type="linenumber">17</context>
+</context-group>
+</trans-unit>
+<trans-unit id="tituloPerfilUsuario" datatype="html">
+<source>Perfil del usuario</source>
+<target>User profile</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/profile/profile.component.html</context>
+<context context-type="linenumber">6</context>
+</context-group>
+</trans-unit>
+<trans-unit id="labelNombreUsuario" datatype="html">
+<source>Nombre de usuario</source>
+<target>User name</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/profile/profile.component.html</context>
+<context context-type="linenumber">10</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/profile/profile.component.html</context>
+<context context-type="linenumber">14</context>
+</context-group>
+</trans-unit>
+<trans-unit id="labelUsuarioEmail" datatype="html">
+<source>Correo de usuario</source>
+<target>User email</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/profile/profile.component.html</context>
+<context context-type="linenumber">18</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/profile/profile.component.html</context>
+<context context-type="linenumber">23</context>
+</context-group>
+</trans-unit>
+<trans-unit id="labelImagenUsuario" datatype="html">
+<source>
+                    Fotografía del usuario</source>
+<target>
+                    User pic</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/profile/profile.component.html</context>
+<context context-type="linenumber">48</context>
+</context-group>
+<note priority="1" from="description">Label del input imagen de usuario</note>
+<note priority="1" from="meaning">Label Input Imagen</note>
+</trans-unit>
+<trans-unit id="button" datatype="html">
+<source>Actualizar Foto</source>
+<target>Update pic </target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/profile/profile.component.html</context>
+<context context-type="linenumber">63</context>
+</context-group>
+<note priority="1" from="description">Button actualizar foto profile</note>
+<note priority="1" from="meaning">Button</note>
+</trans-unit>
+<trans-unit id="nuevoUsuarioBtn" datatype="html">
+<source>Crear usuario</source>
+<target>Create user</target>
+<source>Crear usuario</source>
+<target>Create user</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/users-management/users-list/users-list.component.html</context>
+<context context-type="linenumber">5</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputNombre" datatype="html">
+<source>Nombre *</source>
+<target>Name *</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/users-management/users-detail/users-detail.component.html</context>
+<context context-type="linenumber">4</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/users-management/users-detail/users-detail.component.html</context>
+<context context-type="linenumber">5</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-sources.component.html</context>
+<context context-type="linenumber">8</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">6</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">53</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">147</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/groups-management/group-detail/group-detail.component.html</context>
+<context context-type="linenumber">6</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/calculatedColumn-dialog/calculated-column-dialog.component.html</context>
+<context context-type="linenumber">10</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputEmail" datatype="html">
+<source>Correo *</source>
+<target>Email *</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/users-management/users-detail/users-detail.component.html</context>
+<context context-type="linenumber">8</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/users-management/users-detail/users-detail.component.html</context>
+<context context-type="linenumber">9</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputPassword" datatype="html">
+<source>Contraseña *</source>
+<target>Password *</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/users-management/users-detail/users-detail.component.html</context>
+<context context-type="linenumber">12</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/users-management/users-detail/users-detail.component.html</context>
+<context context-type="linenumber">13</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-sources.component.html</context>
+<context context-type="linenumber">85</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">195</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputSeguridad" datatype="html">
+<source>Seguridad *</source>
+<target>Security *</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/users-management/users-detail/users-detail.component.html</context>
+<context context-type="linenumber">16</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputRepitePassword" datatype="html">
+<source>Repite la contraseña</source>
+<target>Repeat password</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/users-management/users-detail/users-detail.component.html</context>
+<context context-type="linenumber">17</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputGrupo" datatype="html">
+<source>Grupo *</source>
+<target>Group *</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/users-management/users-detail/users-detail.component.html</context>
+<context context-type="linenumber">22</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputTipo" datatype="html">
+<source>TIPO *</source>
+<target>TYPE*</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-sources.component.html</context>
+<context context-type="linenumber">15</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">157</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">162</context>
+</context-group>
+</trans-unit>
+<trans-unit id="placholderSelectTipo" datatype="html">
+<source>Selecciona un tipo</source>
+<target>Select type</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-sources.component.html</context>
+<context context-type="linenumber">17</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputServidor" datatype="html">
+<source>SERVIDOR *</source>
+<target>SERVER *</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-sources.component.html</context>
+<context context-type="linenumber">25</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-sources.component.html</context>
+<context context-type="linenumber">32</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-sources.component.html</context>
+<context context-type="linenumber">41</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputNombreDb" datatype="html">
+<source>BASE DE DATOS *</source>
+<target>DATABASE *</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-sources.component.html</context>
+<context context-type="linenumber">49</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputNombreDb2" datatype="html">
+<source>BASE DE DATOS *</source>
+<target>DATABASE *</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-sources.component.html</context>
+<context context-type="linenumber">56</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputNombreEsquema" datatype="html">
+<source>ESQUEMA</source>
+<target>SCHEMA</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-sources.component.html</context>
+<context context-type="linenumber">64</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputPort" datatype="html">
+<source>PUERTO *</source>
+<target>PORT *</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-sources.component.html</context>
+<context context-type="linenumber">71</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputUsuario" datatype="html">
+<source>USUARIO *</source>
+<target>USER *</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-sources.component.html</context>
+<context context-type="linenumber">78</context>
+</context-group>
+</trans-unit>
+<trans-unit id="tituloCard" datatype="html">
+<source>Modelo de datos</source>
+<target>Datamodel</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-list/data-source-list.component.html</context>
+<context context-type="linenumber">18</context>
+</context-group>
+<note priority="1" from="description">Titulo card</note>
+<note priority="1" from="meaning">Titulo Card</note>
+</trans-unit>
+<trans-unit id="inputNombreTecnico" datatype="html">
+<source>Nombre técnico</source>
+<target>Technical name</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">11</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">60</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputDescripcion" datatype="html">
+<source> Descripción </source>
+<target> Description </target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">16</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">67</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/calculatedColumn-dialog/calculated-column-dialog.component.html</context>
+<context context-type="linenumber">15</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputEsconderTabla" datatype="html">
+<source>Esconder tabla</source>
+<target>Hide table</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">21</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputTipoTabla" datatype="html">
+<source>Tipo de tabla</source>
+<target>Table type</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">27</context>
+</context-group>
+</trans-unit>
+<trans-unit id="addRelation" datatype="html">
+<source>Añadir relación</source>
+<target>Add relation</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">36</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputTipoColumna" datatype="html">
+<source>
+                Tipo de columna
+</source>
+<target>
+                Column type
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">80</context>
+</context-group>
+</trans-unit>
+<trans-unit id="agregacionH6" datatype="html">
+<source>
+                Agregación
+</source>
+
+<target>
+                Aggregation
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">90</context>
+</context-group>
+</trans-unit>
+<trans-unit id="rolesPermisos" datatype="html">
+<source>Roles y permisos de fila</source>
+<target>Row roles and permissions</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">102</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="addPermission" datatype="html">
+<source> Añadir permiso </source>
+<target> Add permission </target>
+</trans-unit>
+
+
+
+<trans-unit id="addModelPermissions" datatype="html">
+  <source>Añadir permiso a nivel de modelo</source>
+  <target>Add model-level permission</target>
+</trans-unit>
+
+
+
+<trans-unit id="esconderColumna" datatype="html">
+<source>Esconder columna</source>
+<target>Hide column</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">112</context>
+</context-group>
+</trans-unit>
+<trans-unit id="metadata" datatype="html">
+<source>
+            Metadata
+</source>
+<target>
+            Metadata
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">142</context>
+</context-group>
+</trans-unit>
+<trans-unit id="conexionh4" datatype="html">
+<source>
+            Conexión
+</source>
+<target>
+            Connection
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">153</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputHost" datatype="html">
+<source>
+                Host
+</source>
+<target>
+                Host
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">167</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputNombreDB" datatype="html">
+<source>
+                Base de datos
+</source>
+<target>
+                Database
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">174</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">181</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputNombreUsuario" datatype="html">
+<source>
+                Usuario
+</source>
+<target>
+                User
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">188</context>
+</context-group>
+</trans-unit>
+<trans-unit id="placeholderSourceColumns" datatype="html">
+<source>Columna origen</source>
+
+<target>Origin column</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/table-relations-dialog/table-relations-dialog.component.html</context>
+<context context-type="linenumber">8</context>
+</context-group>
+</trans-unit>
+<trans-unit id="placeholderTargetTables" datatype="html">
+<source>tabla destino</source>
+<target>Destination table</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/table-relations-dialog/table-relations-dialog.component.html</context>
+<context context-type="linenumber">14</context>
+</context-group>
+</trans-unit>
+<trans-unit id="placeholderTargetColumns" datatype="html">
+<source>Columna destino </source>
+<target>destination column</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/table-relations-dialog/table-relations-dialog.component.html</context>
+<context context-type="linenumber">19</context>
+</context-group>
+</trans-unit>
+<trans-unit id="placeholderTargetColumnId" datatype="html">
+<source>Columna con el id </source>
+<target>Column with the id</target>
+</trans-unit>
+<trans-unit id="placeholderTargetColumnDesc" datatype="html">
+<source>Columna con la descripción </source>
+<target>Column with the description</target>
+</trans-unit>
+<trans-unit id="crearGrupoLabel" datatype="html">
+<source>Crear grupo</source>
+<target>Create group</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/groups-management/group-list/group-list.component.html</context>
+<context context-type="linenumber">5</context>
+</context-group>
+</trans-unit>
+<trans-unit id="0acf4e0f9350f920b529a38364281d337c54edfd" datatype="html">
+<source>Cerrar</source>
+<target>Close</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/groups-management/group-detail/group-detail.component.html</context>
+<context context-type="linenumber">32</context>
+</context-group>
+<note priority="1" from="description">cerrarBtn</note>
+</trans-unit>
+<trans-unit id="aplyToAllPanelsH5" datatype="html">
+<source>
+            ¿Aplica a todos los paneles?
+</source>
+<target>Does it apply to all panels?
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/filter-dialog/dashboard-filter-dialog.component.html</context>
+<context context-type="linenumber">5</context>
+</context-group>
+</trans-unit>
+<trans-unit id="panelsToAplyH5" datatype="html">
+<source>
+                Paneles para los que aplica el filtro
+</source>
+<target> Panels for which the filter applies
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/filter-dialog/dashboard-filter-dialog.component.html</context>
+<context context-type="linenumber">14</context>
+</context-group>
+</trans-unit>
+<trans-unit id="filterForH5" datatype="html">
+<source>
+                Filtrar por
+</source>
+
+<target>
+                Filter by
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/filter-dialog/dashboard-filter-dialog.component.html</context>
+<context context-type="linenumber">30</context>
+</context-group>
+</trans-unit>
+<trans-unit id="placeholderColumns" datatype="html">
+<source>Atributos</source>
+<target>Attributes</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/dashboard/filter-dialog/dashboard-filter-dialog.component.html</context>
+<context context-type="linenumber">46</context>
+</context-group>
+</trans-unit>
+<trans-unit id="tituloPermisosColumna" datatype="html">
+<source>Añadir permiso</source>
+<target>Add permission</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/column-permissions-dialog/column-permission-dialog.component.html</context>
+<context context-type="linenumber">3</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputMapTables" datatype="html">
+<source>Propiedades del mapa</source>
+<target>Map properties</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/mapsDialog/maps-dialog.component.html</context>
+<context context-type="linenumber">6</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/mapsDialog/maps-dialog.component.html</context>
+<context context-type="linenumber">51</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputMapURL" datatype="html">
+<source> Subir archivo GeoJson (JSON)</source>
+<target>Upload GeoJson file (JSON)</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/mapsDialog/maps-dialog.component.html</context>
+<context context-type="linenumber">9</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputMapField" datatype="html">
+<source>Campo a usar para vincular el modelo con el mapa</source>
+<target>Field to link datamodel to the map</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/mapsDialog/maps-dialog.component.html</context>
+<context context-type="linenumber">14</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputMapName" datatype="html">
+<source>Nombre del mapa</source>
+<target>Map name</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/mapsDialog/maps-dialog.component.html</context>
+<context context-type="linenumber">19</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputx" datatype="html">
+<source> Centro del mapa (Latitud, Longitud)</source>
+<target> Map center (Latitude, Longitude)</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/mapsDialog/maps-dialog.component.html</context>
+<context context-type="linenumber">26</context>
+</context-group>
+</trans-unit>
+<trans-unit id="avaliableMaps" datatype="html">
+<source>Mapas disponibles</source>
+<target>Available maps</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/mapsDialog/maps-dialog.component.html</context>
+<context context-type="linenumber">33</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputMapColumnsText" datatype="html">
+<source>Vincular columnas al mapa</source>
+<target>Link colums to the map</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/mapsDialog/maps-dialog.component.html</context>
+<context context-type="linenumber">47</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputMapColumns" datatype="html">
+<source>Columnas</source>
+<target>Columns</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/mapsDialog/maps-dialog.component.html</context>
+<context context-type="linenumber">57</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="borrar" datatype="html">
+<source>Borrar</source>
+<target>Delete</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">124</context>
+</context-group>
+</trans-unit>
+<trans-unit id="checkConnection" datatype="html">
+<source>Comprobar conexión</source>
+<target>Check connection</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">203</context>
+</context-group>
+</trans-unit>
+<trans-unit id="deleteModel" datatype="html">
+<source>Borrar modelo de datos</source>
+<target>Delete datamodel</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-list/data-source-list.component.html</context>
+<context context-type="linenumber">20</context>
+</context-group>
+</trans-unit>
+<trans-unit id="updateModel" datatype="html">
+<source>Actualizar modelo de datos desde la base de datos origen para buscar nuevas tablas y columnas</source>
+<target>Update data model from source database to find new tables and columns</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-list/data-source-list.component.html</context>
+<context context-type="linenumber">15</context>
+</context-group>
+</trans-unit>
+<trans-unit id="saveModel" datatype="html">
+<target>Save datamodel</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-list/data-source-list.component.html</context>
+<context context-type="linenumber">12</context>
+</context-group>
+</trans-unit>
+<trans-unit id="Refresh" datatype="html">
+<source>Tornar a carregar el model de dades emmagatzemat</source>
+<target>Reload the stored data model</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-list/data-source-list.component.html</context>
+<context context-type="linenumber">9</context>
+</context-group>
+</trans-unit>
+<trans-unit id="loading">
+<source>Cargando informe...</source>
+<target>Loading dashboard...</target>
+</trans-unit>
+<trans-unit id="addRelationButton" datatype="html">
+<source> Añadir relación </source>
+<target> Add relation </target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">36</context>
+</context-group>
+</trans-unit>
+<trans-unit id="addCalculatedCol" datatype="html">
+<source>Añadir columna calculada</source>
+<target>Add calculated column</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">41</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="targetRel">
+<source>Destino</source>
+<target>Target</target>
+</trans-unit>
+
+<trans-unit id="originRel">
+<source>Origen</source>
+<target>Origin</target>
+</trans-unit>
+
+<trans-unit id="userTable">
+<source>USUARIO</source>
+<target>USER</target>
+</trans-unit>
+
+<trans-unit id="valueTable">
+<source>VALOR</source>
+<target>VALUE</target>
+</trans-unit>
+
+<trans-unit id="editModelHeaders" datatype="html">
+<source>Editar <x id="INTERPOLATION" equiv-text="{{tablePanel.type ? tablePanel.name : &apos;&apos;}}"/>
+</source>
+<target>Edit <x id="INTERPOLATION" equiv-text="{{tablePanel.type ? tablePanel.name : &apos;&apos;}}"/>
+</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">3</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">50</context>
+</context-group>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+<context context-type="linenumber">140</context>
+</context-group>
+</trans-unit>
+<trans-unit id="edaMode" datatype="html">
+<source>Modo EDA</source>
+<target>EDA Mode</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">344</context>
+</context-group>
+</trans-unit>
+<trans-unit id="sqlMode" datatype="html">
+<source>Modo SQL</source>
+<target>SQL mode</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+<context context-type="linenumber">345</context>
+</context-group>
+</trans-unit>
+<trans-unit id="panelOptions1">
+<source>Editar consulta</source>
+<target>Edit query</target>
+</trans-unit>
+
+<trans-unit id="panelOptions2">
+<source>Editar opciones del gráfico</source>
+<target>Editar chart options</target>
+</trans-unit>
+
+<trans-unit id="panelOptions3">
+<source>Exportar a Excel</source>
+<target>Excel export</target>
+</trans-unit>
+<trans-unit id="panelOptions4">
+<source>Eliminar panel</source>
+<target>Delete panel</target>
+</trans-unit>
+<trans-unit id="panelOptionsDup">
+<source>Duplicar panel</source>
+<target>Duplicate panel</target>
+</trans-unit>
+<trans-unit id="duplicateColumnButton">
+<source>Duplicar columna</source>
+<target>Duplicate column</target>
+</trans-unit>
+
+<trans-unit id="chartTypes1">
+<source>Tabla de Datos</source>
+<target>Table</target>
+</trans-unit>
+<trans-unit id="chartTypes2">
+<source>Tabla Cruzada</source>
+<target>Crosstable</target>
+</trans-unit>
+<trans-unit id="chartTypes3">
+<source>Gráfico de Pastel</source>
+<target>Pie chart</target>
+</trans-unit>
+<trans-unit id="chartTypes4">
+<source>Gráfico de Área Polar</source>
+<target>Polar area chart</target>
+</trans-unit>
+<trans-unit id="chartTypes5">
+<source>Gráfico de Barras</source>
+<target>Bar chart</target>
+</trans-unit>
+<trans-unit id="chartTypesHistograma">
+<source>Histograma</source>
+<target>Histogram</target>
+</trans-unit>
+<trans-unit id="chartTypes17">
+<source>Gráfico Solar</source>
+<target>Sunburst graph</target>
+</trans-unit>
+
+<trans-unit id="chartTypesDynamicText">
+<source>Texto Dinámico</source>
+<target>Dynamic Text</target>
+</trans-unit>
+<trans-unit id="chartInfoDynamicText">
+<source>Un texto dinámicos requiere de un único valor NO numérico</source>
+<target>A dynamic text requires a single NON-numeric value</target>
+</trans-unit>
+
+
+
+<trans-unit id="chartTypes6">
+<source>Gráfico de Barras Apliadas</source>
+<target>Stacked bar chart</target>
+</trans-unit>
+<trans-unit id="chartTypes7">
+<source>Gráfico de Barras Horizontales</source>
+<target>Horizontal bar chart</target>
+</trans-unit>
+<trans-unit id="chartTypesPyramid">
+<source>Gráfico de Piramide</source>
+<target>Pyramid chart</target>
+</trans-unit>
+<trans-unit id="chartTypes8">
+<source>Gráfico de Lineas</source>
+<target>Line chart</target>
+</trans-unit>
+<trans-unit id="chartTypes18">
+<source>Gráfico de Áreas</source>
+<target>Area chart</target>
+</trans-unit>
+<trans-unit id="chartTypes9">
+<source>Mixto: Barras y lineas</source>
+<target>Mixed: Bars and lines</target>
+</trans-unit>
+<trans-unit id="chartTypes10">
+<source>Mapa de coordenadas</source>
+<target>Coordinates map</target>
+</trans-unit>
+<trans-unit id="chartTypes11">
+<source>Mapa de Capas</source>
+<target>Layer Map</target>
+</trans-unit>
+
+<trans-unit id="chartTypes15">
+<source>Velocímetro</source>
+<target>Gauge</target>
+</trans-unit>
+
+<trans-unit id="filters1">
+<source>IGUAL A (=)</source>
+<target> EQUAL TO (=)</target>
+</trans-unit>
+<trans-unit id="filters2">
+<source>NO IGUAL A (!=)</source>
+<target>NOT EQUAL TO (!=)</target>
+</trans-unit>
+<trans-unit id="filters3">
+<source>MAYOR A (&gt;)</source>
+<target>GREATER THAN (&gt;) </target>
+</trans-unit>
+<trans-unit id="filters4">
+<source>MENOR A (&lt;) </source>
+<target>SMALLER THAN (&lt;) </target>
+</trans-unit>
+<trans-unit id="filters5">
+<source>MAYOR o IGUAL A (&gt;=) </source>
+<target>BIGGER OR EQUAL TO (&gt;=) </target>
+</trans-unit>
+<trans-unit id="filters6">
+<source>MENOR o IGUAL A (&lt;=) </source>
+<target>SMALLER OR EQUAL TO (&lt;=) </target>
+</trans-unit>
+<trans-unit id="filters7">
+<source>ENTRE (between) </source>
+<target>BETWEEN </target>
+</trans-unit>
+<trans-unit id="filters8">
+<source>DENTRO DE (in) </source>
+<target> IN </target>
+</trans-unit>
+<trans-unit id="filters9">
+<source>FUERA DE (not in) </source>
+<target> NOT IN </target>
+</trans-unit>
+<trans-unit id="filters10">
+<source>PARECIDO A (like) </source>
+<target>LIKE </target>
+</trans-unit>
+<trans-unit id="filters11">
+<source>NO PARECIDO A (not like)</source>
+<target>NOT LIKE </target>
+</trans-unit>
+<trans-unit id="filters12">
+<source>VALORES NO NULOS (not null)</source>
+<target>NOT NULL</target>
+</trans-unit>
+
+<trans-unit id="dates1">
+<source>AÑO</source>
+<target>YEAR</target>
+</trans-unit>
+<trans-unit id="datesQ">
+<source>TRIMESTRE</source>
+<target>QUARTER</target>
+</trans-unit>
+<trans-unit id="dates2">
+<source>MES</source>
+<target>MONTH</target>
+</trans-unit>
+<trans-unit id="dates3">
+<source>DIA</source>
+<target>DAY</target>
+</trans-unit>
+<trans-unit id="dates4">
+<source>NO</source>
+<target>NO</target>
+</trans-unit>
+<trans-unit id="dates5">
+<source>SEMANA</source>
+<target>SETMANA</target>
+</trans-unit>
+<trans-unit id="dates6">
+<source>DIA DE LA SEMANA</source>
+<target>DIA DE LA SETMANA</target>
+</trans-unit>
+
+<trans-unit id="dates7">
+<source>FECHA COMPLETA</source>
+<target>TIMESTAMP</target>
+</trans-unit>
+<trans-unit id="dates8">
+<source>DIA HORA</source>
+<target>DAY HOUR</target>
+</trans-unit>
+<trans-unit id="dates9">
+<source>DIA HORA MINUTO</source>
+<target>DAY HOUR MINUTE</target>
+</trans-unit>
+
+<trans-unit id="ChartProps">
+<source>PROPIEDADES DEL gráfico</source>
+<target>CHART PROPERTIES</target>
+</trans-unit>
+
+<trans-unit id="newPanelTitle">
+<source>Nuevo Panel</source>
+<target>New Pannel</target>
+</trans-unit>
+<trans-unit id="newPanelTitle2">
+<source>Nuevo Panel</source>
+<target>New Pannel</target>
+</trans-unit>
+
+<trans-unit id="addMap" datatype="html">
+<source> Mapas</source>
+<target> Maps</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+  <context context-type="linenumber">210</context>
+</context-group>
+</trans-unit>
+<trans-unit id="inputNombreEsquemaModel" datatype="html">
+<source>Esquema</source>
+<target>Schema</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+  <context context-type="linenumber">181</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="listRelations" datatype="html">
+<source>Relaciones</source>
+<target>Relations</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+  <context context-type="linenumber">33</context>
+</context-group>
+</trans-unit>
+<trans-unit id="tituloGrupoComunes" datatype="html">
+<source> COMUNES</source>
+<target> COMMON</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/home/home.component.html</context>
+  <context context-type="linenumber">44</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="labelnewPass" datatype="html">
+<source>Nueva Contraseña (Si no quieres modificar tu contraseña actual deja el campo en blanco)</source>
+<target>New password </target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/profile/profile.component.html</context>
+  <context context-type="linenumber">27</context>
+</context-group>
+</trans-unit>
+<trans-unit id="namePass" datatype="html">
+<source>password</source>
+<target>password</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/profile/profile.component.html</context>
+  <context context-type="linenumber">28</context>
+</context-group>
+</trans-unit>
+<trans-unit id="labelRepeatPass" datatype="html">
+<source>Repite la nueva contraseña </source>
+<target>Repeat new password </target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/profile/profile.component.html</context>
+  <context context-type="linenumber">31</context>
+</context-group>
+</trans-unit>
+<trans-unit id="nameNewPass" datatype="html">
+<source>newPassword</source>
+<target>newPassword</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/profile/profile.component.html</context>
+  <context context-type="linenumber">32</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="groups1">
+<source>EMAIL</source>
+<target>EMAIL</target>
+</trans-unit>
+<trans-unit id="groups2">
+<source>GRUPOS</source>
+<target>GROUPS</target>
+</trans-unit>
+<trans-unit id="usersName">
+<source>NOMBRE</source>
+<target>NAME</target>
+</trans-unit>
+<trans-unit id="usersRole">
+<source>ROLE</source>
+<target>ROLE</target>
+</trans-unit>
+
+<trans-unit id="newPassPlaceholderProfile" datatype="html">
+<source>Repite la contraseña</source>
+<target>Repeat new password</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/profile/profile.component.html</context>
+  <context context-type="linenumber">32</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="direccionMail" datatype="html">
+<source>Dirección Email</source>
+<target>Email</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/core/pages/login/login.component.html</context>
+  <context context-type="linenumber">22</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="passwordLogin" datatype="html">
+<source>Contraseña</source>
+<target>Password</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/core/pages/login/login.component.html</context>
+  <context context-type="linenumber">28</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="informacionGeneral" datatype="html">
+<source>Información general</source>
+<target>General information</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+  <context context-type="linenumber">202</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="linkFilters" datatype="html">
+<source>Vincular consulta con los filtros del panel</source>
+<target>Link query and panel filters</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+  <context context-type="linenumber">221</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="examples" datatype="html">
+<source>Ejemplos</source>
+<target>Examples</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+  <context context-type="linenumber">242</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="newPassPlaceholderUsers" datatype="html">
+<source>Repite la contraseña</source>
+<target>Repeat password</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/users-management/users-detail/users-detail.component.html</context>
+  <context context-type="linenumber">17</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="AddPermiso" datatype="html">
+<source>Añadir permiso</source>
+<target>Add permission</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/column-permissions-dialog/column-permission-dialog.component.html</context>
+  <context context-type="linenumber">3</context>
+</context-group>
+</trans-unit>
+
+
+<trans-unit id="AddValueListOptions" datatype="html">
+<source>Definir un listado de valores posibles</source>
+<target>Define a list of possible values</target>
+</trans-unit>
+
+<trans-unit id="possibleValuesList" datatype="html">
+<source>Tabla y columna asociadas</source>
+<target>Associated table and column</target>
+</trans-unit>
+
+<trans-unit id="possibleValuesListTable" datatype="html">
+<source>Tabla:</source>
+<target>Table:</target>
+</trans-unit>
+
+<trans-unit id="valueListSourceHeader" datatype="html">
+<source>Tabla que contiene los valores posibles para el filtro asociado a esta columna</source>
+<target>Table containing the possible values for the filter associated with this column</target>
+</trans-unit>
+
+<trans-unit id="valueListSourceTabla" datatype="html">
+<source>Tabla relacionada</source>
+<target>Related table</target>
+</trans-unit>
+
+<trans-unit id="valueListSourceID" datatype="html">
+<source>Id de la columna relacionada</source>
+<target>Related column id</target>
+</trans-unit>
+
+<trans-unit id="possibleValuesListID" datatype="html">
+<source>Id Columna:</source>
+<target>Column Id:</target>
+</trans-unit>
+
+<trans-unit id="valueListSourceDescripcion" datatype="html">
+<source>Descripción de la columna relacionada</source>
+<target>Related column description</target>
+</trans-unit>
+
+
+<trans-unit id="possibleValuesListDescription" datatype="html">
+<source>Columna descripción</source>
+<target>Column description</target>
+</trans-unit>
+
+<trans-unit id="columnaCalculada" datatype="html">
+<source> Nueva columna calculada </source>
+<target> New calculated column </target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/calculatedColumn-dialog/calculated-column-dialog.component.html</context>
+  <context context-type="linenumber">3</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="inputxDescription" datatype="html">
+<source>Si desconoces las coordenadas del centro las calcularemos automáticamente</source>
+<target>If you do not know the coordinates of the center we will calculate them automatically</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/mapsDialog/maps-dialog.component.html</context>
+  <context context-type="linenumber">27</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="sqlExp" datatype="html">
+<source>Expresión SQL</source>
+<target> SQL  Expression</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+  <context context-type="linenumber">74</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="sqlExpColumn" datatype="html">
+<source>Expresión SQL (Debe incluir la agregación)</source>
+<target>SQL expression (Must include aggregation)</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+  <context context-type="linenumber">103</context>
+</context-group>
+</trans-unit>
+
+
+
+<trans-unit id="aggTsum">
+<source>Suma</source>
+<target>Sum</target>
+</trans-unit>
+<trans-unit id="aggTmean">
+<source>Media</source>
+<target>AVG</target>
+</trans-unit>
+<trans-unit id="aggTmax">
+<source>Màximo</source>
+<target>Max</target>
+</trans-unit>
+<trans-unit id="aggTmin">
+<source>Mínimo</source>
+<target>Min</target>
+</trans-unit>
+<trans-unit id="aggTcount">
+<source>Cuenta Valores</source>
+<target>Count</target>
+</trans-unit>
+<trans-unit id="aggTcountD">
+<source>Valores Distintos</source>
+<target>Count Distinct</target>
+</trans-unit>
+<trans-unit id="commonPanel">
+<source>Común</source>
+<target>Common</target>
+</trans-unit>
+<trans-unit id="groupPanel">
+<source>Grupo</source>
+<target>Group</target>
+</trans-unit>
+<trans-unit id="privatePanel">
+<source>Privado</source>
+<target>Private</target>
+</trans-unit>
+
+
+<trans-unit id="col">
+<source>Atributo</source>
+<target>Attribute:</target>
+</trans-unit>
+<trans-unit id="table">
+<source>de la entidad</source>
+<target>. Entity: </target>
+</trans-unit>
+
+<trans-unit id="addCalculatedColTitle">
+<source>Añadir columna calculada a la tabla</source>
+<target>Add calculated column to  table  </target>
+</trans-unit>
+<trans-unit id="addRelationTo">
+<source>Añadir relación a la tabla</source>
+<target>Add relation to table</target>
+</trans-unit>
+
+<trans-unit id="chartInfo1">
+<source>Los datos seleccionados no permiten utilizar este gráfico.</source>
+<target>Chart not avaiable with current data.</target>
+</trans-unit>
+<trans-unit id="chartInfo2">
+<source>Un KPI necesita un único número.</source>
+<target>To get a KPI only one number is required.</target>
+</trans-unit>
+<trans-unit id="chartInfo3">
+<source>Un gráfico de barras necesita una o más categorías y una série numéricas.</source>
+<target>Bar  chart needs one or more categories and one numeric serie. If there is also two series numeric data should be aggregated.</target>
+</trans-unit>
+<trans-unit id="chartInfo4">
+<source> Un gráfico combinado necesita una categoría y dos séries numéricas.</source>
+<target>Mixed chart needs one category and two or more numeric series.</target>
+</trans-unit>
+<trans-unit id="chartInfo5">
+<source>Un gráfico de línea necesita una o más categorías y una série numérica.</source>
+<target>Line chart needs one or more categories and one numeric serie. If there is also two series numeric data should be aggregated.</target>
+</trans-unit>
+<trans-unit id="chartInfoArea">
+<source>Un gráfico de areas necesita una o más categorías y una série numérica. Además, si hay mas de una série los datos numéricos deben agregarse.</source>
+<target>Area chart needs one or more categories and one numeric serie. If there is also two series numeric data should be aggregated.</target>
+</trans-unit>
+<trans-unit id="chartInfo6">
+<source>Un gráfico de barras necesita una o más categorías y una série numérica.</source>
+<target>Bar chart needs one or more categories and one numeric serie. If there is also two series numeric data should be aggregated.</target>
+</trans-unit>
+<trans-unit id="chartInfo7">
+<source>Un gráfico de barras necesita una o más categorías y una série numérica.</source>
+<target>Bar chart needs one or more categories and one numeric serie. If there is also two series numeric data should be aggregated.</target>
+</trans-unit>
+<trans-unit id="chartInfo8">
+<source>Un gráfico polar necesita una categoría y una série numérica.</source>
+<target>Polar area needs one category and one numeric serie.</target>
+</trans-unit>
+<trans-unit id="chartInfo9">
+<source>Un gráfico de pastel necesita una categoría y una série numérica.</source>
+<target>Pie chart needs one category and one numeric serie. </target>
+</trans-unit>
+<trans-unit id="chartInfo10">
+<source>Una tabla cruzada necesita dos o más categorías y una série numérica.</source>
+<target>Crosstable needs two or more categories and one numeric serie.</target>
+</trans-unit>
+<trans-unit id="chartInfo11">
+<source>Es necesario que los dos primeros campos sean de tipo coordenada.</source>
+<target>First two fields must be coordinates.</target>
+</trans-unit>
+<trans-unit id="chartInfo111">
+<source>Puedes añarir un campo de tipo métrica y uno de tipo etiqueta en este orden o cualquiera de los dos por separado.</source>
+<target>Add a metric field and a label field in this order or either one separately.</target>
+</trans-unit>
+<trans-unit id="chartInfo12">
+<source>Es necesario un campo vinculado a un archivo GeoJson y un campo de tipo numérico.</source>
+<target>GeoJson linked field and numeric one is needed.</target>
+</trans-unit>
+<trans-unit id="chartInfo13">
+<source>Los datos seleccionados no permiten utilizar este gráfico.</source>
+<target>Chart not avaiable with current data.</target>
+</trans-unit>
+<trans-unit id="chartInfoBubble">
+<source>Un gráfico de burbujas necesita una categorías y una série numérica.</source>
+<target>A bubble chart needs a category and a numerical series.</target>
+</trans-unit>
+
+
+<trans-unit id="tooManyValues" datatype="html">
+<source> - Demasiados valores</source>
+<target> - Too many values</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+  <context context-type="linenumber">332</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="notAvaliable" datatype="html">
+<source> - No Disponible</source>
+<target> - Not Available</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+  <context context-type="linenumber">335</context>
+</context-group>
+</trans-unit>
+<trans-unit id="MapDatamodel">
+<source>Mapas</source>
+<target>Maps</target>
+</trans-unit>
+
+<trans-unit id="tooManyValuestext">
+<source>Hay demasiados valores para este gráfico. Agrega o filtra los datos para poder visualizarlos mejor.</source>
+<target>Too many values for this chart. Add or filter the data to be able to visualize it better.</target>
+</trans-unit>
+
+<trans-unit id="inputTipoDatamodel" datatype="html">
+<source> Tipo </source>
+<target> Type </target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+  <context context-type="linenumber">157</context>
+</context-group>
+</trans-unit>
+<trans-unit id="MapsDatamodel" datatype="html">
+<source>  Mapas  </source>
+<target>  Maps  </target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+  <context context-type="linenumber">206</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="notSavedChanges" datatype="html">
+<source> Hay cambios sin guardar... </source>
+<target> Not saved changes... </target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/dashboard/dashboard.component.html</context>
+  <context context-type="linenumber">205</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="dahsboardSaved">
+<source>Informe guardado correctamente</source>
+<target>Dashboard correctly saved</target>
+</trans-unit>
+
+<trans-unit id="DatadourceTitle">
+<source>Fuente de datos: </source>
+<target>Datasource:  </target>
+</trans-unit>
+
+<trans-unit id="DatadourceText">
+<source>Creada correctamente </source>
+<target>Correctly created</target>
+</trans-unit>
+
+<trans-unit id="ErrorMessage">
+<source>Ha ocurrido un error </source>
+<target>Some error has occurred</target>
+</trans-unit>
+
+<trans-unit id="CorrectQuery">
+<source>Consulta correcta </source>
+<target>Correct query</target>
+</trans-unit>
+
+<trans-unit id="IncorrectQuery">
+<source>Consulta incorrecta</source>
+<target>Incorrect query</target>
+</trans-unit>
+
+<trans-unit id="IncorrectQueryAgg">
+<source>Debes incluir la agregación (distinct, sum, max, min, etc)</source>
+<target>You must include the aggregation (distinct, sum, max, min, etc)</target>
+</trans-unit>
+
+<trans-unit id="EstablishedConnections">
+<source>Conexión establecida </source>
+<target>Connection established</target>
+</trans-unit>
+
+<trans-unit id="IncorrectConnectionData">
+<source>Datos de conexión incorrectos</source>
+<target>Incorrect connection details</target>
+</trans-unit>
+
+<trans-unit id="Sure">
+<source>¿Estás seguro?</source>
+<target>Are you sure?</target>
+</trans-unit>
+
+<trans-unit id="SureInfo">
+<source>Estás a punto de borrar el modelo de datos y todos los dashboards asociados, el cambio es irreversible</source>
+<target>You are about to delete the data model and all associated dashboards, this is irreversible.</target>
+</trans-unit>
+
+<trans-unit id="ConfirmDeleteModel">
+<source>Si, ¡Eliminalo! </source>
+<target>Yes, delete it!</target>
+</trans-unit>
+
+<trans-unit id="Deleted">
+<source>¡Eliminado!</source>
+<target>Deleted!</target>
+</trans-unit>
+
+<trans-unit id="DeleteSuccess">
+<source>Modelo eliminado correctamente.</source>
+<target>Model deleted correctly.</target>
+</trans-unit>
+
+<trans-unit id="UpdateModelSucess">
+<source>Modelo actualizado correctamente</source>
+<target>Model updated correctly</target>
+</trans-unit>
+
+<trans-unit id="DeletedUser">
+<source>Usuario borrado</source>
+<target>User deleted</target>
+</trans-unit>
+
+<trans-unit id="UserDeletedOk">
+<source>El usuario a sido eliminado correctamente</source>
+<target>User has been successfully removed</target>
+</trans-unit>
+
+<trans-unit id="picUpdated">
+<source>Imagen Actualizada</source>
+<target>Picture updated</target>
+</trans-unit>
+
+<trans-unit id="NoRecords">
+<source>No se pudo obtener ningún registro</source>
+<target>Could not get any record</target>
+</trans-unit>
+
+<trans-unit id="mandatoryFields">
+<source>Recuerde rellenar los campos obligatorios</source>
+<target>Remember to fill in the required fields </target>
+</trans-unit>
+
+<trans-unit id="IncorrectForm">
+<source>Formulario incorrecto. Revise los campos obligatorios.</source>
+<target>Wrong form. Review the required fields.</target>
+</trans-unit>
+
+<trans-unit id="ImportantMessage">
+<source>Importante</source>
+<target>Important</target>
+</trans-unit>
+
+<trans-unit id="AcceptConditions">
+<source>Debe de aceptar las condiciones</source>
+<target>You must accept the conditions</target>
+</trans-unit>
+
+<trans-unit id="UserCreated">
+<source>Usuario creado</source>
+<target>User created</target>
+</trans-unit>
+
+<trans-unit id="RegisterError">
+<source>Error al registrarse</source>
+<target>Registration failed</target>
+</trans-unit>
+
+<trans-unit id="AddFiltersWarningTittle">
+<source>Solo puedes añadir filtros cuando todos los paneles están configurados</source>
+<target>You can only add filters when all panels are configured</target>
+</trans-unit>
+
+<trans-unit id="AddFiltersWarningText">
+<source>Puedes borrar los paneles en blanco o configurarlos</source>
+<target>You can delete the blank panels or configure them</target>
+</trans-unit>
+
+<trans-unit id="AddFiltersWarningButton">
+<source>Entendido</source>
+<target>Got it!</target>
+</trans-unit>
+
+<trans-unit id="DeleteGroup">
+<source>ELIMINAR GRUPO</source>
+<target>DELETE GROUP</target>
+</trans-unit>
+
+<trans-unit id="DeleteGroupText">
+<source>Eliminarás todos los elementos relacionados con este grupo, ¿Deseas continuar?</source>
+<target>You are gonna delete all elements related to this group. Do you want to continue?</target>
+</trans-unit>
+
+<trans-unit id="DeleteGroupButton">
+<source>Si, ¡Eliminalo!</source>
+<target>Yes, delete it!</target>
+</trans-unit>
+
+<trans-unit id="DeleteGroupCancel">
+<source>Cancelar</source>
+<target>Cancel</target>
+</trans-unit>
+
+<trans-unit id="deleteDashboardWarning">
+<source>Estás a punto de borrar el informe: </source>
+<target>You are gonna delete dashboard: </target>
+</trans-unit>
+
+<trans-unit id="DashboardDeletedInfo">
+<source>Informe eliminado correctamente. </source>
+<target>Dashboard correctly deleted. </target>
+</trans-unit>
+
+<trans-unit id="userDetailHeader">
+<source>USUARIO </source>
+<target>USER </target>
+</trans-unit>
+
+<trans-unit id="userDetailSaveButton">
+<source>GUARDAR </source>
+<target>SAVE </target>
+</trans-unit>
+
+<trans-unit id="UpdatedUser">
+<source>Usuario actualizado </source>
+<target>User updated </target>
+</trans-unit>
+
+<trans-unit id="PasswordsNotEqual">
+<source>Las contraseñas no coinciden </source>
+<target>Passwords do not match</target>
+</trans-unit>
+
+<trans-unit id="CreatedUser">
+<source>Usuario creado </source>
+<target>User created</target>
+</trans-unit>
+
+<trans-unit id="fileNotPicture">
+<source>El archivo seleccionado no es una imagen </source>
+<target>Selected file is not a picture</target>
+</trans-unit>
+
+<trans-unit id="cantDeleteUser">
+<source>No se puede borrar el usuario </source>
+<target>Can't delete user</target>
+</trans-unit>
+
+<trans-unit id="cantSelfDelete">
+<source>No se puede borrar a si mismo </source>
+<target>Can't delete himself</target>
+</trans-unit>
+
+<trans-unit id="DeleteUserMessage">
+<source>Estás a punto de borrar el usuario </source>
+<target>You are gonna delete user  </target>
+</trans-unit>
+
+<trans-unit id="DeleteUser">
+<source>Si, ¡Bórralo! </source>
+<target>Yes, delete it!</target>
+</trans-unit>
+
+<trans-unit id="rowOptions">
+<source>OPCIONES DE LA FILA </source>
+<target>ROW OPTIONS</target>
+</trans-unit>
+
+<trans-unit id="EDITCAP">
+<source>EDITAR </source>
+<target>EDIT</target>
+</trans-unit>
+
+<trans-unit id="deleteCAP">
+<source>ELIMINAR </source>
+<target>DELETE</target>
+</trans-unit>
+
+<trans-unit id="DashboardFilters">
+<source>FILTROS DEL INFORME </source>
+<target>DASHBOARD FILTERS</target>
+</trans-unit>
+
+<trans-unit id="newUserTitle">
+<source>CREAR NUEVO USUARIO</source>
+<target>CREATE NEW USER</target>
+</trans-unit>
+
+<trans-unit id="registers1" datatype="html">
+<source>
+  <x id="INTERPOLATION" equiv-text="{{ table.filteredValue.length }}"/>
+ registros</source>
+<target>
+  <x id="INTERPOLATION" equiv-text="{{ table.filteredValue.length }}"/>
+ records</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/components/eda-table/eda-table.component.html</context>
+  <context context-type="linenumber">110</context>
+</context-group>
+</trans-unit>
+<trans-unit id="registers2" datatype="html">
+<source>
+  <x id="INTERPOLATION" equiv-text="{{ table.value.length }}"/>
+ registros</source>
+<target>
+  <x id="INTERPOLATION" equiv-text="{{ table.value.length }}"/>
+ registres</target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/components/eda-table/eda-table.component.html</context>
+  <context context-type="linenumber">112</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="EditQuery">
+<source>EDITAR CONSULTA</source>
+<target>EDIT QUERY</target>
+</trans-unit>
+<trans-unit id="EditSQLQuery">
+<source>EDITAR CONSULTA SQL</source>
+<target>EDIT SQL QUERY</target>
+</trans-unit>
+
+<trans-unit id="DatePickerAll">
+<source>Todas</source>
+<target>All</target>
+</trans-unit>
+<trans-unit id="DatePickerYesterday">
+<source>Ayer</source>
+<target>Yesterday</target>
+</trans-unit>
+<trans-unit id="DatePickerBeforeYesterday">
+<source>Antes de ayer</source>
+<target>Before Yesterday</target>
+</trans-unit>
+<trans-unit id="DatePickerWeek">
+<source>Ésta semana</source>
+<target>This week</target>
+</trans-unit>
+<trans-unit id="DatePickerWeekFull">
+<source>Ésta semana al completo</source>
+<target>All this week</target>
+</trans-unit>
+<trans-unit id="DatePickerLastWeek">
+<source>La semana pasada</source>
+<target>Last week</target>
+</trans-unit>
+<trans-unit id="DatePickerLastWeekFull">
+<source>La semana pasada completa</source>
+<target>All last week</target>
+</trans-unit>
+<trans-unit id="DatePickerMonth">
+<source>Éste mes</source>
+<target>This month</target>
+</trans-unit>
+<trans-unit id="DatePickerLastMonth">
+<source>El mes pasado</source>
+<target>Last month</target>
+</trans-unit>
+<trans-unit id="DatePickerLastMonthFull">
+<source>El mes pasado completo</source>
+<target>All last month</target>
+</trans-unit>
+<trans-unit id="DatePickerMonthPreviousYear">
+<source>Éste mes del año pasado</source>
+<target>This month from previous year</target>
+</trans-unit>
+<trans-unit id="DatePickerMonthPreviousYearFull">
+<source>Éste mes al completo del año pasado</source>
+<target>This whole month of last year</target>
+</trans-unit>
+<trans-unit id="DatePickerYear">
+<source>Éste año</source>
+<target>This year</target>
+</trans-unit>
+<trans-unit id="DatePickerYearPreviousYear">
+<source>El año pasado</source>
+<target>Last year</target>
+</trans-unit>
+<trans-unit id="DatePickerLast7">
+<source> Últimos 7 días </source>
+<target>Last 7 days </target>
+</trans-unit>
+<trans-unit id="DatePickerLast3">
+<source> Últimos 3 días </source>
+<target>Last 3 days </target>
+</trans-unit>
+<trans-unit id="DatePickerLast15">
+<source> Últimos 15 días </source>
+<target>Last 15 days </target>
+</trans-unit>
+<trans-unit id="DatePickerLast30">
+<source> Últimos 30 días </source>
+<target>Last 30 days </target>
+</trans-unit>
+<trans-unit id="DatePickerLast60">
+<source> Últimos 60 días </source>
+<target>Last 60 days </target>
+</trans-unit>
+<trans-unit id="DatePickerLast120">
+<source> Últimos 120 días </source>
+<target>Last 120 days </target>
+</trans-unit>
+<trans-unit id="DateSelectRange">
+<source>Selecciona un rango</source>
+<target>Select range</target>
+</trans-unit>
+<trans-unit id="inputPuerto" datatype="html">
+<source>Puerto  </source>
+<target>Port  </target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+  <context context-type="linenumber">181</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="filterButtonDashboard">
+<source>Filtrar</source>
+<target>Filter </target>
+</trans-unit>
+
+
+<trans-unit id="kpiAlertH6" datatype="html">
+<source>      Generar alerta    </source>
+<target>      Generate alert   </target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html</context>
+  <context context-type="linenumber">15</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="DynamicTextColor" datatype="html">
+<source>       Cambiar Color   </source>
+<target>       Change Color   </target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/dynamicText-dialog/dynamicText-dialog.component.html</context>
+  <context context-type="linenumber">11</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="kpiGreatSmallEqualH6" datatype="html">
+<source>        Operador       </source>
+<target>        Operator       </target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html</context>
+  <context context-type="linenumber">29</context>
+</context-group>
+</trans-unit>
+<trans-unit id="colorKpiH6" datatype="html">
+<source>        Color       </source>
+<target>        Color       </target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html</context>
+  <context context-type="linenumber">49</context>
+</context-group>
+</trans-unit>
+<trans-unit id="kpiAlerts" datatype="html">
+<source>        Alertas      </source>
+<target>        Alerts      </target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html</context>
+  <context context-type="linenumber">60</context>
+</context-group>
+</trans-unit>
+<trans-unit id="addAlert" datatype="html">
+<source> Añadir alerta    </source>
+<target> Add alert    </target>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html</context>
+  <context context-type="linenumber">77</context>
+</context-group>
+<context-group purpose="location">
+  <context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html</context>
+  <context context-type="linenumber">76</context>
+</context-group>
+</trans-unit>
+
+<trans-unit id="alertsInfo">
+<source>Cuando el valor del kpi sea (=, &lt;,&gt;) que el valor definido cambiará el color del texto</source>
+  <target>When the kpi value is (=, &lt;,&gt;) than the defined value, the text color will change  </target>
+  </trans-unit>
+
+  <trans-unit id="generateView" datatype="html">
+    <source>Generar vista</source>
+    <target>Generate view</target>
+    <context-group purpose="location">
+      <context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/viewDialog/view-dialog.component.html</context>
+      <context context-type="linenumber">31</context>
+    </context-group>
+  </trans-unit>
+
+
+  <trans-unit id="inputQueryView" datatype="html">
+    <source> Vista </source>
+    <target> View </target>
+    <context-group purpose="location">
+      <context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+      <context context-type="linenumber">23</context>
+    </context-group>
+  </trans-unit>
+
+  <trans-unit id="ViewsDatamodel" datatype="html">
+    <source>  Vistas </source>
+    <target>  Views </target>
+    <context-group purpose="location">
+      <context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+      <context context-type="linenumber">246</context>
+    </context-group>
+  </trans-unit>
+
+
+  <trans-unit id="addView" datatype="html">
+    <source> Añadir  vista</source>
+    <target> Add  view</target>
+    <context-group purpose="location">
+      <context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+      <context context-type="linenumber">250</context>
+    </context-group>
+  </trans-unit>
+
+  <trans-unit id="ViewDatamodel">
+    <source>Añadir Vista</source>
+    <target>Add  view </target>
+  </trans-unit>
+
+  <trans-unit id="inputBorrarVista" datatype="html">
+    <source>Borrar vista</source>
+    <target>Delete view</target>
+    <context-group purpose="location">
+      <context context-type="sourcefile">app/module/pages/data-sources/data-source-detail/data-source-detail.component.html</context>
+      <context context-type="linenumber">54</context>
+    </context-group>
+  </trans-unit>
+
+  <trans-unit id="topQueryH4" datatype="html">
+    <source> Mostrar Top:  
+      <x id="START_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;p-inputNumber&gt;"/>
+      <x id="CLOSE_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;/p-inputNumber&gt;"/>
+    </source>
+    <target> Show Top:  
+      <x id="START_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;p-inputNumber&gt;"/>
+      <x id="CLOSE_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;/p-inputNumber&gt;"/>
+    </target>
+    <context-group purpose="location">
+      <context context-type="sourcefile">app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
+      <context context-type="linenumber">131</context>
+    </context-group>
+  </trans-unit>
+
+    <trans-unit id="joinTypeH4" datatype="html">
+    <source> Tipo de intersección:  </source>
+    <target> Join type:  </target>
+  </trans-unit>
+
+  <trans-unit id="addCSV" datatype="html">
+    <source>Añadir tabla desde CSV</source>
+    <target>Add table from CSV</target>
+    <context-group purpose="location">
+      <context context-type="sourcefile">app/module/pages/data-sources/data-source-list/data-source-list.component.html</context>
+      <context context-type="linenumber">26</context>
+    </context-group>
+    <context-group purpose="location">
+      <context context-type="sourcefile">app/module/pages/data-sources/data-source-list/addCSV/add-csv.component.html</context>
+      <context context-type="linenumber">14</context>
+    </context-group>
+  </trans-unit>
+
+  <trans-unit id="placeholderTableName" datatype="html">
+    <source>Nombre de la tabla</source>
+    <target>Table name</target>
+    <context-group purpose="location">
+      <context context-type="sourcefile">app/module/pages/data-sources/data-source-list/addCSV/add-csv.component.html</context>
+      <context context-type="linenumber">5</context>
+    </context-group>
+  </trans-unit>
+  <trans-unit id="placeholderInputSeparator" datatype="html">
+    <source>Separador</source>
+    <target>Separator</target>
+    <context-group purpose="location">
+      <context context-type="sourcefile">app/module/pages/data-sources/data-source-list/addCSV/add-csv.component.html</context>
+      <context context-type="linenumber">9</context>
+    </context-group>
+  </trans-unit>
+  <trans-unit id="saveCSV" datatype="html">
+    <source>Generar tabla</source>
+    <target>Generate table</target>
+    <context-group purpose="location">
+      <context context-type="sourcefile">app/module/pages/data-sources/data-source-list/addCSV/add-csv.component.html</context>
+      <context context-type="linenumber">51</context>
+    </context-group>
+  </trans-unit>
+
+  <trans-unit id="addTableTitle">
+    <source>Añadir Tabla</source>
+    <target>Add Table</target>
+  </trans-unit>
+
+  <trans-unit id="succesAddTable">
+    <source>Tabla creada correctamente</source>
+    <target>Table created successfully</target>
+  </trans-unit>
+
+  <trans-unit id="csvField">
+    <source>Campo</source>
+    <target>Field</target>
+  </trans-unit>
+  <trans-unit id="csvType">
+    <source>Tipo</source>
+    <target>Type</target>
+  </trans-unit>
+  <trans-unit id="csvFormat">
+    <source>Formato</source>
+    <target>Format</target>
+  </trans-unit>
+
+  <trans-unit id="functionalities">
+    <source>Extender el model</source>
+    <target>Extend model</target>
+  </trans-unit>
+
+  <trans-unit id="utilities">
+    <source>Utilidades</source>
+    <target>Utilities</target>
+  </trans-unit>
+
+  <trans-unit id="hideTables">
+    <source>Ocultar todas las tablas</source>
+    <target>Hide all tables</target>
+  </trans-unit>
+  <trans-unit id="hideColumns">
+    <source>Ocultar todas las columnas</source>
+    <target>Hide all columns</target>
+  </trans-unit>
+  <trans-unit id="hideAllRelations">
+    <source>Ocultar todas las relaciones</source>
+    <target>Hide all relations</target>
+  </trans-unit>
+
+  <trans-unit id="addFile">
+    <source>Subir archivo</source>
+    <target>Add file </target>
+  </trans-unit>
+
+  <trans-unit id="FiltersH4">
+    <source>Filtros</source>
+    <target>Filters </target>
+  </trans-unit>
+
+  <trans-unit id="dragFields">
+    <source>Arrastre aquí los atributos que quiera ver en su panel</source>
+    <target>Drag here the attributes you want to see in your pannel</target>
+  </trans-unit>
+
+  <trans-unit id="dragFilters">
+    <source>Arrastre aquí los atributos sobre los que quiera filtrar</source>
+    <target>Drag here the attributes you want to filter on</target>
+  </trans-unit>
+
+  <trans-unit id="LegendPosition">
+    <source>Posición de la leyenda</source>
+    <target>Legend position</target>
+  </trans-unit>
+
+  <trans-unit id="LinkDashboardDbFilter">
+    <source> Informe a vincular </source>
+    <target>Dashbaord to link</target>
+  </trans-unit>
+
+  <trans-unit id="LinkDashboardSelectedDashboard">
+    <source> Campo del informe </source>
+    <target>Dashboard field</target>
+  </trans-unit>
+
+  <trans-unit id="DashboardLink">
+    <source> Vincular con un informe </source>
+    <target> Link to dashboard </target>
+  </trans-unit>
+
+  <trans-unit id="panelOptions5">
+    <source> Vincular con otro informe </source>
+    <target>Link to another dashboard</target>
+  </trans-unit>
+
+  <trans-unit id="NoTag">
+    <source> Sin Etiqueta  </source>
+    <target>No Tag </target>
+  </trans-unit>
+
+  <trans-unit id="newTag">
+    <source> Nueva etiqueta   </source>
+    <target>New tag </target>
+  </trans-unit>
+
+  <trans-unit id="addTag">
+    <source>AÑADIR ETIQUETA</source>
+    <target>ADD TAG </target>
+  </trans-unit>
+
+  <trans-unit id="AllTags">
+    <source> Todos  </source>
+    <target>All  </target>
+  </trans-unit>
+    
+  <trans-unit id="NoneTags">
+    <source> Ninguno  </source>
+    <target>None </target>
+  </trans-unit>
+
+  <trans-unit id="linkedTo">
+    <source> Vinculado con  </source>
+    <target>Linked to   </target>
+  </trans-unit>
+
+  <trans-unit id="DataModelHeader">
+    <source> Configurar nuevo orígen de datos  </source>
+    <target> New datasource  </target>
+  </trans-unit>
+
+  <trans-unit id="OptimizeQuery">
+    <source> Optimizar consultas  </source>
+    <target> Optimize queries  </target>
+  </trans-unit>
+
+  <trans-unit id="inputBigQueryKeys">
+    <source> Subir archivo de claves (json) *  </source>
+    <target> Upload keys (json) *   </target>
+  </trans-unit>
+
+  <trans-unit id="DatasourceText">
+    <source> Creada correctamente  </source>
+    <target> Correctly created  </target>
+  </trans-unit>
+
+  <trans-unit id="panelOptions0">
+    <source> OPCIONES DEL PANEL  </source>
+    <target> PANEL OPTIONS </target>
+  </trans-unit>
+
+  <trans-unit id="greendot">
+    <source> Paneles filtrados  </source>
+    <target> Filtered panels </target>
+  </trans-unit>
+
+  <trans-unit id="reddot">
+    <source> Paneles no relacionados  </source>
+    <target> Non related panels </target>
+  </trans-unit>
+
+  <trans-unit id="unselecteddot">
+    <source> Paneles no filtrados  </source>
+    <target> Non filtered panels </target>
+  </trans-unit>
+
+  <trans-unit id="seconds_to_refresh">
+    <source> Intervalo de recarga </source>
+    <target>Refresh interval </target>
+  </trans-unit>
+
+  <trans-unit id="sidebarModelsManagement">
+    <source> Gestión de modelos </source>
+    <target> Model management </target>
+  </trans-unit>
+
+
+  <trans-unit id="Models_ms">
+    <source> Modelos </source>
+    <target> Models </target>
+  </trans-unit>
+
+  <trans-unit id="Dashboards_ms">
+    <source> Informes </source>
+    <target> Dashboards </target>
+  </trans-unit>
+
+  <trans-unit id="ExportModel">
+    <source> Exportar Modelo </source>
+    <target> Export Model </target>
+  </trans-unit>
+
+  <trans-unit id="ExportDashboard">
+    <source> Exportar Informe </source>
+    <target> Export Dashboards </target>
+  </trans-unit>
+
+  <trans-unit id="importModel">
+    <source> Importar Modelo </source>
+    <target> Import Model </target>
+  </trans-unit>
+
+  <trans-unit id="importDashboard">
+    <source> Importar Informe </source>
+    <target> Import Dashboards </target>
+  </trans-unit>
+
+  <trans-unit id="import">
+    <source> Importar </source>
+    <target> Import </target>
+  </trans-unit>
+
+  <trans-unit id="DBInconsistencies">
+    <source> Se han encontrado inconsistencias en el informe, los siguientes elementos no existen en el modelo: </source>
+    <target> Inconsistencies found in current dashboard, the following items do not exist in the model:   </target>
+  </trans-unit>
+
+  <trans-unit id="modelInconsistenciesS">
+    <source> Se han encontrado inconsistencias en los siguientes informes:  </source>
+    <target> Inconsistencies found in current dashboards:  </target>
+  </trans-unit>
+
+  <trans-unit id="ModelSaved">
+    <source> Modelo guardado correctamente </source>
+    <target> Model guardat correctament </target>
+  </trans-unit>
+
+  <trans-unit id="downloadModel">
+    <source> Descargar modelo </source>
+    <target> Download model </target>
+  </trans-unit>
+
+  <trans-unit id="downloadDashboard">
+    <source> Descargar Informe </source>
+    <target> Download Dashboard </target>
+  </trans-unit>
+
+  <trans-unit id="NotSavedWarning">
+    <source> Hay cambios sin guardar. ¿Seguro que quieres salir? </source>
+    <target>  There are unsaved changes, do you want to continue anyway? </target>
+  </trans-unit>
+
+  <trans-unit id="csvSep">
+    <source> Separador Decimal </source>
+    <target>  Decimal separator</target>
+  </trans-unit>
+
+  <trans-unit id="viewOk">
+    <source> Vista generada correctamente</source>
+    <target>  View generated correctly</target>
+  </trans-unit>
+
+  <trans-unit id="limitRowsInfo">
+    <source> Establece un Top n para la consulta</source>
+    <target>  Define Top n for query</target>
+  </trans-unit>
+
+  <trans-unit id="Limits">
+    <source> Límites</source>
+    <target>  Boundaries</target>
+  </trans-unit>
+
+  <trans-unit id="usersPermissions">
+    <source> Permisos de usuario</source>
+    <target>  User permissions </target>
+  </trans-unit>
+
+  <trans-unit id="groupsPersmissions">
+    <source> Permisos de grupo</source>
+    <target>  Group permissions</target>
+  </trans-unit>
+
+  <trans-unit id="users">
+    <source> Usuarios</source>
+    <target>  Users</target>
+  </trans-unit>
+  <trans-unit id="groups">
+    <source> Grupos</source>
+    <target>  Groups</target>
+  </trans-unit>
+
+  <trans-unit id="groupTable">
+    <source>GRUPO</source>
+    <target>GROUP</target>
+  </trans-unit>
+
+  <trans-unit id="yourQuerySQL">
+    <source>Mi consulta SQL</source>
+    <target>My SQL query</target>
+  </trans-unit>
+
+  <trans-unit id="openSqlMode">
+    <source>Abrir en modo SQL</source>
+    <target>Open in SQL mode</target>
+  </trans-unit>
+
+  <trans-unit id="sqlTooltip">
+    <source>Al cambiar de modo perderás la configuración de la consulta actual</source>
+    <target>Changing mode will override current query configuration</target>
+  </trans-unit>
+
+  <trans-unit id="ptooltipViewQuery">
+    <source>Ver consulta SQL</source>
+    <target>View SQL query</target>
+  </trans-unit>
+
+  <trans-unit id="noStyle">
+    <source>Sin estilo</source>
+    <target>No style</target>
+  </trans-unit>
+
+  <trans-unit id="removeRowTotals">
+    <source>Quitar totales de columna</source>
+    <target>Delete column totals</target>
+  </trans-unit>
+  <trans-unit id="removeRowSubtotals">
+    <source>Quitar subtotales de columna</source>
+    <target>Delete column subtotals</target>
+  </trans-unit>
+  <trans-unit id="addRowTotals">
+    <source>Totales de fila</source>
+    <target>Row totals</target>
+  </trans-unit>
+  <trans-unit id="addRowSubtotals">
+    <source>Subtotales de fila</source>
+    <target>Row subtotals</target>
+  </trans-unit>
+  <trans-unit id="addColTotals">
+    <source>Totales de columna</source>
+    <target>Column totals</target>
+  </trans-unit>
+  <trans-unit id="removeColTotals">
+    <source>Quitar totales de columna</source>
+    <target>Delete column totals</target>
+  </trans-unit>
+  <trans-unit id="addOnlyPercentages">
+    <source>Sólo porcentajes</source>
+    <target>Only percentages</target>
+  </trans-unit>
+  <trans-unit id="addOnlyValues">
+    <source>Sólo valores</source>
+    <target>Only values</target>
+  </trans-unit>
+  <trans-unit id="addValuesPercentages">
+    <source>Valores y porcentajes</source>
+    <target>Values and Percentages</target>
+  </trans-unit>
+  <trans-unit id="addtrend">
+    <source>Tendencia</source>
+    <target>Trend</target>
+  </trans-unit>
+  <trans-unit id="removetrend">
+    <source>Quitar tendencia</source>
+    <target>Delete trend</target>
+  </trans-unit>
+
+  <trans-unit id="addTotals">
+    <source>Totales</source>
+    <target>Totals</target>
+  </trans-unit>
+  <trans-unit id="addPercentages">
+    <source>Porcentajes</source>
+    <target>Percentages</target>
+  </trans-unit>
+  <trans-unit id="addStyles">
+    <source>Còdigo de color</source>
+    <target>Color code</target>
+  </trans-unit>
+  <trans-unit id="tableTitleDialog">
+    <source>Propiedades de la tabla</source>
+    <target>Table properties</target>
+  </trans-unit>
+  <trans-unit id="SubTotals">
+    <source>SubTotales</source>
+    <target>SubTotals</target>
+  </trans-unit>
+
+  <trans-unit id="gradientTitle">
+    <source>Código de color para la columna: </source>
+    <target>Color code for column:  </target>
+  </trans-unit>
+
+  <trans-unit id="unlink">
+    <source>Desvincular del informe: </source>
+    <target>Unlink dashboard:  </target>
+  </trans-unit>
+
+  <trans-unit id="adChacheConfig">
+    <source>Configurar caché del modelo</source>
+    <target>Caché configuration</target>
+  </trans-unit>
+
+  <trans-unit id="CacheDeletedOK">
+    <source>Caché eliminada correctamente</source>
+    <target>Cache deleted correctly</target>
+  </trans-unit>
+
+  <trans-unit id="IncorrectCacheDelete">
+    <source>No ha sido posible eliminar la caché</source>
+    <target>Error deleting cache</target>
+  </trans-unit>
+  
+  <trans-unit id="RefreshCacheTitle">
+    <source>Actualizar los datos del modelo cada:</source>
+    <target>Update model data every:  </target>
+  </trans-unit>
+
+  <trans-unit id="hours">
+    <source>Hora/s</source>
+    <target>Hour/s</target>
+  </trans-unit>
+
+  <trans-unit id="days">
+    <source>Día/s</source>
+    <target>Day/s</target>
+  </trans-unit>
+  
+  <trans-unit id="noCache">
+    <source>Sin caché</source>
+    <target>No caché</target>
+  </trans-unit>
+
+  <trans-unit id="deleteCache">
+    <source>Borrar cache del modelo</source>
+    <target>Delete model's caché</target>
+  </trans-unit>
+
+  <trans-unit id="MailSending">
+    <source>Envío de alertas por mail </source>
+    <target>Mail alerts</target>
+  </trans-unit>
+
+  <trans-unit id="SendMailEvery">
+    <source>Enviar mail de alerta cada:</source>
+    <target>Send mail every:</target>
+  </trans-unit>
+
+  <trans-unit id="SendMailWho">
+    <source>Destinatarios </source>
+    <target>Targets </target>
+  </trans-unit>
+
+  <trans-unit id="SendMailWhat">
+    <source>Contenido del mail: </source>
+    <target>Mail body:  </target>
+  </trans-unit>
+
+  <trans-unit id="at">
+    <source>A las</source>
+    <target>At</target>
+  </trans-unit>
+
+
+  <trans-unit id="NoValidCol">
+    <source>No hay columnas válidas</source>
+    <target>No valid columns</target>
+  </trans-unit>
+
+
+  <trans-unit id="securityConfig">
+    <source>Configuración de seguridad</source>
+    <target>Security configuration</target>
+  </trans-unit>
+  
+  <trans-unit id="viewsecurity">
+    <source>Ver configuración de seguridad</source>
+    <target>View security configuration</target>
+  </trans-unit>
+
+  <trans-unit id="tablesd">
+    <source>TABLAS</source>
+    <target>TABLES</target>
+  </trans-unit>
+
+  <trans-unit id="rolesPermisosTabla">
+    <source>Visibilidad de tablas</source>
+    <target>Table visibility</target>
+  </trans-unit>
+  <trans-unit id="rolesPermisosModelo">
+    <source>Visibilidad a nivel de modelo</source>
+    <target>Model-level visibility</target>
+  </trans-unit>
+  <trans-unit id="tablePermissionNO">
+    <source>No tiene permiso para ver esta tabla</source>
+    <target>You do not have permission to view this table</target>
+  </trans-unit>
+  <trans-unit id="tablePpermissionYES">
+    <source>SI tiene permiso para ver esta tabla</source>
+    <target>You have permission to view this table</target>
+  </trans-unit>
+  <trans-unit id="modelPermissionNO">
+    <source>No tiene permiso para ver este modelo</source>
+    <target>You do not have permission to view this model</target>
+  </trans-unit>
+  <trans-unit id="modelPermissionYES">
+    <source>SI tiene permiso para ver este modelo</source>
+    <target>You have permission to view this model</target>
+  </trans-unit>
+  <trans-unit id="anyCanSeeNO">
+    <source>Los usuarios y grupos que pueden ver el modelo son SOLO los definidos explicitamente.</source>
+    <target>The users and groups that can see the model are ONLY those explicitly defined</target>
+  </trans-unit>
+  <trans-unit id="anyCanSeeYES">
+    <source>Cualquier usuario puede ver el modelo. Los filtros de seguridad se definen a nivel de tabla y columna concreta.</source>
+    <target>Any user can see the model. Security filters are defined at the specific table and column level.</target>
+  </trans-unit>
+
+
+
+  <trans-unit id="permisos">
+    <source>PERMISOS</source>
+    <target>PERMISSIONS</target>
+  </trans-unit>
+
+  
+  <trans-unit id="visible">
+    <source>VISIBLE</source>
+    <target>VISIBLE</target>
+  </trans-unit>
+
+  <trans-unit id="column">
+    <source>COLUMNAS </source>
+    <target>COLUMNS</target>
+  </trans-unit>
+
+<trans-unit id="sidebarAlertsManagement">
+  <source>Gestión de alertas </source>
+  <target>Alert management</target>
+</trans-unit>
+
+
+<trans-unit id="alertTable">
+  <source>ALERTAS </source>
+  <target>ALERTS</target>
+</trans-unit>
+
+<trans-unit id="gotodashboard">
+  <source>Ir al informe </source>
+  <target>Go to dashboard</target>
+</trans-unit>
+
+<trans-unit id="alertsConfigTitle">
+  <source>Gestión de alertas </source>
+  <target>Alert management</target>
+</trans-unit>
+
+<trans-unit id="panelTable">
+  <source>PANEL </source>
+  <target>PANEL</target>
+</trans-unit>
+
+<trans-unit id="dashboardTable">
+  <source>INFORME </source>
+  <target>DASHBOARD</target>
+</trans-unit>
+
+   <trans-unit id="chartInfo14">
+    <source>Un Parallel Set necesita dos o más categorias y un campo numérico </source>
+    <target>Parallel Set requires two or more categories and a numeric field </target>
+  </trans-unit>
+
+   <trans-unit id="chartInfo15">
+    <source>Un Tree Map necesita un campo numérico y una o más categorias </source>
+    <target>Tree Map requires a numeric field and one or more categories</target>
+  </trans-unit>
+
+   <trans-unit id="chartInfo16">
+    <source>Un Scatter Plot necesita una categoria y dos o tres campos numéricos </source>
+    <target>Scatter Plot requires one category and two or three numeric fields</target>
+  </trans-unit>
+
+   <trans-unit id="chartInfo17">
+    <source>El velocímetro necesita uno o dos valores numéricos. En caso de disponer de dos valores el segundo se interpretará como límite </source>
+    <target>Gauge requires uno or two numeric values, if two values are provided second one is interpreted as a limit</target>
+  </trans-unit>
+
+     <trans-unit id="chartInfoHistogram">
+    <source>Un histograma requiere una única columna de valores numericos de los que se calculará la frecuencia </source>
+    <target>A histogram requires a single column of numeric values from which the frequency is calculated</target>
+  </trans-unit>
+
+  <trans-unit id="chartInfoFunnel">
+    <source>Un embudo necesitar una categoría y un valor numérico </source>
+    <target>A funnel will need a category and a numeric value</target>
+  </trans-unit>
+
+   <trans-unit id="chartInfoPyramid">
+    <source>Un gráfico de piramide necesita de dos categorías y un valor numérico </source>
+    <target>A pyramid chart needs two categories and one numeric value</target>
+  </trans-unit>
+
+   <trans-unit id="mailConfOk">
+    <source>Credenciales correctas </source>
+    <target> Credencials are oK</target>
+  </trans-unit>
+
+  <trans-unit id="checkCredentials">
+    <source> Comprobar credenciales</source>
+    <target>Check credentials</target>
+  </trans-unit>
+
+  <trans-unit id="mailmanagementHeader">
+    <source>Gestión de correo y envio de mails</source>
+    <target>Email and email sending management</target>
+  </trans-unit>
+
+  <trans-unit id="mailConfSaved">
+    <source>Configuración guardada correctamente </source>
+    <target>Configuration saved correctly</target>
+  </trans-unit>
+
+  <trans-unit id="allowCache">
+    <source>Habilitar caché </source>
+    <target>Allow caché</target>
+  </trans-unit>
+
+    <trans-unit id="addCacheConfig">
+    <source>Configurar Caché </source>
+    <target>Manage Caché</target>
+  </trans-unit>
+
+   <trans-unit id="conexionh3">
+    <source>Conexión  </source>
+    <target>Connection</target>
+  </trans-unit>
+
+  <trans-unit id="newDashboardtitle">
+    <source>CREA UN NUEVO INFORME</source>
+    <target>YOUR NEW DASHBOARD</target>
+  </trans-unit>
+  
+ <trans-unit id="inputCuenta">
+    <source>CUENTA*  </source>
+    <target>ACCOUNT* </target>   
+  </trans-unit>
+
+   <trans-unit id="inputCuentaEdit">
+    <source>CUENTA  </source>
+    <target>Account </target>
+  </trans-unit> 
+
+  <trans-unit id="entidadesTitle">
+    <source>Clique sobre un entidad para ver sus atributos.</source>
+    <target>Click on an entity to see its attributes</target>
+  </trans-unit>
+
+    <trans-unit id="atributsTitle">
+    <source>Atributos de una entidad. Arrastre los atrubutos a la selección o los filtros para consultarlos. Haciendo click sobre el atributo se accede a sus propiedaes.</source>
+    <target>Attributes of an entity. Drag attributes onto selection or filters to view them. By clicking on the attribute you access its properties</target>
+  </trans-unit>
+
+    <trans-unit id="seleccionTitle">
+    <source>Para lanzar una consulta. Seleccione los atributos que desea ver, Clique sobre ellos para configurarlos y ejecute la consulta. Siempre podrá volver a esta vista.</source>
+    <target>To launch a query. Select the attributes you want to see, click on them to configure them and run the query. You can always go back to this view.</target>
+  </trans-unit>
+
+    <trans-unit id="agregacionh5">
+    <source>Agregación   </source>
+    <target>Aggregation  </target>
+  </trans-unit> 
+
+    <trans-unit id="inputFormat">
+    <source>Número de decimales   </source>
+    <target>Decimal places  </target>
+  </trans-unit> 
+
+  <trans-unit id="DashboardMailingTitle">
+    <source>Configuración del envío por email  </source>
+    <target>Mail sending configuration  </target>
+  </trans-unit> 
+
+    <trans-unit id="opcionMail">
+    <source>Enviar por email  </source>
+    <target>Send via email  </target>
+  </trans-unit> 
+
+   <trans-unit id="noMail">
+    <source>Sin alertas de correo </source>
+    <target>No mail alerts  </target>
+  </trans-unit> 
+
+    <trans-unit id="dashbaordsMailingHeader">
+    <source>Envio de informes por email </source>
+    <target>Dashboards mail sending</target>
+  </trans-unit> 
+
+ <trans-unit id="cumulativeSum">
+    <source>Suma acumulativa   </source>
+    <target>Cumulative sum </target>
+  </trans-unit> 
+
+    <trans-unit id="ptooltipViewAlerts">
+    <source>Configurar alertas</source>
+    <target>Alerts configuration</target>
+  </trans-unit> 
+
+
+  <trans-unit id="inputFilter">
+    <source>Filtros</source>
+    <target>Filters</target>
+  </trans-unit> 
+
+     <trans-unit id="comparativeTooltip">
+    <source>La función de comparar sólo se puede activar si se dispone de un campo de fecha agregado por mes y un único campo numèrico agregado</source>
+    <target>Compare function is only allowed in queries with one date field monthly or weekly aggregated and one numeric field</target>
+  </trans-unit> 
+
+
+     <trans-unit id="canIeditTooltip">
+    <source>Si esta opción está seleccionada, sólo el propietario del informe y los administradores podrán guardar los cambios</source>
+    <target>If this option is selected, only the report owner and administrators will be able to save changes</target>
+  </trans-unit> 
+     <trans-unit id="onlyIcanEditTag">
+    <source>Edición privada:</source>
+    <target>Private edition:  </target>
+  </trans-unit> 
+
+  <trans-unit id="showLablesTooltip">
+    <source>Mostrar o ocultar las etiquetas sobre los gráficos</source>
+    <target>Show or hide labels on charts</target>
+  </trans-unit> 
+
+  <trans-unit id="showLablesPercentTooltip">
+    <source>Mostrar o ocultar las etiquetas sobre los gráficos</source>
+    <target>Show or hide labels in percent on charts</target>
+  </trans-unit> 
+
+
+         <trans-unit id="columnsTooltip">
+    <source>Elige cuantas columnas quieres mostrar</source>
+    <target>Choose how many columns you want to display</target>
+  </trans-unit> 
+
+       <trans-unit id="showLabels">
+    <source>Mostrar Etiquetas</source>
+    <target>Show Tags</target>
+  </trans-unit> 
+           <trans-unit id="showLabelsPercent">
+    <source>Mostrar Etiquetas en Porcentaje</source>
+    <target>Show Tags in Percent</target>
+  </trans-unit> 
+
+
+       <trans-unit id="histogramColum">
+    <source>Columnas</source>
+    <target>Columns</target>
+  </trans-unit> 
+
+     <trans-unit id="trendTooltip">
+    <source>La función de añadir tendencia sólo se puede activar en los gràficos de lineas</source>
+    <target>Trend function is only allowed in line charts</target>
+  </trans-unit> 
+
+     <trans-unit id="filterTooltip">
+    <source>Puedes añadir palabras separadas por comas, que se aplicarán como filtros de tipo LIKE a la hora de recuperar las tablas de tu base de datos</source>
+    <target>Could add words separated by commas, which will be applied as LIKE filters when retrieving the tables from your database</target>
+  </trans-unit> 
+
+   <trans-unit id="cumulativeSumTooltip">
+    <source>Si activas ésta función se calculará la suma acumulativa 
+                                            para los campos numéricos que eligas. Sólo se puede activar si la fecha está agregada por mes o dia.</source>
+    <target>Activating this function the cumulative sum for numeric filelds will be calculated. 
+                                        It can only be activated if date field is aggregated by month, week or day. </target>
+  </trans-unit> 
+
+   <trans-unit id="cumsumAlertMessage1">
+    <source> La suma acumulativa sólo se puede aplicar si se dispone de una única serie no numérica.</source>
+    <target>Cummulative sum can only be applied in one non-numeric serie.</target>
+  </trans-unit> 
+
+     <trans-unit id="cumsumAlertMessage2">
+    <source>Puedes desactivar la función acumulativa en el campo de fecha o quitar una columna no numérica.</source>
+    <target>Disable cummulative function in date field or remove one non-numeric field. </target>
+  </trans-unit> 
+
+   <trans-unit id="SaveAs">
+    <source>GUARDAR COMO...</source>
+    <target>SAVE AS...  </target>
+  </trans-unit> 
+
+     <trans-unit id="opcionGuardarComo">
+    <source>GUARDAR COMO</source>
+    <target>SAVE AS</target>
+  </trans-unit> 
+
+
+   <trans-unit id="editStylesTitle">
+    <source>EDITAR ESTILOS DEL INFORME</source>
+    <target>EDIT DASHBOARD STYLES</target>
+  </trans-unit> 
+
+     <trans-unit id="dashboardTitleEdit">
+    <source>Título del informe</source>
+    <target>Dashboard title</target>
+  </trans-unit> 
+
+     <trans-unit id="filtersEdit">
+    <source>Filtros</source>
+    <target>Filters</target>
+  </trans-unit> 
+
+     <trans-unit id="panelTitleEdit">
+    <source>Título del panel</source>
+    <target>Panel title</target>
+  </trans-unit> 
+
+     <trans-unit id="panelContentEdit">
+    <source>Contenido del panel</source>
+    <target>Panel content</target>
+  </trans-unit> 
+
+     <trans-unit id="ChangeFontFamily">
+    <source>Tipo de fuente</source>
+    <target>Font type</target>
+  </trans-unit> 
+
+     <trans-unit id="ChangeFontSize">
+    <source>Tamaño de fuente</source>
+    <target>Font size</target>
+  </trans-unit> 
+
+     <trans-unit id="ChangeFontColor">
+    <source>Color de la fuente</source>
+    <target>Font color</target>
+  </trans-unit> 
+
+
+  <trans-unit id="ChangeBackgroundColor">
+    <source>Color del fondo</source>
+    <target>Background color </target>
+  </trans-unit> 
+  
+     <trans-unit id="ChangePaneColor">
+    <source>Color del panel</source>
+    <target>Panel color</target>
+  </trans-unit> 
+
+  <trans-unit id="opcionEditarEstilos">
+    <source>EDITAR ESTILOS</source>
+    <target>EDIT STYLES</target>
+  </trans-unit> 
+
+    <trans-unit id="left">
+    <source>Izquierda</source>
+    <target>Left</target>
+  </trans-unit> 
+  <trans-unit id="center">
+    <source>Centro</source>
+    <target>Center</target>
+  </trans-unit> 
+  <trans-unit id="right">
+    <source>Derecha</source>
+    <target>Right</target>
+  </trans-unit> 
+
+  <trans-unit id="resetStylesBtn">
+    <source>Volver a los valores por defecto</source>
+    <target>Set default values</target>
+  </trans-unit> 
+
+    <trans-unit id="samplePanelTitle">
+    <source>Previsualización</source>
+    <target>Previsualization</target>
+  </trans-unit> 
+
+   <trans-unit id="samplePanelDBName">
+    <source>Título del informe</source>
+    <target>Dashboard title</target>
+  </trans-unit> 
+
+   <trans-unit id="samplePanelName">
+    <source>Título del panel</source>
+    <target>Panel title</target>
+  </trans-unit> 
+  
+   <trans-unit id="histoGramRangesTxt">
+    <source>Rango</source>
+    <target>Range</target>
+  </trans-unit> 
+
+  <trans-unit id="histoGramDescTxt">
+    <source>Número de</source>
+    <target>Number of</target>
+  </trans-unit> 
+
+    <trans-unit id="histoGramDescTxt2">
+    <source>en este rango</source>
+    <target>in this range</target>
+  </trans-unit> 
+
+
+<trans-unit id="sidebarInform" datatype="html">
+<source>Crear Informe</source>
+<target>Create Inform</target>
+<context-group purpose="location">
+<context context-type="sourcefile">app/shared/components/sidebar/sidebar.component.html</context>
+<context context-type="linenumber">83</context>
+</context-group>
+</trans-unit>
+
+
+<trans-unit id="si">
+<source>Si</source>
+<target>Yes</target>
+</trans-unit>
+
+<trans-unit id="no">
+<source>No</source>
+<target>No</target>
+</trans-unit>
+
+<trans-unit id="duplicatedColumnNameLabel">
+<source>Nombre columna duplicada:</source>
+<target>Duplicated column name:</target>
+</trans-unit>
+
+</body>
+</file>
+</xliff>


### PR DESCRIPTION

Se ha modificado en EDA_APP los valores necesarios para la traducción de la app a gallego, a la vez que se ha incluido como base el archivo de traducciones al castellano, para no tener que modificar en el código los originales. 

Para poner en funcionamiento correctamente el visionado, hay que recompilar la app. Se debe ejecutar en terminal el comando 

>> _npm run build:prod_

en la carpeta /eda_app,  que recompilará la app para generar la carpeta _dist/eda_app/gl_.

- Una vez recompilado, se podrá escoger la opción galego en la barra lateral izquierda.
- El archivo _eda/eda_app/src/locale/messages.gl.xlf_ contiene todas las traducciones, cada una con el siguiente formato:

```
<trans-unit id="newPanelTitle"> // esta id hace referencia al código que para la traducción utiliza el módulo $localize'@@id:texto_a_traducir'
<source>Nuevo Panel</source> // texto origen
<target>New Pannel</target> // texto a traducir, en este caso al gallego
</trans-unit>
```

- El archivo _messages.gl.xlf_ es una copia de las traducciones en inglés. Para traducir los textos, sencillamente hay que modificar los textos que encontrareis en inglés dentro del tag "target"  a gallego.