### PR TITLE
Hotfix - APP  - recarga de paneles en modo arbol.

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -455,11 +455,14 @@ export class EdaBlankPanelComponent implements OnInit {
                     PanelInteractionUtils.handleCurrentQuery2(this);
                     this.reloadTablesData();
                     PanelInteractionUtils.loadTableNodes(this);
+                    this.userSelectedTable = undefined;
+                    this.columns = [];
                 } else {
                     PanelInteractionUtils.handleCurrentQuery(this);
+                    this.columns = this.columns.filter((c) => !c.isdeleted);
                 }
                 
-                this.columns = this.columns.filter((c) => !c.isdeleted);
+                
             } catch(e) {
                 console.error('Error loading columns to define query in blank panel compoment........ Do you have deleted any column?????');
                 console.error(e);

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
@@ -118,6 +118,7 @@ export const PanelInteractionUtils = {
           assertTable.table_name = column.table_id;
           assertTable.display_name.default = displayName;
           assertTable.description.default = displayName;
+          assertTable.autorelation = relation.autorelation;
           ebp.assertedTables.push(assertTable);
           ebp.tables.push(assertTable);
         }

--- a/eda/eda_app/src/app/services/api/global-filters.service.ts
+++ b/eda/eda_app/src/app/services/api/global-filters.service.ts
@@ -101,6 +101,7 @@ export class GlobalFiltersService {
                 if (assertTablesNames.includes(idRelation)) {
                     const assertTable = _.cloneDeep(modelTables.find((t: any) => t.table_name == relation.target_table));
                     assertTable.table_name = idRelation;
+                    assertTable.autorelation = relation.autorelation;
                     assertTable.display_name.default = relation.display_name.default;
                     assertTable.description.default = relation.display_name.default;
                     modelTables.push(assertTable);


### PR DESCRIPTION
## Descripción del Cambio
Cuando se guarda un informe elaborado en modo árbol y se vuelve a cargar. No se deben cargar los campos de la última tabla visitada. Porque, en el modo arbol, se debe establecer la ruta hasta la tabla. 
Por eso, cuando se carga un informe de nuevo, se borran los campos de la última tabla visitada  para que se vuelva a establecer la ruta con la navegación del usuario si quiere añadir un nuevo campo.  
Por otro lado. Se debe mantener si es una autorelación.

## Issue(s) resuelto(s)
- solves  issue identificado durante la reunión.

## Pruebas a realizar para validar el cambio
Realizar un informe en modo árbol. guardarlo y recargar. Volver a poner cualquier campo. antes de esta modificación fallará. con esta modificación se hará bien
