### PR TITLE
Hotfix - API -  No se aplican permisos si no hay registros para el grupo/módulo en la tabla sda_def_securitygroups_records

### DIFF
--- a/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
+++ b/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
@@ -16,7 +16,8 @@ export class CleanModel {
             "column": "",
             "global": "",
             "permission": "",
-            "type": ""
+            "type": "",
+            "value":[]
         }
 
         let modelAc = {
@@ -27,7 +28,8 @@ export class CleanModel {
             "column": "",
             "global": "",
             "permission": "",
-            "type": ""
+            "type": "",
+            "value":[]
         }
 
         let groupModel =  {
@@ -38,7 +40,8 @@ export class CleanModel {
             "column": "",
             "global": "",
             "permission": "",
-            "type": ""
+            "type": "",
+            "value":[]
         }
         
         let model_granted_roles = [] ;
@@ -51,7 +54,17 @@ export class CleanModel {
             
             } else {
                 
-                const match = model_granted_roles.find(r => r.table == roles[i].table && r.column == roles[i].column && r.type == roles[i].type )
+                let match = model_granted_roles.find(r => r.table == roles[i].table && r.column == roles[i].column && r.type == roles[i].type   );
+                if( _.isEmpty(match) == false ){
+                    if(roles[i].value && match.value ){
+                        roles[i].value.forEach((e,i)=> {
+                            if( e != match.value[i]){
+                                match =  false;
+                            }
+                        });
+                    }
+                }
+
                 
                 if (_.isEmpty(match) == false && roles[i].type == "users") {
                     if (!match.users.includes(roles[i].users[0])) {match.users.push(roles[i].users[0]) } ;
@@ -74,7 +87,6 @@ export class CleanModel {
                         if (_.isEmpty(model.table) == false) {model_granted_roles.push(model)} ;
                     }
                 }
-
                 }
             }
 

--- a/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
+++ b/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
@@ -118,10 +118,10 @@ export class updateModel {
                                                             await connection.query(' select user_name as name, `table` from sda_def_permissions ')
                                                                 .then(async permi => {
                                                                     let permissions = permi
-                                                                    //select distinct `table`, 'id' as 'column',  `group` from sda_def_security_group_records where 
-                                                                    await connection.query("select distinct `table`, 'id' as 'column',  `group` from sda_def_security_group_records ")
+                                                                    //select distinct `table`, 'id' as 'column',  `group` from sda_def_security_group_records
+                                                                    await connection.query(" select distinct `table`, 'id' as `column`,  `group` from sda_def_permissions  where `group` != ''  ")
                                                                         .then(async permiCol => {
-                                                                            let permissionsColumns = permiCol
+                                                                            let permissionsColumns = permiCol;
                                                                             /**Ahora que ya tengo todos los datos, monto el modelo */
                                                                             // montamos el modelo
                                                                             console.log('Recuperando usuarios');


### PR DESCRIPTION

## Descripción del Cambio
Se cambia la consulta para obtener los permisos a nivel de registro y se reformula el algoritmo para identificar valores únicos a la hora de simplificar el modelo.

## Issue(s) resuelto(s)
- solves  https://github.com/SinergiaTIC/SinergiaDA/issues/131

## Pruebas a realizar para validar el cambio
Actualizar el modelo de datos com update model y comprobar que todos los registros de seguridad están correctamente aplicados en el modelo de datos.

## Información Adicional
Este PR resuelve este issue. Este Issue es una condicion previa al pr https://github.com/SinergiaTIC/SinergiaDA/pull/177 que lo deberá incluir 
