### PR TITLE
Hotfix - API -  Establecer dos decimales por defecto para cálculo de medias

### DIFF
--- a/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
@@ -259,7 +259,12 @@ export class MySqlBuilderService extends QueryBuilderService {
           if (el.aggregation_type === 'count_distinct') {
             columns.push(`cast( count( distinct \`${el.table_id}\`.\`${el.column_name}\`) as decimal(32,${el.minimumFractionDigits||0}) ) as \`${el.display_name}\``);
           } else {
-            columns.push(`cast(${el.aggregation_type}(\`${el.table_id}\`.\`${el.column_name}\`) as decimal(32,${el.minimumFractionDigits||0}) ) as \`${el.display_name}\``);
+              if(el.aggregation_type ==='avg'){
+                // If aggregation is AVG, set decimal places to 2
+                columns.push(`cast(${el.aggregation_type}(\`${el.table_id}\`.\`${el.column_name}\`) as decimal(32,${el.minimumFractionDigits||2}) ) as \`${el.display_name}\``);
+              }else{
+                columns.push(`cast(${el.aggregation_type}(\`${el.table_id}\`.\`${el.column_name}\`) as decimal(32,${el.minimumFractionDigits||0}) ) as \`${el.display_name}\``);
+              }
           }
         } else {
           if (el.column_type === 'numeric') {


### PR DESCRIPTION
solves #52 

# Descripción

Como se detalla en el issue #52, se ha identificado un problema en las agregaciones que calculan promedios (AVG) en la aplicación, donde estos se muestran sin decimales. El origen del problema se encuentra en la clase `MysqlBuilderService`, específicamente en el archivo `eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts`. Este comportamiento no solo afecta a MySQL, sino que también podría impactar a otras conexiones de bases de datos (lo que no se ha abordado en este PR). Actualmente, al construir la consulta, se utiliza 0 como valor por defecto para las posiciones decimales en las agregaciones, excepto en `count_distinct`. En este PR se introduce un cambio para establecer, por defecto, 2 decimales en las agregaciones de tipo `avg`, a menos que la variable `minimumFractionDigits` especifique un número diferente de decimales.

# Pruebas a Realizar

1. Preparar un informe que incluya una agregación de promedio (AVG) con decimales y comprobar que los decimales se muestran correctamente.
2. Transformar la misma agregación a una suma (con valores enteros) o a un conteo (count), y verificar que en estos casos, los valores se muestren como números enteros, sin decimales.
