### PR TITLE
Hotfix -  APP + API - Ocultar información de versión de la APP de EDA

### DIFF
--- a/eda/eda_api/lib/module/getSdaInfo/getSdaInfo.controller.ts
+++ b/eda/eda_api/lib/module/getSdaInfo/getSdaInfo.controller.ts
@@ -60,9 +60,10 @@ export class getSdaInfo {
         }
       });
 
-      // Retrieve EDA APP version from package.json.
-      const packageJsonPathAPP = path.join(__dirname, "../../../../eda_app/package.json");
-      info["edaAppVersion"] = JSON.parse(fs.readFileSync(packageJsonPathAPP, "utf8")).version;
+      //  It is necessary to put this information in an accessible place from the API
+      // // Retrieve EDA APP version from package.json.
+      // const packageJsonPathAPP = path.join(__dirname, "../../../../eda_app/package.json");
+      // info["edaAppVersion"] = JSON.parse(fs.readFileSync(packageJsonPathAPP, "utf8")).version;
 
       // Retrieve the last synchronization date with SinergiaCRM.
       let connection: any;

--- a/eda/eda_app/src/app/module/pages/about/about.component.html
+++ b/eda/eda_app/src/app/module/pages/about/about.component.html
@@ -25,14 +25,14 @@
                 {{ sinergiaDaVersion }}</span
               >
             </li>
-            <li
+            <!-- <li
               class="list-group-item d-flex justify-content-between align-items-center"
             >
               <span i18n="@@aboutPageEdaVersionAPP">Versión de EDA (APP)</span>
               <span class="badge badge-primary badge-dark">{{
                 edaAppVersion
               }}</span>
-            </li>
+            </li> -->
             <li
               class="list-group-item d-flex justify-content-between align-items-center"
             >


### PR DESCRIPTION
Se oculta la información de la APP de EDA en la página Acerca De, ya que no puede ser servida por la API, al estar el fichero de dónde se lee en la propia APP. Se decide ocultar por ahora dicha información hasta encontrar un método alternativo.