### PR TITLE
Hotfix - APP - Se duplican tablas en el modo árbol - SDA#180

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
@@ -744,6 +744,8 @@ export const PanelInteractionUtils = {
     if (ebp.currentQuery.length === 0 && ebp.filtredColumns.length === 0) {
       ebp.rootTable = undefined;
       ebp.tablesToShow = ebp.inject.dataSource.model.tables.filter( t => t.visible == true);
+      ebp.tablesToShow.sort((a, b) => (a.display_name.default > b.display_name.default) ? 1 : ((b.display_name.default > a.display_name.default) ? -1 : 0));
+
     } else {
       _.map(ebp.currentQuery, selected => selected.table_id === c.table_id);
     }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
@@ -75,14 +75,17 @@ export const PanelInteractionUtils = {
       const rootTable = idTables.find((idTable: string) => ebp.rootTable?.table_name == idTable);
       
       if (rootTable) {
-        const dataSource = ebp.inject.dataSource.model.tables;
-  
+
+        // Tablas visibles para el usuario. Visibles una vez aplicada la seguridad
+        const visibleTables = ebp.inject.dataSource.model.tables.filter( t => t.visible == true);
+        const visibleTableNames = visibleTables.map( t=> t.table_name );
         ebp.tableNodes = [];
-    
-        const table = dataSource.find((source) => source.table_name == rootTable);
+        const table = visibleTables.find((source) => source.table_name == rootTable);
         
         if (table) {
-          let isexpandible = table.relations.length > 0;
+          table.relations = table.relations.filter(  r=> visibleTableNames.includes( r.target_table ) );
+
+           const isexpandible = table.relations.length > 0;
     
           let node: any = {
             label: table.display_name.default,
@@ -740,8 +743,7 @@ export const PanelInteractionUtils = {
     // Buscar relacións per tornar a mostrar totes les taules
     if (ebp.currentQuery.length === 0 && ebp.filtredColumns.length === 0) {
       ebp.rootTable = undefined;
-      ebp.tablesToShow = ebp.tables;
-
+      ebp.tablesToShow = ebp.inject.dataSource.model.tables.filter( t => t.visible == true);
     } else {
       _.map(ebp.currentQuery, selected => selected.table_id === c.table_id);
     }


### PR DESCRIPTION
## Descripción del Cambio
Cuando se aplica la seguridad. Es necesario filtrar el modelo de datos para las tablas visibles. y quitar las auto-relaciones cuando se regenera el listado de tablas

## Issue(s) resuelto(s)
- solves  #180 

## Pruebas a realizar para validar el cambio
Hacer un informe con un usuario no administrador. Generar una consulta con auto-relaciones y borrarla. Cuando se vuelve a mostrar el listado de tablas. Ahora es correcto.


