### PR TITLE
SDA #100 - Hotfix - Filtro de tipo fecha aparece sin formato

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
@@ -83,13 +83,10 @@
                                 (mouseover)="showDescription(column)" 
                                 (mouseout)="description= ''" 
                                 cdkDrag
-
                                 [cdkDragData] = "column"
                                 (cdkDragDropped)="searchRelations(column, $event)" 
-                                (cdkDragDropped)="openColumnDialog(column)" 
+                                
                                 [ngStyle]=" column.hidden == 1 && {'opacity': '0.5'} " >  
-                                   
-   
                                    <span *ngIf='column.column_type == "text" ' class="mdi  mdi-alphabetical" style="margin-right:4px;"></span>
                                    <span *ngIf='column.column_type == "date" ' class="mdi mdi-calendar-text" style="margin-right:4px;"></span> 
                                    <span *ngIf='column.column_type == "numeric" ' class="mdi mdi-numeric" style="margin-right:4px;"></span> 
@@ -152,7 +149,8 @@
                         <hr class="mb-0">
                         <div class="filter-list" cdkDropList cdkDropListOrientation="horizontal"
                             #filterList="cdkDropList" [cdkDropListData]="filtredColumns"
-                            [cdkDropListConnectedTo]="[columnsList, selectList]" (cdkDropListDropped)="drop($event)" >
+                            [cdkDropListConnectedTo]="[columnsList, selectList]" (cdkDropListDropped)="drop($event)"
+                            >
                             <p *ngIf="filtredColumns.length < 1" class="fieldsInfo">{{draggFilters}}</p>
                             <div class="select-box col-3 col-md-2 p-1" *ngFor="let item of filtredColumns"
                                 (click)="openColumnDialog(item, true)" (mouseover)="showDescription(item)"

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -547,6 +547,13 @@ export class EdaBlankPanelComponent implements OnInit {
                 event.container.data,
                 event.previousIndex,
                 event.currentIndex);
+                
+                //apertura del diálogo de atributos o filtros
+                if(event.container.id == 'cdk-drop-list-1'){                
+                    this.openColumnDialog( <Column><unknown>event.container.data[event.currentIndex] );
+                }else{       
+                    this.openColumnDialog( <Column><unknown>event.container.data[event.currentIndex]  , true);
+                }
         }
 
 


### PR DESCRIPTION
En relación al issue #100, donde se veía que el filtrado de tipo fecha no se ejecutaba correctamente, hemos modificado el diálogo para que se ejecute el correspondiente.