### PR TITLE
Hotfix  - API - Potenciar las tablas incluidas en la consulta

### DIFF
--- a/eda/eda_api/lib/services/query-builder/query-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/query-builder.service.ts
@@ -1,6 +1,8 @@
 import { Console } from 'console';
+import { lstat } from 'fs';
 import * as _ from 'lodash';
 import { filter } from 'lodash';
+import { join } from 'path';
 
 class TreeNode {
     public value: string;
@@ -48,7 +50,7 @@ export abstract class QueryBuilderService {
 
     public builder() {
 
-        const graph = this.buildGraph();
+        let graph = this.buildGraph();
         /* Agafem els noms de les taules, origen i destí (és arbitrari), les columnes i el tipus d'agregació per construïr la consulta */
         let origin = this.queryTODO.fields.find(x => x.order === 0).table_id;
         let dest = [];
@@ -67,19 +69,7 @@ export abstract class QueryBuilderService {
         /** joins per els value list */
         const valueListJoins = [];
 
-
-        /** ............................................................................... */
-        /** ............................PER ELS VALUE LISTS................................ */
-        /** si es una consulta de llista de valors es retorna la llista de valors possibles */
-        /** ............................................................................... */
-        /*
-        if( this.queryTODO.fields.length == 1 && this.queryTODO.fields[0].valueListSource   && this.queryTODO.fields[0].column_type === 'text'   && this.permissions.length == 0&& this.queryTODO.filters.length == 0){
-            nO APLICA PORQUE NO APLICA LA SEGURDAD
-            this.query = this.valueListQuery( );
-            return this.query;
-        }
-*/
-        /** Reviso si cap columna de la  consulta es un multivalueliest..... */
+       /** Reviso si cap columna de la  consulta es un multivalueliest..... */
         this.queryTODO.fields.forEach( e=>{
                 if( e.valueListSource ){
                     valueListList.push( JSON.parse(JSON.stringify(e)) );
@@ -147,11 +137,19 @@ export abstract class QueryBuilderService {
         }
 
         
+
         /** SEPAREM ENTRE AGGREGATION COLUMNS/GROUPING COLUMNS */
         const separedCols = this.getSeparedColumns(origin, dest);
         const columns = separedCols[0];
         const grouping = separedCols[1];
 
+
+        // Las taules de les consultes van primer per potenciar relacions directes
+        const vals = [...dest];
+        const firs = [];
+        vals.forEach(v => firs.push(  graph.filter( e => v == e.name )[0])   );
+        firs.forEach(e => graph = graph.filter(f=> f.name != e.name)   );
+        graph  = [...firs, ...graph];
 
         /** ARBRE DELS JOINS A FER */
         let joinTree = this.dijkstraAlgorithm(graph, origin, dest.slice(0));
@@ -176,8 +174,16 @@ export abstract class QueryBuilderService {
                 dest = [...new_dest];
                 joinTree = new_joinTree;
             }
-
         }
+
+        /**poso les taules de la consulta al principi del joinTree per potenciar relacions directes */
+        const my_tables = [...dest ];
+        const firsts = [];
+        my_tables.forEach( e => firsts.push(  joinTree.filter( t => e == t.name )[0])  );
+        firsts.forEach(e =>   joinTree = joinTree.filter(f=> f.name != e.name)  );
+        joinTree  = [...firsts, ...joinTree];
+        
+
 
         //to WHERE CLAUSE
         const filters = this.queryTODO.filters.filter(f => {

--- a/eda/eda_api/lib/services/query-builder/query-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/query-builder.service.ts
@@ -1,8 +1,4 @@
-import { Console } from 'console';
-import { lstat } from 'fs';
 import * as _ from 'lodash';
-import { filter } from 'lodash';
-import { join } from 'path';
 
 class TreeNode {
     public value: string;


### PR DESCRIPTION

## Descripción del Cambio
Se altera el algoritmo de creación de caminos para poner primero los caminos de las tablas que salen en la consulta. De este modo, si una tabla está implicada en la consulta el camino que va por esa tabla se prioriza por delante de otros en la lista de tablas que componen los joins de la consulta.

## Issue(s) resuelto(s)
<!-- Indicar el #<número> del/los issues resiueltos por este Pull Request -->
- solves   https://github.com/SinergiaTIC/SinergiaDA/issues/45  y https://github.com/SinergiaTIC/SinergiaDA/issues/102 

## Pruebas a realizar para validar el cambio
Se realizan las consultas que se indican en los issues 45 y 102 y se comprueba que el resultado es el esperado. 

