### PR TITLE
Enhancement -  APP - Mostrar nombre de tabla actual en diseñador de informes 

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
@@ -38,12 +38,11 @@
             <p-tabPanel i18n-header="@@vistaSeleccionador" header="{{!modeSQL ? editQuery : editSQLQuery}}">
 
                 <div *ngIf="!modeSQL" class="grid">
-
-                    <div class="col-6 md:col-2 pl-2 pr-2">
-                        <h4 i18n="@@entidadesH4"  i18n-title="@@entidadesTitle" title="Clique sobre un entidad para ver sus atributos." >
-                            Entidades
+                    <div class="col-6 md:col-2 pl-2 pr-2" >
+                        <h4  i18n="@@entidadesH4"  i18n-title="@@entidadesTitle" title="Clique sobre un entidad para ver sus atributos.">
+                            Entidades 
                         </h4>
-                        <hr class="mb-0">
+                        <h5 style="padding-bottom: 2.6rem;"></h5>
                         <eda-input [inject]="inputs.findTable"></eda-input>
                         <div class="column-list">
                             <div class="our-table-box" *ngFor="let table of tablesToShow" (click)="loadColumns(table)"
@@ -58,8 +57,14 @@
 
                     <div class="col-6 md:col-2 pl-2">
                         <div class="d-flex justify-content-between">
-                            <h4 i18n="@@atributosH4"  i18n-title="@@atributsTitle" title="Atributos de una entidad. Arrastre los atrubutos a la selección o los filtros para consultarlos. Haciendo click sobre el atributo se accede a sus propiedaes" >
+                            <h4 *ngIf="!userSelectedTable" i18n="@@atributosH4"  i18n-title="@@atributsTitle" title="Atributos de una entidad. Arrastre los atrubutos a la selección o los filtros para consultarlos. Haciendo click sobre el atributo se accede a sus propiedaes">
                                 Atributos
+                            </h4>
+                            <h4 *ngIf="userSelectedTable" i18n="@@atributosH4+" i18n-title="@@atributsTitle+" title="Clique sobre un entidad para ver sus atributos.">
+                                Columnas de: <br>
+                                <h5> 
+                                    {{getDisplayName(userSelectedTable)}} 
+                                </h5>
                             </h4>
                             <div *ngIf="userService.isAdmin && showHiddId">
                                 <span i18n="@@hiddenAttributes" class="pointer icon-hover" (click)="changeHiddenMode()">
@@ -68,10 +73,14 @@
                                     <i *ngIf="hiddenColumn==1" class="pi pi-eye-slash" style="font-size: 1.5rem"></i>
                                 </span>
                             </div>
+                    </div>
+                        
+                        <div *ngIf="!userSelectedTable" style="padding-top: 2.5rem;">
+                            <eda-input [inject]="inputs.findColumn"></eda-input>
                         </div>
-
-                        <hr class="mb-0" style="margin-top: 0.5rem!important;">
-                        <eda-input [inject]="inputs.findColumn"></eda-input>
+                        <div *ngIf="userSelectedTable" style="padding-top: 1.2rem;">
+                            <eda-input [inject]="inputs.findColumn"></eda-input>
+                        </div>
                             
                         <div class="column-list" cdkDropList #columnsList="cdkDropList" [cdkDropListData]="columns"
                             [cdkDropListConnectedTo]="[selectList, filterList]" (cdkDropListDropped)="drop($event)"

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
@@ -39,10 +39,12 @@
 
                 <div *ngIf="!modeSQL" class="grid">
                     <div class="col-6 md:col-2 pl-2 pr-2" >
-                        <h4  i18n="@@entidadesH4"  i18n-title="@@entidadesTitle" title="Clique sobre un entidad para ver sus atributos.">
-                            Entidades 
+                      <div class="d-flex justify-content-between"  style="min-height: 45px;">
+                        <h4 i18n="@@entidadesH4"  i18n-title="@@entidadesTitle" title="Clique sobre un entidad para ver sus atributos.">
+                            Entidades
                         </h4>
