### PR TITLE
Hotfix - APP - Suma incorrecta en totales de fila en tablas de referencia cruzada

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
@@ -307,8 +307,8 @@ export class EdaTable {
 
                 numericCols.forEach(key => {
                     valuesKeys.forEach(valueKey => {
-                      let keyForCompare = key.split('~')[1].trim();
-                        if (keyForCompare.trim() === valueKey.trim()) {
+                      let keyArray = key.split('~');
+                        if (keyArray.includes(valueKey)) {
                             let decimalplaces =  0;  /** esto se hace  para ajustar el número de dicimales porque 3.1+2.5 puede dar 5.600004 */
                             try{
                                 if(  row[key].toString().split(".")[1].length > 0){

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
@@ -37,7 +37,7 @@ export class EdaTable {
 
     public _value: any[] = [];
     public _value_copy: any[] = [];
-    
+
     public cols: EdaColumn[] = [];
     public rows: number = 10;
     public initRows: number = 10;
@@ -68,7 +68,7 @@ export class EdaTable {
     public resultAsPecentage: boolean = false;
     public onlyPercentages: boolean = false;
     public percentageColumns: Array<any> = [];
-    public noRepetitions: boolean = false; 
+    public noRepetitions: boolean = false;
     public autolayout: boolean = true;
     public sortedSerie: any = null;
     public sortedColumn: any = { field: null, order: null };
@@ -220,7 +220,7 @@ export class EdaTable {
         }
         if (this.withColSubTotals) {
             event ? this.colSubTotals(event.first / event.rows + 1) : this.colSubTotals(1);
-        } 
+        }
         if (this.noRepetitions) {
             this.noRepeatedRows();
         }
@@ -240,7 +240,7 @@ export class EdaTable {
             this.cols = this.cols.filter(col => col.rowTotal !== true);
             this.series[numSeries - 2].labels = this.series[numSeries - 2].labels.filter(label => label.isTotal !== true);
 
-            //percentage columns has no label 
+            //percentage columns has no label
             const lastLayerLabels = this.cols.filter(col => col.type !== "EdaColumnPercentage").length - 1;
             this.series[numSeries - 1].labels = this.series[numSeries - 1].labels.slice(0, lastLayerLabels);
 
@@ -254,7 +254,7 @@ export class EdaTable {
         this.cols = this.cols.filter(col => col.rowTotal !== true);
         this.series[numSeries - 2].labels = this.series[numSeries - 2].labels.filter(label => label.isTotal !== true);
 
-        //percentage columns has no label 
+        //percentage columns has no label
         const lastLayerLabels = this.cols.filter(col => col.type !== "EdaColumnPercentage").length - 1;
         this.series[numSeries - 1].labels = this.series[numSeries - 1].labels.slice(0, lastLayerLabels);
 
@@ -263,7 +263,7 @@ export class EdaTable {
 
     rowTotals() {
         if (this.pivot === true) {
-            // 
+            //
             const colNames = this.cols.map(col => col.field);
 
             //get unique names for same metric in each sub-set -> columns : A-income, B-income, A-amount, B-amount -> returns:  [income, amount]
@@ -272,7 +272,7 @@ export class EdaTable {
                 .filter(key => numericCols.includes(key))
                 .map(key => key.slice(key.lastIndexOf('~') + 1));
             const valuesKeys = Array.from(new Set(keys));
-            
+
             //get names for new columns from series array
             let pretyNames;
             if (this.series[0].labels.length > 2) {
@@ -307,7 +307,8 @@ export class EdaTable {
 
                 numericCols.forEach(key => {
                     valuesKeys.forEach(valueKey => {
-                        if (key.includes(valueKey)) {     
+                      let keyForCompare = key.split('~')[1].trim();
+                        if (keyForCompare.trim() === valueKey.trim()) {
                             let decimalplaces =  0;  /** esto se hace  para ajustar el número de dicimales porque 3.1+2.5 puede dar 5.600004 */
                             try{
                                 if(  row[key].toString().split(".")[1].length > 0){
@@ -435,7 +436,7 @@ export class EdaTable {
         const values = this._value;
         const keys = this.cols.map(col => col.field);
 
-      
+
 
         for (let i = 0; i < values.length; i++) {
             for (let j = 0; j < keys.length; j++) {
@@ -512,14 +513,14 @@ export class EdaTable {
     makeCopy(val) : void {
         this._value_copy = val;
     }
-    
+
     getCopy() {
         return this._value_copy;
     }
 
     withRepeatedRows() {
         const val = this.getCopy();
-       
+
         if (_.isEmpty(val) == true) {
             return this._value;
         } else {
@@ -529,7 +530,7 @@ export class EdaTable {
     }
 
     noRepeatedRows() {
-        
+
         this.makeCopy(this._value); //hacemos una copia del valor original que nos entra, por si tenemos que reutilizarlo en la vista opuesta
         let val = this._value;
         //separamos valores de claves
@@ -537,26 +538,26 @@ export class EdaTable {
         for (let i=0; i<val.length;i++) {
             values.push(Object.values(val[i]));
         }
-        
+
         //tomamos claves que serán el cabecero
-        let labels = [];      
+        let labels = [];
         labels.push(Object.keys(val[0])); //insertamos el primer objeto con el cabecero para iterar y extraer los datos
         labels.forEach(e => {
             e.forEach(function(key,val) {
                 labels.push(key);
-                
+
             })
-        
+
         })
         labels.shift(); //borramos el primer objeto.
 
         let output = [];
 
-            // ESTO SE HACE PARA EVITAR REPETIDOS EN LA TABLA. SI UN CAMPO TIENE UNA COLUMNA QUE SE REPITE 
+            // ESTO SE HACE PARA EVITAR REPETIDOS EN LA TABLA. SI UN CAMPO TIENE UNA COLUMNA QUE SE REPITE
             let first  = _.cloneDeep(values[0]);
             for (let i = 0; i < values.length; i += 1) {
                 const obj = [];
-                if(i == 0){   
+                if(i == 0){
                     for (let e = 0; e < values[i].length; e += 1) {
                             obj[labels[e]] = values[i][e];
                         }
@@ -570,13 +571,13 @@ export class EdaTable {
                         first[e]  =  values[i][e]; //AQUI SE SUTITUYE EL PRIMER VALOR
                         }
                 }
-                output.push(obj);   
+                output.push(obj);
             }
 
-            this._value = output;        
+            this._value = output;
 
         return this._value;
-       
+
     }
 
     colsPercentages() {
@@ -759,7 +760,7 @@ export class EdaTable {
     }
     /**
      * Build a serie to pivot (one serie per metric)
-     * @param serieIndex 
+     * @param serieIndex
      */
     buildPivotSerie(serieIndex: number) {
         const params = this.generatePivotParams();
@@ -780,7 +781,7 @@ export class EdaTable {
 
     /**
      * Merges series rows in one set of rows
-     * @param rowsToMerge 
+     * @param rowsToMerge
      */
     mergeRows(rowsToMerge: any) {
         const NUM_ROWS_IN_SERIES = rowsToMerge[0].length;
@@ -798,7 +799,7 @@ export class EdaTable {
 
     /**
      * Merges series columns in one set of columns
-     * @param colsToMerge 
+     * @param colsToMerge
      */
     mergeColumns(colsToMerge: any) {
         const NUM_COLS = colsToMerge[0].length;
@@ -835,7 +836,7 @@ export class EdaTable {
     }
     /**
      * Build a map of maps recursively
-     * @param cols 
+     * @param cols
      */
     buildMapRecursive(cols: Array<Array<string>>) {
         let map = new Map();
@@ -887,10 +888,10 @@ export class EdaTable {
     }
     /**
      * Buils new rows recursively (iterating over the tree until last nodes are found)
-     * @param map 
-     * @param colLabel 
-     * @param row 
-     * @param serieLabel 
+     * @param map
+     * @param colLabel
+     * @param row
+     * @param serieLabel
      */
     buildNewRowsRecursive(map: Map<string, any>, colLabel: string, row: any, serieLabel: string) {
         map.forEach((value, key) => {
@@ -917,7 +918,7 @@ export class EdaTable {
         const oldRows = this.getValues();
         //get index for numeric and text/date columns
         const typesIndex = this.getColsInfo();
-        //Get left column 
+        //Get left column
         const mainCol = this.cols[typesIndex.text[0]];
         const mainColLabel = Object.keys(oldRows[0])[typesIndex.text[0]];
         const mainColValues = _.orderBy(_.uniq(_.map(this.value, mainCol.field)));
@@ -953,7 +954,7 @@ export class EdaTable {
     }
 
     /**
-     * 
+     *
      * @param labels labels to set headers
      * @param colsInfo contains userName for main column
      */
@@ -1035,6 +1036,6 @@ export class EdaTable {
 
 
 
-   
+
 
 }


### PR DESCRIPTION
# Descripción del PR

Este PR aborda el problema identificado en el issue #50, donde se identificó un problema en el cálculo de los totales en una tabla. El problema surge cuando se utiliza la función `includes()` para verificar si el nombre de una columna en el total está incluido en el nombre de la columna mostrada en la tabla. Esto provocaba un falso positivo, particularmente con la columna `N` (etiquetada como _(N) Pagos_), ya que `N` también está incluido en otros nombres de columna como _Nóminas_.

## Solución Propuesta

Para corregir este problema, se ha modificado el código para extraer el nombre exacto de la columna y luego compararlo utilizando el operador de igualdad estricta `===`. Esto asegura que solo se sumen los valores correspondientes a la columna exacta, evitando falsos positivos causados por coincidencias parciales de nombres.

# Pruebas a Realizar

Para validar la corrección del problema, se deben realizar las siguientes pruebas:

1. **Creación de Informe en el Módulo de Pagos:**
   - Crear un informe en el módulo de Pagos que incluya tanto el campo `N` como el campo `Nomina`.
   - Asegurarse de que ambos campos contengan valores válidos.

2. **Verificación de Totales de Fila:**
   - Revisar que la suma de los totales por fila se realice correctamente.
   - Verificar que la suma no incluya valores de otras columnas que no correspondan, asegurando que el total para `N` no incluya valores de `Nomina` y viceversa.

3. **Comparación con Comportamiento Anterior:**
   - Comparar los resultados obtenidos con el comportamiento previo para confirmar que el problema identificado en el issue #50 ha sido efectivamente solucionado.


![image](https://github.com/SinergiaTIC/SinergiaDA/assets/46187267/233e12f1-5e53-42d2-9d2f-ed0ab1f4ada3)


![image](https://github.com/SinergiaTIC/SinergiaDA/assets/46187267/dd1ff42f-0f4b-4eaf-8086-44068b3f2ca8)

