### PR TITLE
Hotfix  - API + APP - Filtra por campo de auto-relación

### DIFF
--- a/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
@@ -98,6 +98,7 @@ export class MySqlBuilderService extends QueryBuilderService {
         const column = this.findColumn(f.filter_table, f.filter_column);
         column.autorelation = f.autorelation;
         column.joins = f.joins;
+        column.valueListSource = f.valueListSource;
         const colname = this.getFilterColname(column);
         if (f.filter_type === 'not_null' || f.filter_type === 'not_null_nor_empty' || f.filter_type === 'null_or_empty') {
           filtersString += '\nand ' + this.filterToString(f);
@@ -421,6 +422,7 @@ export class MySqlBuilderService extends QueryBuilderService {
 
       column.autorelation = filterObject.autorelation;
       column.joins = filterObject.joins || [];
+      column.valueListSource = filterObject.valueListSource;
       const colname=this.getFilterColname(column);
       
       switch (this.setFilterType(filterObject.filter_type)) {

--- a/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
@@ -24,6 +24,7 @@ export class MySqlBuilderService extends QueryBuilderService {
     // JOINS
     let joinString: any[];
     let alias: any;
+    // joined == EDA2
     if (this.queryTODO.joined) {
       /**tree */
       const responseJoins = this.setJoins(joinTree, joinType, schema, valueListJoins);
@@ -95,6 +96,8 @@ export class MySqlBuilderService extends QueryBuilderService {
 
       filters.forEach(f => {
         const column = this.findColumn(f.filter_table, f.filter_column);
+        column.autorelation = f.autorelation;
+        column.joins = f.joins;
         const colname = this.getFilterColname(column);
         if (f.filter_type === 'not_null' || f.filter_type === 'not_null_nor_empty' || f.filter_type === 'null_or_empty') {
           filtersString += '\nand ' + this.filterToString(f);
@@ -182,7 +185,6 @@ export class MySqlBuilderService extends QueryBuilderService {
 
   
   public setJoins(joinTree: any[], joinType: string, schema: string, valueListJoins: string[]) {
-
     // Inicialización de variables
     const joinExists = new Set();
     const aliasTables = {};
@@ -249,7 +251,7 @@ export class MySqlBuilderService extends QueryBuilderService {
             }
         }
     }
-
+    
     return {
         joinString,
         aliasTables
@@ -273,7 +275,9 @@ export class MySqlBuilderService extends QueryBuilderService {
       el.order !== 0 && el.table_id !== origin && !dest.includes(el.table_id) ? dest.push(el.table_id) : false;
 
       let table_column;
-      if (el.autorelation && !el.valueListSource) {
+
+      if (el.autorelation && !el.valueListSource && !this.queryTODO.forSelector ) {
+
         table_column = `\`${el.joins[el.joins.length-1][0]}\`.\`${el.column_name}\``;
       } else {
         table_column = `\`${el.table_id}\`.\`${el.column_name}\``;
@@ -410,9 +414,13 @@ export class MySqlBuilderService extends QueryBuilderService {
     public filterToString(filterObject: any): any {
       const column = this.findColumn(filterObject.filter_table, filterObject.filter_column);
       const colType = filterObject.filter_column_type;
+
       if (!column.hasOwnProperty('minimumFractionDigits')) {
         column.minimumFractionDigits = 0;
       }
+
+      column.autorelation = filterObject.autorelation;
+      column.joins = filterObject.joins || [];
       const colname=this.getFilterColname(column);
       
       switch (this.setFilterType(filterObject.filter_type)) {
@@ -451,7 +459,13 @@ export class MySqlBuilderService extends QueryBuilderService {
   public getFilterColname(column: any){
     let colname:String ;
     if( column.computed_column == 'no'  || ! column.hasOwnProperty('computed_column') ){
-      colname =   `\`${column.table_id}\`.\`${column.column_name}\`` ;
+
+      if (column.autorelation && !column.valueListSource) {
+        colname = `\`${column.joins[column.joins.length-1][0]}\`.\`${column.column_name}\``;
+      } else {
+        colname = `\`${column.table_id}\`.\`${column.column_name}\`` ;
+      }
+      
     }else{
       if(column.column_type == 'numeric'){
         colname = `CAST( ${column.SQLexpression} as decimal(32,${column.minimumFractionDigits}))`;
@@ -475,8 +489,9 @@ export class MySqlBuilderService extends QueryBuilderService {
       let filtersString = `\nhaving 1=1 `;
 
       filters.forEach(f => {
-
         const column = this.findHavingColumn(f.filter_table, f.filter_column);
+        column.autorelation = f.autorelation;
+        column.joins = f.joins;
         const colname = this.getHavingColname(column);
         if (f.filter_type === 'not_null') {
           filtersString += `\nand ${colname}  is not null `;
@@ -517,8 +532,14 @@ export class MySqlBuilderService extends QueryBuilderService {
    */
 public getHavingColname(column: any){
   let colname:String  ;
-  if( column.computed_column === 'no'  || ! column.hasOwnProperty('computed_column')   ){
-    colname =  `cast(${column.aggregation_type}(\`${column.table_id}\`.\`${column.column_name}\`) as decimal(32,${column.minimumFractionDigits||0}) ) ` ;
+  if( column.computed_column === 'no'  || !column.hasOwnProperty('computed_column') ){
+    let table_id = column.table_id;
+
+    if (column.autorelation && !column.valueListSource) {
+        table_id = column.joins[column.joins.length-1][0];
+    }
+
+    colname = `cast(${column.aggregation_type}(\`${table_id}\`.\`${column.column_name}\`) as decimal(32,${column.minimumFractionDigits||0}) ) ` ;
   }else{
     if(column.column_type == 'numeric'){
       colname = `CAST( ${column.SQLexpression} as decimal(32,${column.minimumFractionDigits}))`;
@@ -536,6 +557,8 @@ public getHavingColname(column: any){
    */
  public havingToString(filterObject: any) {
     const column = this.findHavingColumn(filterObject.filter_table, filterObject.filter_column);
+    column.autorelation = filterObject.autorelation;
+    column.joins = filterObject.joins;
 
     if (!column.hasOwnProperty('minimumFractionDigits')) {
       column.minimumFractionDigits = 0;

--- a/eda/eda_api/lib/services/query-builder/query-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/query-builder.service.ts
@@ -629,7 +629,7 @@ export abstract class QueryBuilderService {
     }
 
     public findHavingColumn(table: string, column: string) {
-        return this.queryTODO.fields.find((f: any)=> f.table_id === table.split('.')[0] && f.column_name === column);
+        return this.queryTODO.fields.find((f: any)=> f.table_id === table && f.column_name === column);
     }
 
     public setFilterType(filter: string) {

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
@@ -123,6 +123,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         const selectedRange = this.filter.range;
         const valueListSource = this.selectedColumn.valueListSource;
         const joins = this.selectedColumn.joins;
+        const autorelation = this.selectedColumn.autorelation;
 
         const filter = this.columnUtils.setFilter({
             obj: this.filterValue,
@@ -132,6 +133,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             type,
             selectedRange,
             valueListSource,
+            autorelation,
             joins
         });
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.ts
@@ -72,13 +72,14 @@ export class FilterDialogComponent extends EdaDialogAbstract {
     }
 
     addFilter() {
-        const table =  this.selectedColumn.table_id;
+        const table = this.selectedColumn.table_id;
         const column_type  = this.selectedColumn.column_type;
         const column = this.selectedColumn.column_name;
         const type = this.filterSelected.value;
         const selectedRange = this.filter.range;
         const valueListSource = this.selectedColumn.valueListSource;
         const joins = this.selectedColumn.joins;
+        const autorelation = this.selectedColumn.autorelation;
 
         const filter = this.columnUtils.setFilter({
             obj: this.filterValue,
@@ -88,6 +89,7 @@ export class FilterDialogComponent extends EdaDialogAbstract {
             type,
             selectedRange,
             valueListSource,
+            autorelation,
             joins
         });
         

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
@@ -187,6 +187,7 @@ export const PanelInteractionUtils = {
             type: 'child',
             label: childLabel,
             child_id: child_id.trim(),
+            autorelation: relation.autorelation,
             joins
           };
 

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
@@ -315,7 +315,7 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
         const table_id = node.table_id || node.child_id;
         const pathList = this.globalFilter.pathList;
 
-        if (this.globalFilter.selectedTable.table_name !== table_id.split('.')[0]) {
+        if (node.autorelation || this.globalFilter.selectedTable.table_name !== table_id.split('.')[0]) {
             this.alertService.addWarning($localize`:@@invalidPathForm: Ruta incorrecta para el filtro seleccionado`);
             setTimeout(() => {
                 pathList[panel.id].table_id = null;

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
@@ -311,6 +311,7 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
 
     public onNodeSelect(panel: any, event: any): void {
         const node = event?.node;
+
         const table_id = node.table_id || node.child_id;
         const pathList = this.globalFilter.pathList;
 
@@ -324,6 +325,8 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
             pathList[panel.id].table_id = table_id;
             pathList[panel.id].path = node.joins || [];
 
+            this.globalFilter.autorelation = node.autorelation; 
+            
             if (!this.globalFilter.panelList.includes(panel.id)) {
                 this.globalFilter.panelList.push(panel.id);
             }

--- a/eda/eda_app/src/app/services/api/global-filters.service.ts
+++ b/eda/eda_app/src/app/services/api/global-filters.service.ts
@@ -257,6 +257,7 @@ export class GlobalFiltersService {
                         child_id: child_id.trim(),
                         type: 'child',
                         label: childLabel,
+                        autorelation: relation.autorelation,
                         joins
                     };
 
@@ -328,6 +329,7 @@ export class GlobalFiltersService {
             pathList: pathList,
             isGlobal: true,
             applyToAll: globalFilter.applyToAll,
+            autorelation: globalFilter.autorelation,
             valueListSource: globalFilter.selectedColumn.valueListSource
         }
 

--- a/eda/eda_app/src/app/services/utils/column-utils.service.ts
+++ b/eda/eda_app/src/app/services/utils/column-utils.service.ts
@@ -10,6 +10,7 @@ interface FilterOptions {
     type: string;
     selectedRange: string;
     valueListSource?: {};
+    autorelation?: boolean;
     joins?: any[];
 }
 @Injectable()
@@ -59,7 +60,7 @@ export class ColumnUtilsService {
     }
     
     public setFilter(options: FilterOptions): object {
-        const { obj, table, column, column_type, type, selectedRange, valueListSource, joins } = options;
+        const { obj, table, column, column_type, type, selectedRange, valueListSource, joins, autorelation } = options;
     
         const values = Object.keys(obj).map((key) => {
             if (!_.isNil(obj[key])) {
@@ -76,6 +77,7 @@ export class ColumnUtilsService {
             filter_type: type,
             filter_elements: values,
             selectedRange: selectedRange,
+            autorelation, 
             joins
         };
     


### PR DESCRIPTION
## Descripción del Cambio
Se añade un identificador en las auto-relaciones porque se deben tratar de forma individualizada. No se puede propagar el arbol más alla de ellas y cuando se filtra tampoco. El camino se debe detener en ellas. Tabién es necesario para identificar a donde se hace referencia en el filtro.

## Issue(s) resuelto(s)
- solves  incidencia detectada por Jortilles

## Pruebas a realizar para validar el cambio
Realizar un informe y un panel e intentar filtrar por un campo de una auto-relación.