-                        <h5 style="padding-bottom: 2.5rem;"></h5>
+                      </div>
+
                         <eda-input [inject]="inputs.findTable"></eda-input>
                         <div class="column-list">
                             <div class="our-table-box" *ngFor="let table of tablesToShow" (click)="loadColumns(table)"
@@ -54,70 +56,63 @@
                             </div>
                         </div>
                     </div>
-
                     <div class="col-6 md:col-2 pl-2">
-                        <div class="d-flex justify-content-between">
+                        <div class="d-flex justify-content-between"  style="min-height: 45px;">
                             <h4 *ngIf="!userSelectedTable" i18n="@@atributosH4"  i18n-title="@@atributsTitle" title="Atributos de una entidad. Arrastre los atrubutos a la selección o los filtros para consultarlos. Haciendo click sobre el atributo se accede a sus propiedaes">
                                 Atributos
                             </h4>
-                            <h4 *ngIf="userSelectedTable" i18n="@@atributosH4+" i18n-title="@@atributsTitle+" title="Clique sobre un entidad para ver sus atributos." > 
-                                Columnas de:
-                            </h4>
-                            <div style="position:absolute;  left: 6px; ">
-                                <br>
-                                <h4 *ngIf="userSelectedTable" i18n="@@atributosH4interpolation" i18n-title="@@atributsTitle+" title="Clique sobre un entidad para ver sus atributos." style="text-align: left;"> 
-                                    {{getDisplayName(userSelectedTable)}}
-                                </h4>
-                            </div>
+                            <h5 *ngIf="userSelectedTable"  i18n-title="@@atributsTitle+" title="Clique sobre un entidad para ver sus atributos." >
+                                <span i18n="@@atributosH4+">Columnas de:</span> <span class="d-block font-weight-bold" i18n="@@atributosH4interpolation" i18n-title="@@atributsTitle+">{{getDisplayName(userSelectedTable)}}</span>
+                            </h5>
+
                             <div *ngIf="userService.isAdmin && showHiddId">
-                                <span i18n="@@hiddenAttributes" class="pointer icon-hover" (click)="changeHiddenMode()">
-                                    Atributos ocultos
+                                <span i18n-title="@@hiddenAttributes" title="Mostrar/ocultar campos ocultos" class="pointer icon-hover" (click)="changeHiddenMode()">
                                     <i *ngIf="hiddenColumn==0" class="pi pi-eye" style="font-size: 1.5rem"></i>
                                     <i *ngIf="hiddenColumn==1" class="pi pi-eye-slash" style="font-size: 1.5rem"></i>
                                 </span>
                             </div>
                     </div>
-                        <div style="padding-top: 2.4rem;">
+                        <div>
                             <eda-input [inject]="inputs.findColumn"></eda-input>
                         </div>
-                            
+
                         <div class="column-list" cdkDropList #columnsList="cdkDropList" [cdkDropListData]="columns"
                             [cdkDropListConnectedTo]="[selectList, filterList]" (cdkDropListDropped)="drop($event)"
                             [cdkDropListEnterPredicate]="isAllowed" >
                             <div *ngFor="let column of columns">
-                                <div class="column-box"  
-                                *ngIf='(column.column_type === "numeric" || column.column_type === "date" ) && ( column.hidden != hiddenColumn || hiddenColumn==0) ' 
-                                (click)="moveItem(column)" 
-                                (mouseover)="showDescription(column)" 
-                                (mouseout)="description= ''" 
+                                <div class="column-box"
+                                *ngIf='(column.column_type === "numeric" || column.column_type === "date" ) && ( column.hidden != hiddenColumn || hiddenColumn==0) '
+                                (click)="moveItem(column)"
+                                (mouseover)="showDescription(column)"
+                                (mouseout)="description= ''"
                                 cdkDrag
                                 [cdkDragData] = "column"
