### PR TITLE
Hotfix - APP - Filtros deshabilitados para propio usuario

### DIFF
--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -390,6 +390,7 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
                     this.setEditMode();
                     // Check dashboard owner
                     this.checkVisibility(res.dashboard);
+                    me.setDashboardCreator(res.dashboard);
                     me.title = config.title; // Titul del dashboard, utilitzat per visualització
                     me.gFilter.initGlobalFilters(config.filters||[]); // Filtres del dashboard
                     me.dataSource = res.datasource; // DataSource del dashboard
@@ -412,7 +413,6 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
                     // i es crida també des de els subscribe del groupcontroller ... a mes a mes des de la inicilialització del dashboard
                     // per estar segurn que es tenen disponibles.
                     let grp = [];
-                    me.setDashboardCreator(res.dashboard);
                     if (config.visible === 'group' && res.dashboard.group) {
                         grp = res.dashboard.group;
                     }

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
@@ -43,6 +43,7 @@ export class GlobalFilterComponent implements OnInit {
 
     public initGlobalFilters(filters: any[]): void {
         this.globalFilters = _.cloneDeep(filters);
+        this.isDashboardCreator = this.dashboard.isDashboardCreator;
         this.setFiltersVisibility();
         this.setFilterButtonVisibilty();
     }
@@ -57,10 +58,13 @@ export class GlobalFilterComponent implements OnInit {
 
     // métode per descobrir o amagar el botó de filtrar al dashboard
     private setFilterButtonVisibilty(): void {
-        this.globalFilters = this.globalFilters.filter((f: any) => {
-            return (f.visible != "hidden" && f.visible == "readOnly") ||
-                (f.visible != "hidden" && f.visible == "public")
-        });
+        if(!this.isDashboardCreator  || !this.isAdmin){
+            this.globalFilters = this.globalFilters.filter((f: any) => {
+                return (f.visible != "hidden" && f.visible == "readOnly") ||
+                    (f.visible != "hidden" && f.visible == "public")
+            });
+        }
+
 
         this.globalFilters.forEach(a => {
             if (a.visible == "public") {


### PR DESCRIPTION

## Descripción del Cambio
Se cambia el orden en el que se comprueba si el informe lo ha hecho el propio usuario porque se establecía primero la visibildad y despues se comprobaba si el informe era propio. ahora se hace en el orden correcto.
Un filtro oculto. Es editable para el propio usuario.

## Issue(s) resuelto(s)

- solves  https://github.com/SinergiaTIC/SinergiaDA/issues/163

## Pruebas a realizar para validar el cambio
Hacer un informe. Establecer un filtro como oculto y comprobar que el propio usuario lo sigue viendo. Pero un usuario tercero no.

