### PR TITLE
Hotfix  - APP - Sda#110 - Error en la suma de totales en tablas de referencia cruzada

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-table/eda-columns/eda-column-number.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-columns/eda-column-number.ts
@@ -1,7 +1,7 @@
 import { EdaColumn } from './eda-column';
 
 export class EdaColumnNumber extends EdaColumn {
-    decimals: number = 0;
+    decimals: number = 2; //numero de decimales con los que se inicializa la columna
     prefix: string = '';
     sufix: string = '';
 

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
@@ -315,7 +315,7 @@ export class EdaTable {
                     valuesKeys.forEach(valueKey => {
                       let keyArray = key.split('~');
                         if (keyArray.includes(valueKey)) {
-                            let decimalplaces =  0;  /** esto se hace  para ajustar el número de dicimales porque 3.1+2.5 puede dar 5.600004 */
+                            let decimalplaces = new EdaColumnNumber({}).decimals;  /** esto se hace  para ajustar el número de dicimales porque 3.1+2.5 puede dar 5.600004 */ 
                             try{
                                 if(  row[key].toString().split(".")[1].length > 0){
                                     decimalplaces =  row[key].toString().split(".")[1].length;
@@ -442,8 +442,6 @@ export class EdaTable {
         const values = this._value;
         const keys = this.cols.map(col => col.field);
 
-
-
         for (let i = 0; i < values.length; i++) {
             for (let j = 0; j < keys.length; j++) {
                 if (i < values.length) {
@@ -478,7 +476,7 @@ export class EdaTable {
                         border: '',
                         type: col.type
                     });
-            }
+            } 
             else {
                 if (firstNonNumericRow) {
                     this.totalsRow.push({ data: `${this.Totals} `, border: " ", class: 'total-row-header', type: col.type });


### PR DESCRIPTION
## Descripción del Cambio
El problema era derivado de los redondeos . Se han inicializado las columnas de totales a 2 decimales en vez de enteros como hasta ahora. 


## Issue(s) resuelto(s)
- solves  https://github.com/SinergiaTIC/SinergiaDA/issues/110

## Pruebas a realizar para validar el cambio
Realizar las pruebas que se detallan en el issue 110 