-                                (cdkDragDropped)="searchRelations(column, $event)" 
-                                
-                                [ngStyle]=" column.hidden == 1 && {'opacity': '0.5'} " >  
+                                (cdkDragDropped)="searchRelations(column, $event)"
+
+                                [ngStyle]=" column.hidden == 1 && {'opacity': '0.5'} " >
                                    <span *ngIf='column.column_type == "text" ' class="mdi  mdi-alphabetical" style="margin-right:4px;"></span>
-                                   <span *ngIf='column.column_type == "date" ' class="mdi mdi-calendar-text" style="margin-right:4px;"></span> 
-                                   <span *ngIf='column.column_type == "numeric" ' class="mdi mdi-numeric" style="margin-right:4px;"></span> 
-                                   <span class="text-left" title="{{column.description.default}}" class="eda-col-class-{{column.column_type}}">                        
-                                       {{column.display_name.default}}  
+                                   <span *ngIf='column.column_type == "date" ' class="mdi mdi-calendar-text" style="margin-right:4px;"></span>
+                                   <span *ngIf='column.column_type == "numeric" ' class="mdi mdi-numeric" style="margin-right:4px;"></span>
+                                   <span class="text-left" title="{{column.description.default}}" class="eda-col-class-{{column.column_type}}">
+                                       {{column.display_name.default}}
                                    </span>
-                               </div> 
-                               <div  class="column-box" 
-                               *ngIf='(column.column_type != "numeric" && column.column_type !="date" ) && ( column.hidden != hiddenColumn || hiddenColumn==0) ' 
-                               (click)="moveItem(column)" 
-                               (mouseover)="showDescription(column)" 
-                               (mouseout)="description= ''" 
+                               </div>
+                               <div  class="column-box"
+                               *ngIf='(column.column_type != "numeric" && column.column_type !="date" ) && ( column.hidden != hiddenColumn || hiddenColumn==0) '
+                               (click)="moveItem(column)"
+                               (mouseover)="showDescription(column)"
+                               (mouseout)="description= ''"
                                cdkDrag
                                (cdkDragDropped)="searchRelations(column, $event)"
-                               [ngStyle]=" column.hidden == 1  && {'opacity': '0.5'} " >    
-                                  
+                               [ngStyle]=" column.hidden == 1  && {'opacity': '0.5'} " >
+
                                   <span *ngIf='column.column_type == "text" ' class="mdi  mdi-alphabetical" style="margin-right:4px;"></span>
-                                  <span *ngIf='column.column_type == "date" ' class="mdi mdi-calendar-text" style="margin-right:4px;"></span> 
-                                  <span *ngIf='column.column_type == "numeric" ' class="mdi mdi-numeric" style="margin-right:4px;"></span> 
-                                  <span class="text-left" title="{{column.description.default}}" class="eda-col-class-{{column.column_type}}">                        
-                                      {{column.display_name.default}}  
+                                  <span *ngIf='column.column_type == "date" ' class="mdi mdi-calendar-text" style="margin-right:4px;"></span>
+                                  <span *ngIf='column.column_type == "numeric" ' class="mdi mdi-numeric" style="margin-right:4px;"></span>
+                                  <span class="text-left" title="{{column.description.default}}" class="eda-col-class-{{column.column_type}}">
+                                      {{column.display_name.default}}
                                   </span>
-                                </div> 
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -131,18 +126,18 @@
                             #selectList="cdkDropList" [cdkDropListData]="currentQuery"
                             [cdkDropListConnectedTo]="[columnsList, filterList]" (cdkDropListDropped)="drop($event)" >
                             <p *ngIf="currentQuery.length < 1" class="fieldsInfo">{{draggFields}}</p>
-                            <div *ngFor="let item of currentQuery" 
-                                class="select-box col-3 col-md-2 p-1" 
-                                (click)="openColumnDialog(item)"  
+                            <div *ngFor="let item of currentQuery"
+                                class="select-box col-3 col-md-2 p-1"
+                                (click)="openColumnDialog(item)"
                                 (mouseover)="showDescription(item)"
                                 (mouseout)="description = ''"
