### PR TITLE
Hotfix - API - Error provocado por las cadenas vacías

### DIFF
--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -789,12 +789,8 @@ export class DashboardController {
               }
             } else {
               // trec els nulls i els canvio per ' ' dels labels al igual que les cadenes buides
-              if (numerics[ind] != 'true' && r[i] == null) {
-                if(r[i].length == 0){
+              if (numerics[ind] != 'true' && ( r[i] == null || r[i].length == 0 ) ) {
                   return ' ';
-                }else{
-                  return r[i];
-                }
               } else {
                 return r[i];
               }
@@ -962,9 +958,14 @@ export class DashboardController {
               const output = Object.keys(r).map(i => r[i])
               resultsRollback.push([...output])
               const tmpArray = []
+
               output.forEach((val, index) => {
+                if(val===null || val.length == 0){
+                  output[index] = ' ' // los valores nulos o cadenas vacías les canvio per un espai en blanc pero que si no tinc problemes
+                  resultsRollback[i][index] = ' ';// los valores nulos o cadenas vacías les canvio per un espai en blanc pero que si no tinc problemes
+                }
                 if (DashboardController.isNotNumeric(val)) {
-                  tmpArray.push('NaN')
+                  tmpArray.push('NaN');
                 } else {
                   tmpArray.push('int')
                   output[index] = parseFloat(val)
@@ -973,7 +974,13 @@ export class DashboardController {
               oracleDataTypes.push(tmpArray)
               results.push(output)
             } else {
-              const output = Object.keys(r).map(i => r[i])
+              const output = Object.keys(r).map(i => r[i]);
+              output.forEach((val, index) => {
+                if(val===null || val.length == 0){
+                  output[index] = ' ' // los valores nulos o cadenas vacías les canvio per un espai en blanc pero que si no tinc problemes
+                  resultsRollback[i][index] = ' ';// los valores nulos o cadenas vacías les canvio per un espai en blanc pero que si no tinc problemes
+                }
+              })
               results.push(output)
               resultsRollback.push(output)
             }
@@ -994,13 +1001,11 @@ export class DashboardController {
               }
             }
           }
-
           /** si tinc numeros barrejats. Poso el rollback */
           if (oracleEval !== true) {
             results = resultsRollback
           }
           const output = [labels, results]
-
           if (output[1].length < cache_config.MAX_STORED_ROWS && cacheEnabled) {
             CachedQueryService.storeQuery(req.body.model_id, query, output)
           }

--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -776,7 +776,7 @@ export class DashboardController {
                 }
               } else {
                 //això es per evitar els null trec els nulls i els canvio per ' ' dels labels al igual que les cadenes buides
-                if (r[i] == null == null) {
+                if (r[i] === null ) {
                     return ' ';
                 } else {
                   if(r[i].length == 0){
@@ -789,7 +789,7 @@ export class DashboardController {
               }
             } else {
               // trec els nulls i els canvio per ' ' dels labels al igual que les cadenes buides
-              if (numerics[ind] != 'true' && ( r[i] == null || r[i].length == 0 ) ) {
+              if (numerics[ind] != 'true' && ( r[i] == null || r[i]?.length == 0 ) ) {
                   return ' ';
               } else {
                 return r[i];

--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -775,17 +775,26 @@ export class DashboardController {
                   return res
                 }
               } else {
-                //això es per evitar els null trec els nulls i els canvio per '' dels lavels
+                //això es per evitar els null trec els nulls i els canvio per '-' dels lavels al igual que les cadenes buidaes
                 if (r[i] == null == null) {
-                  return ''
+                    return '-';
                 } else {
-                  return r[i]
+                  if(r[i].length == 0){
+                    return '-';
+                  }else{
+                    return r[i];
+                  }
+                 
                 }
               }
             } else {
-              // trec els nulls i els canvio per '' dels lavels
+              // trec els nulls i els canvio per '--' dels lavelsal igual que les cadenes buidaes
               if (numerics[ind] != 'true' && r[i] == null) {
-                return ''
+                if(r[i].length == 0){
+                  return '-';
+                }else{
+                  return r[i];
+                }
               } else {
                 return r[i];
               }
@@ -814,6 +823,8 @@ export class DashboardController {
           `Date: ${formatDate(new Date())} Dashboard:${req.body.dashboard.dashboard_id
           } Panel:${req.body.dashboard.panel_id} DONE\n`
         )
+
+        console.log(output);
 
         return res.status(200).json(output)
 

--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -775,7 +775,7 @@ export class DashboardController {
                   return res
                 }
               } else {
-                //això es per evitar els null trec els nulls i els canvio per '-' dels lavels al igual que les cadenes buidaes
+                //això es per evitar els null trec els nulls i els canvio per '-' dels labels al igual que les cadenes buides
                 if (r[i] == null == null) {
                     return '-';
                 } else {
@@ -788,7 +788,7 @@ export class DashboardController {
                 }
               }
             } else {
-              // trec els nulls i els canvio per '--' dels lavelsal igual que les cadenes buidaes
+              // trec els nulls i els canvio per '--' dels labels al igual que les cadenes buides
               if (numerics[ind] != 'true' && r[i] == null) {
                 if(r[i].length == 0){
                   return '-';
@@ -823,8 +823,6 @@ export class DashboardController {
           `Date: ${formatDate(new Date())} Dashboard:${req.body.dashboard.dashboard_id
           } Panel:${req.body.dashboard.panel_id} DONE\n`
         )
-
-        console.log(output);
 
         return res.status(200).json(output)
 

--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -775,12 +775,12 @@ export class DashboardController {
                   return res
                 }
               } else {
-                //això es per evitar els null trec els nulls i els canvio per '-' dels labels al igual que les cadenes buides
+                //això es per evitar els null trec els nulls i els canvio per ' ' dels labels al igual que les cadenes buides
                 if (r[i] == null == null) {
-                    return '-';
+                    return ' ';
                 } else {
                   if(r[i].length == 0){
-                    return '-';
+                    return ' ';
                   }else{
                     return r[i];
                   }
@@ -788,10 +788,10 @@ export class DashboardController {
                 }
               }
             } else {
-              // trec els nulls i els canvio per '--' dels labels al igual que les cadenes buides
+              // trec els nulls i els canvio per ' ' dels labels al igual que les cadenes buides
               if (numerics[ind] != 'true' && r[i] == null) {
                 if(r[i].length == 0){
-                  return '-';
+                  return ' ';
                 }else{
                   return r[i];
                 }

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
@@ -223,8 +223,10 @@ export class EdaTable {
             event ? this.colSubTotals(event.first / event.rows + 1) : this.colSubTotals(1);
 
         } 
-        if (this.noRepetitions || !this.noRepetitions) {
-            this.noRepeatedRows();
+
+        if ( !this.pivot) {
+            console.log('desactivadas las no repeticiones');
+            //this.noRepeatedRows();
         }
 
     }


### PR DESCRIPTION
## Descripción del Cambio
Cuando una consulta devuelve un campo vacío o nulo EDA devolvía una cadena vacía.  ''.  Como resultado de una actualización ahora esa cadena vacía provoca un error en los componentes de visualización. Por lo que se ha cambiado la cadena vacía '' por una cadena que contiene un espacio en blanco ' ' 


## Issue(s) resuelto(s)
<!-- Indicar el #<número> del/los issues resiueltos por este Pull Request -->
- solves  #101 
- solves #96 

- solves #58 


## Pruebas a realizar para validar el cambio
Realizar un test  para cada caso.
1. Tabla con datos con cadenas en blanco.
2. Graficos de barras normales
3. Graficos de barras apliladas.
