### PR TITLE
Hotfix - API - Representación precisa de las medias de valores con decimales

### DIFF
--- a/eda/eda_api/lib/services/custom/custom.ts
+++ b/eda/eda_api/lib/services/custom/custom.ts
@@ -1,0 +1,15 @@
+
+
+
+  export function muSqlBuilderServiceCustomGetMinFractionDigits(target: Object, propertyKey: string, descriptor: any) {
+	descriptor.value = function (el: any) {
+        if (!el.hasOwnProperty('minimumFractionDigits')) {
+            el.minimumFractionDigits = 0;
+          }
+          /*SDA CUSTOM*/if(el.aggregation_type ==='avg'){
+          /*SDA CUSTOM*/  el.minimumFractionDigits = 2;
+          /*SDA CUSTOM*/}
+          return el;
+    }
+    return descriptor;
+}

--- a/eda/eda_api/lib/services/custom/custom.ts
+++ b/eda/eda_api/lib/services/custom/custom.ts
@@ -1,15 +1,26 @@
-
-
-
-  export function muSqlBuilderServiceCustomGetMinFractionDigits(target: Object, propertyKey: string, descriptor: any) {
-	descriptor.value = function (el: any) {
-        if (!el.hasOwnProperty('minimumFractionDigits')) {
-            el.minimumFractionDigits = 0;
-          }
-          /*SDA CUSTOM*/if(el.aggregation_type ==='avg'){
-          /*SDA CUSTOM*/  el.minimumFractionDigits = 2;
-          /*SDA CUSTOM*/}
-          return el;
+/**
+   * Modifica la propiedad `minimumFractionDigits` de un objeto basado en condiciones específicas.
+   * Se utiliza para forzar a dos decimales los calculos de promedio en SinergiaDA
+   * 
+   * @param {Object} target - El objeto al cual está adjunto el descriptor.
+   * @param {string} propertyKey - La clave de la propiedad a la que se está adjuntando el descriptor.
+   * @param {any} descriptor - El descriptor de propiedad para la función.
+   * @returns {any} El descriptor modificado.
+   * 
+   * La función intercepta el llamado a la propiedad y modifica el objeto `el`.
+   * Si `el` no tiene la propiedad `minimumFractionDigits`, se establece a 0.
+   * Si `el.aggregation_type` es 'avg', se establece `minimumFractionDigits` a 2.
+   */
+export function muSqlBuilderServiceCustomGetMinFractionDigits(target: Object, propertyKey: string, descriptor: any) {
+  descriptor.value = function(el: any) {
+    if (!el.hasOwnProperty("minimumFractionDigits")) {
+      el.minimumFractionDigits = 0;
     }
-    return descriptor;
+    /*SDA CUSTOM*/ if (el.aggregation_type === "avg") {
+    /*SDA CUSTOM*/ el.minimumFractionDigits = 2;
+    /*SDA CUSTOM*/
+    }
+    return el;
+  };
+  return descriptor;
 }

--- a/eda/eda_api/lib/services/custom/custom.ts
+++ b/eda/eda_api/lib/services/custom/custom.ts
@@ -1,6 +1,7 @@
 /**
    * Modifica la propiedad `minimumFractionDigits` de un objeto basado en condiciones específicas.
    * Se utiliza para forzar a dos decimales los calculos de promedio en SinergiaDA
+   * https://github.com/SinergiaTIC/SinergiaDA/pull/67
    * 
    * @param {Object} target - El objeto al cual está adjunto el descriptor.
    * @param {string} propertyKey - La clave de la propiedad a la que se está adjuntando el descriptor.

--- a/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
@@ -1,7 +1,6 @@
 import { QueryBuilderService } from './../query-builder.service';
 import * as _ from 'lodash';
 import { filter, values } from 'lodash';
-import { Column } from 'snowflake-sdk';
 
  /*SDA CUSTOM*/ import * as custom from '../../custom/custom';
 

--- a/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
@@ -1,7 +1,8 @@
 import { QueryBuilderService } from './../query-builder.service';
 import * as _ from 'lodash';
 import { filter, values } from 'lodash';
-
+import { Column } from 'snowflake-sdk';
+import * as custom from '../../custom/custom';
 
 
 export class MySqlBuilderService extends QueryBuilderService {
@@ -175,6 +176,14 @@ export class MySqlBuilderService extends QueryBuilderService {
 
   }
 
+  @custom.muSqlBuilderServiceCustomGetMinFractionDigits
+  public getMinFractionDigits(el:any): any{
+    if (!el.hasOwnProperty('minimumFractionDigits')) {
+      el.minimumFractionDigits = 0;
+    }
+    return el;
+  }
+  
   public getSeparedColumns(origin: string, dest: string[]): any {
 
     const columns = [];
@@ -183,9 +192,8 @@ export class MySqlBuilderService extends QueryBuilderService {
     this.queryTODO.fields.forEach(el => {
       el.order !== 0 && el.table_id !== origin && !dest.includes(el.table_id) ? dest.push(el.table_id) : false;
 
-      if (!el.hasOwnProperty('minimumFractionDigits')) {
-        el.minimumFractionDigits = 0;
-      }
+      el = this.getMinFractionDigits(el);
+
       // Aqui se manejan las columnas calculadas
       if (el.computed_column === 'computed') {
         if(el.column_type=='text'){

--- a/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
@@ -2,7 +2,8 @@ import { QueryBuilderService } from './../query-builder.service';
 import * as _ from 'lodash';
 import { filter, values } from 'lodash';
 import { Column } from 'snowflake-sdk';
-import * as custom from '../../custom/custom';
+
+ /*SDA CUSTOM*/ import * as custom from '../../custom/custom';
 
 
 export class MySqlBuilderService extends QueryBuilderService {
@@ -176,7 +177,7 @@ export class MySqlBuilderService extends QueryBuilderService {
 
   }
 
-  @custom.muSqlBuilderServiceCustomGetMinFractionDigits
+  /*SDA CUSTOM*/ @custom.muSqlBuilderServiceCustomGetMinFractionDigits
   public getMinFractionDigits(el:any): any{
     if (!el.hasOwnProperty('minimumFractionDigits')) {
       el.minimumFractionDigits = 0;

--- a/eda/eda_api/tsconfig.json
+++ b/eda/eda_api/tsconfig.json
@@ -9,6 +9,8 @@
       "outDir": "./dist",
       "baseUrl": "./lib",
       "resolveJsonModule":  true,
+      "emitDecoratorMetadata": true,
+      "experimentalDecorators": true,
       "typeRoots": ["lib/types", "node_modules/@types"]
   },
   "include": [


### PR DESCRIPTION
## Descripción del Cambio
Se fuerza que para mysql formatee los números a dos decimales en el caso de que se haga una media.


## Issue(s) resuelto(s)

- solves  https://github.com/SinergiaTIC/SinergiaDA/issues/52

## Pruebas a realizar para validar el cambio

Hacer una consulta con una media.

## Información Adicional

En el caso de que el número sea entero  (1 por ejemplo) el valor que se muestra es 1. Si hay decimales se muestran los decimales.

Adicionalmente ya se aplica el nuevo protocolo de desarrollo.