-                                cdkDrag 
+                                cdkDrag
                                 [cdkDragData]="column">
 
                                 <span class="close-thin pointer" style="z-index: 9999;" (click)="removeColumn( item, 'select' )"></span>
                                 <span *ngIf='item.column_type == "text" ' class="mdi  mdi-alphabetical" style="margin-right:4px;"></span>
-                                <span *ngIf='item.column_type == "date" ' class="mdi mdi-calendar-text" style="margin-right:4px;"></span> 
-                                <span *ngIf='item.column_type == "numeric" ' class="mdi mdi-numeric" style="margin-right:4px;"></span> 
+                                <span *ngIf='item.column_type == "date" ' class="mdi mdi-calendar-text" style="margin-right:4px;"></span>
+                                <span *ngIf='item.column_type == "numeric" ' class="mdi mdi-numeric" style="margin-right:4px;"></span>
                                 <span class="text-center eda-col-class-{{item.column_type}}" title="{{item.description.default}}"  >
                                     {{item.display_name.default}}
                                 </span>
@@ -152,7 +147,7 @@
                         </div>
 
                         <h4 class="mt-4" i18n="@@filtrosH4">
-                            Filtrar los resultados por: 
+                            Filtrar los resultados por:
                         </h4>
                         <hr class="mb-0">
                         <div class="filter-list" cdkDropList cdkDropListOrientation="horizontal"
@@ -165,15 +160,15 @@
                                 (mouseout)="description = ''" cdkDrag [cdkDragData]="column" >
                                 <span class="close-thin pointer" (click)="removeColumn( item, 'filter' )"></span>
                                 <span *ngIf='item.column_type == "text" ' class="mdi  mdi-alphabetical" style="margin-right:4px;"></span>
-                                <span *ngIf='item.column_type == "date" ' class="mdi mdi-calendar-text" style="margin-right:4px;"></span> 
-                                <span *ngIf='item.column_type == "numeric" ' class="mdi mdi-numeric" style="margin-right:4px;"></span> 
+                                <span *ngIf='item.column_type == "date" ' class="mdi mdi-calendar-text" style="margin-right:4px;"></span>
+                                <span *ngIf='item.column_type == "numeric" ' class="mdi mdi-numeric" style="margin-right:4px;"></span>
                                 <span  class=" text-center eda-col-class-{{item.column_type}}" title="{{item.description.default}}"  >
                                     {{item.display_name.default}}
                                 </span>
                             </div>
 
                         </div>
-                        
+
                         <div class="grid">
                             <div class="col-4 md:col-12 infoFiltres">
                                 <span i18n="@@topQueryH4">
@@ -195,7 +190,7 @@
                                     </p-selectButton>
 
 
-                                
+
 
 
                             </div>

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
@@ -42,7 +42,7 @@
                         <h4  i18n="@@entidadesH4"  i18n-title="@@entidadesTitle" title="Clique sobre un entidad para ver sus atributos.">
                             Entidades 
                         </h4>
-                        <h5 style="padding-bottom: 2.6rem;"></h5>
+                        <h5 style="padding-bottom: 2.5rem;"></h5>
                         <eda-input [inject]="inputs.findTable"></eda-input>
                         <div class="column-list">
                             <div class="our-table-box" *ngFor="let table of tablesToShow" (click)="loadColumns(table)"
@@ -60,12 +60,15 @@
                             <h4 *ngIf="!userSelectedTable" i18n="@@atributosH4"  i18n-title="@@atributsTitle" title="Atributos de una entidad. Arrastre los atrubutos a la selección o los filtros para consultarlos. Haciendo click sobre el atributo se accede a sus propiedaes">
                                 Atributos
                             </h4>
