### PR TITLE
Hotfix  -  APP - Carga correcta de informes anteriores en modo EDA

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -215,8 +215,7 @@ export class EdaBlankPanelComponent implements OnInit {
             try{
                 const contentQuery = this.panel.content.query;
 
-               const modeSQL = contentQuery.query.modeSQL; // Comptabilitzar dashboard antics sense queryMode informat
-
+                const modeSQL = contentQuery.query.modeSQL; // Comptabilitzar dashboard antics sense queryMode informat
                 let queryMode = contentQuery.query.queryMode;
 
                 if (!queryMode) {
@@ -439,8 +438,9 @@ export class EdaBlankPanelComponent implements OnInit {
 
     public buildGlobalconfiguration(panelContent: any) {
         const modeSQL = panelContent.query.query.modeSQL;
-        const queryMode = panelContent.query.query.queryMode;
+        const queryMode = this.selectedQueryMode;
         this.showHiddenColumn = true;
+
         if ((queryMode && queryMode != 'SQL') || modeSQL === false) {
 
             try {
@@ -458,6 +458,7 @@ export class EdaBlankPanelComponent implements OnInit {
                 } else {
                     PanelInteractionUtils.handleCurrentQuery(this);
                 }
+                
                 this.columns = this.columns.filter((c) => !c.isdeleted);
             } catch(e) {
                 console.error('Error loading columns to define query in blank panel compoment........ Do you have deleted any column?????');


### PR DESCRIPTION
## Descripción del Cambio
Cuando se carga un informe antiguo. No hay la configuración del queryMode. Por eso fallaba al recuperarlo.  Esa configuración se establece en otro punto anterior.

## Issue(s) resuelto(s)
- solves  https://github.com/SinergiaTIC/SinergiaDA/issues/166

## Pruebas a realizar para validar el cambio
Cargar un informe anterior al modo Arbol.


