### PR TITLE
SDA #106 - Hotfix - Colores

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-chart/eda-chart.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-chart/eda-chart.component.ts
@@ -25,7 +25,7 @@ export class EdaChartComponent implements OnInit, AfterViewInit {
         let out = [];
         let col = ChartsColors;
 
-        for (let i = 0; i < MAX_ITERATIONS; i += 50) {
+        for (let i = 0; i < MAX_ITERATIONS; i += 10) {
             for (let j = 0; j < col.length; j++) {
                 out.push(
                     {


### PR DESCRIPTION
Resuelve https://github.com/SinergiaTIC/Sinergia-Data-Analytics/issues/106

La combinación de valores generaban más colores de los que se inicializan  para el grafico. Por eso fallaba