-                            <h4 *ngIf="userSelectedTable" i18n="@@atributosH4+" i18n-title="@@atributsTitle+" title="Clique sobre un entidad para ver sus atributos.">
-                                Columnas de: <br>
-                                <h5> 
-                                    {{getDisplayName(userSelectedTable)}} 
-                                </h5>
+                            <h4 *ngIf="userSelectedTable" i18n="@@atributosH4+" i18n-title="@@atributsTitle+" title="Clique sobre un entidad para ver sus atributos." > 
+                                Columnas de:
                             </h4>
+                            <div style="position:absolute;  left: 6px; ">
+                                <br>
+                                <h4 *ngIf="userSelectedTable" i18n="@@atributosH4interpolation" i18n-title="@@atributsTitle+" title="Clique sobre un entidad para ver sus atributos." style="text-align: left;"> 
+                                    {{getDisplayName(userSelectedTable)}}
+                                </h4>
+                            </div>
                             <div *ngIf="userService.isAdmin && showHiddId">
                                 <span i18n="@@hiddenAttributes" class="pointer icon-hover" (click)="changeHiddenMode()">
                                     Atributos ocultos
@@ -74,11 +77,7 @@
                                 </span>
                             </div>
                     </div>
-                        
-                        <div *ngIf="!userSelectedTable" style="padding-top: 2.5rem;">
-                            <eda-input [inject]="inputs.findColumn"></eda-input>
-                        </div>
-                        <div *ngIf="userSelectedTable" style="padding-top: 1.2rem;">
+                        <div style="padding-top: 2.4rem;">
                             <eda-input [inject]="inputs.findColumn"></eda-input>
                         </div>
                             

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -77,7 +77,6 @@ export class EdaBlankPanelComponent implements OnInit {
     public lodash: any = _;
     public hiddenColumn: number;
 
-
     public inputs: any = {};
 
     /**Dashbard emitter */
@@ -1028,5 +1027,15 @@ export class EdaBlankPanelComponent implements OnInit {
             this.showHiddId = false;
         }
      
+    }
+
+    public getDisplayName(table) {
+        let tmpTable : any; 
+        this.tablesToShow.filter(a => {
+            if (a.table_name == table) {
+                tmpTable = a;
+            } 
+            })
+        return tmpTable.display_name.default;
     }
 }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
