### PR TITLE
Hotfix - API - Query builder usa relaciones erróneas 

### DIFF
--- a/eda/eda_api/lib/services/query-builder/query-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/query-builder.service.ts
@@ -50,8 +50,8 @@ export abstract class QueryBuilderService {
 
         const graph = this.buildGraph();
         /* Agafem els noms de les taules, origen i destí (és arbitrari), les columnes i el tipus d'agregació per construïr la consulta */
-        const origin = this.queryTODO.fields.find(x => x.order === 0).table_id;
-        const dest = [];
+        let origin = this.queryTODO.fields.find(x => x.order === 0).table_id;
+        let dest = [];
         const valueListList = [];
         const modelPermissions = this.dataModel.ds.metadata.model_granted_roles;
 
@@ -151,7 +151,32 @@ export abstract class QueryBuilderService {
 
 
         /** ARBRE DELS JOINS A FER */
-        const joinTree = this.dijkstraAlgorithm(graph, origin, dest.slice(0));
+        let joinTree = this.dijkstraAlgorithm(graph, origin, dest.slice(0));
+        // Busco relacions directes.
+        if( ! this.validateJoinTree(  joinTree, dest ) ){
+            let exito = false;
+            let new_origin  = '';
+            let new_dest  = [...dest];
+            let new_joinTree:any;
+            for (let d of  dest) {
+                new_origin = d;
+                new_dest =  [...dest].filter(e => e !== d);
+                new_dest.push(origin);
+                new_joinTree = this.dijkstraAlgorithm(graph, new_origin, new_dest.slice(0) );
+                if(  this.validateJoinTree(  new_joinTree, new_dest ) ){
+                    exito = true;
+                    break;
+                }
+            }
+            if(exito){
+                origin = new_origin;
+                dest = [...new_dest];
+                joinTree = new_joinTree;
+            }
+
+        }
+
+
 
         if (this.queryTODO.simple) {
             this.query = this.simpleQuery(columns, origin);
@@ -178,6 +203,16 @@ export abstract class QueryBuilderService {
         return graph;
     }
 
+    public validateJoinTree(joinTree:any, dest:any){
+        for (let i = 0; i < dest.length; i++) {
+            let elem = joinTree.find(n => n.name === dest[i]);
+            if(elem.dist > 1 ){
+                return false;
+            }
+          }
+        return true;
+    }
+    
     public dijkstraAlgorithm(graph, origin, dest) {
         const not_visited = [];
         const v = [];

--- a/eda/eda_api/lib/services/query-builder/query-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/query-builder.service.ts
@@ -203,6 +203,7 @@ export abstract class QueryBuilderService {
         return graph;
     }
 
+    /** valida relaciones directas */
     public validateJoinTree(joinTree:any, dest:any){
         for (let i = 0; i < dest.length; i++) {
             let elem = joinTree.find(n => n.name === dest[i]);
@@ -212,7 +213,7 @@ export abstract class QueryBuilderService {
           }
         return true;
     }
-    
+
     public dijkstraAlgorithm(graph, origin, dest) {
         const not_visited = [];
         const v = [];


### PR DESCRIPTION
- fix #45 

Se itera sobre las tablas implicadas y se priorizan las relaciones directas.

El comportamiento es "Correcto" aunque no el esperado. EDA no prioriza un camino por encima de otros.   Y al existir un camino a través de la tabla users EDA sigue ese camino. 

Se ha realizado un ajuste para que  se prioricen las relaciones directas. Es decir. Si hay una relación directa entre las tablas implicadas se priorizará sobre otros caminos más largos.  Esto no permite elegir el camino. Simplemente si hay un camino directo se prioriza sobre otro que necesite de tablas intermedias. 