@@ -83,7 +83,6 @@ export const PanelInteractionUtils = {
           if (field) {
             ebp.currentQuery[i].format = field.format;
             ebp.currentQuery[i].cumulativeSum = field.cumulativeSum;
-            console.log(ebp.currentQuery[i], field);
             if (ebp.currentQuery[i].column_type === 'text' && ![null, 'none'].includes(field.aggregation_type)) {
               ebp.currentQuery[i].column_type = 'numeric';
               ebp.currentQuery[i].old_column_type = 'text';

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4213,18 +4213,18 @@
         <target>Nom columna duplicada:</target>
       </trans-unit>
 
-      <trans-unit id="@@hiddenAttributes">
+      <trans-unit id="hiddenAttributes">
         <source>Atributos ocultos</source>
-        <target>Columnes ocultes</target>
+        <target>Mostra/amaga columnes ocultes</target>
       </trans-unit>
       <trans-unit id="atributosH4+" datatype="html">
         <source>
           Columnas de:
         </source>
         <target>
-          Atributs de: 
+          Columnes de:
         </target>
-      </trans-unit>  
+      </trans-unit>
       <trans-unit id="atributosH4interpolation" datatype="html">
         <source>
           <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -687,10 +687,10 @@
       <trans-unit id="atributosH4" datatype="html">
         <source>
           Atributos
-</source>
+        </source>
         <target>
           Atributs
-</target>
+        </target>
         <context-group purpose="location">
           <context context-type="sourcefile">
             app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
@@ -4217,7 +4217,22 @@
         <source>Atributos ocultos</source>
         <target>Columnes ocultes</target>
       </trans-unit>
-
+      <trans-unit id="atributosH4+" datatype="html">
+        <source>
+          Columnas de:
+        </source>
+        <target>
+          Atributs de: 
+        </target>
+      </trans-unit>  
+      <trans-unit id="atributosH4interpolation" datatype="html">
+        <source>
+          <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
+        </source>
+        <target>
+          <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
+        </target>
+      </trans-unit>
 
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4191,10 +4191,28 @@
         <target>Duplicated column name:</target>
       </trans-unit>
 
-      <trans-unit id="@@hiddenAttributes">
+      <trans-unit id="hiddenAttributes">
         <source>Atributos ocultos</source>
-        <target>Hidden columns</target>
+        <target>Show/hide hidden columns</target>
       </trans-unit>
+
+      <trans-unit id="atributosH4+" datatype="html">
+        <source>
+          Columnas de:
+        </source>
+        <target>
+          Columns of:
+        </target>
+      </trans-unit>
+      <trans-unit id="atributosH4interpolation" datatype="html">
+        <source>
+          <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
+        </source>
+        <target>
+          <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
+        </target>
+      </trans-unit>
+
     </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -673,21 +673,13 @@
         </context-group>
       </trans-unit>
 
-<trans-unit id="atributosH4" datatype="html">
+      <trans-unit id="atributosH4" datatype="html">
         <source>
           Atributos
 </source>
         <target>
           Columnas
 </target>
-<trans-unit id="atributsTitle+" datatype="html">
-       Columnas de:             {{getDisplayName(userSelectedTable)}} 
-      
-        <target>
-          Columnas de:
-            {{getDisplayName(userSelectedTable)}} 
-</target>
-  </trans-unit>
         <context-group purpose="location">
           <context context-type="sourcefile">
             app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>
@@ -4246,11 +4238,27 @@
         <target>Nombre de columna duplicada:</target>
       </trans-unit>
 
-      <trans-unit id="@@hiddenAttributes">
+      <trans-unit id="hiddenAttributes">
         <source>Atributos ocultos</source>
-        <target>Columnas ocultas</target>
+        <target>Mostrar/ocultar columnas ocultas</target>
       </trans-unit>
 
+      <trans-unit id="atributosH4+" datatype="html">
+        <source>
+          Columnas de:
+        </source>
+        <target>
+          Columnas de:
+        </target>
+      </trans-unit>
+      <trans-unit id="atributosH4interpolation" datatype="html">
+        <source>
+          <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
+        </source>
+        <target>
+          <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
+        </target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -673,13 +673,21 @@
         </context-group>
       </trans-unit>
 
-      <trans-unit id="atributosH4" datatype="html">
+<trans-unit id="atributosH4" datatype="html">
         <source>
           Atributos
 </source>
         <target>
           Columnas
 </target>
+<trans-unit id="atributsTitle+" datatype="html">
+       Columnas de:             {{getDisplayName(userSelectedTable)}} 
+      
+        <target>
+          Columnas de:
+            {{getDisplayName(userSelectedTable)}} 
+</target>
+  </trans-unit>
         <context-group purpose="location">
           <context context-type="sourcefile">
             app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html</context>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -4238,9 +4238,26 @@
         <target>Nombre de columna duplicada:</target>
       </trans-unit>
 
-      <trans-unit id="@@hiddenAttributes">
+      <trans-unit id="hiddenAttributes">
         <source>Atributos ocultos</source>
-        <target>Columnas ocultas</target>
+        <target>Mostar/ocultar columnas ocultas</target>
+      </trans-unit>
+
+      <trans-unit id="atributosH4+" datatype="html">
+        <source>
+          Columnas de:
+        </source>
+        <target>
+          Columnas de:
+        </target>
+      </trans-unit>
+      <trans-unit id="atributosH4interpolation" datatype="html">
+        <source>
+          <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
+        </source>
+        <target>
+          <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
+        </target>
       </trans-unit>
 
     </body>


### PR DESCRIPTION
- fix #44 

Añadida la traducción al español del nuevo texto generado para visionar correctamente. Para añadir el resto de traducciones, utlizar el transunit i18n="atributsTitle+"

Hay también una eliminación de un console.log en panel-interaction-utils.ts, aprovechando el PR. 