### PR TITLE
Hotfix  - API - - Filtrado incompleto en queries para usuarios en múltiples grupos de seguridad

### DIFF
--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -699,18 +699,20 @@ export class DashboardController {
         }
       }
     }
-    /** puedo ver la tabla porque puedo ver datos de una columna */
+    
+    // Check if the user has permission to view the table based on column visibility
     if (dataModelObject.ds.metadata.model_granted_roles !== undefined) {
-      for (var i = 0; i < dataModelObject.ds.metadata.model_granted_roles.length; i++ ) {
-        if ( /** puedo ver valores de una columna de la tabla */
+      for (var i = 0; i < dataModelObject.ds.metadata.model_granted_roles.length; i++) {
+        // Verify if the user has access to at least one column in the table
+        if (
           dataModelObject.ds.metadata.model_granted_roles[i].global === false &&
           dataModelObject.ds.metadata.model_granted_roles[i].none === false &&
           dataModelObject.ds.metadata.model_granted_roles[i].value.length > 0
         ) {
-          if (dataModelObject.ds.metadata.model_granted_roles[i].groups !== undefined ) {
-            for (var j = 0; j < dataModelObject.ds.metadata.model_granted_roles[i].groups.length; j++ ) {
-              if (  userGroups.includes( dataModelObject.ds.metadata.model_granted_roles[i].groups[j] )  ) {
-                allowedTablesBySecurityForMe.push(  dataModelObject.ds.metadata.model_granted_roles[i].table );
+          if (dataModelObject.ds.metadata.model_granted_roles[i].groups !== undefined) {
+            for (var j = 0; j < dataModelObject.ds.metadata.model_granted_roles[i].groups.length; j++) {
+              if (userGroups.includes(dataModelObject.ds.metadata.model_granted_roles[i].groups[j])) {
+                allowedTablesBySecurityForMe.push(dataModelObject.ds.metadata.model_granted_roles[i].table);
               }  
             }
           }
@@ -718,8 +720,6 @@ export class DashboardController {
       }
     }
 
-    //console.log('Tablas PERMITIDAS PARA el usuario por el GRUPO ');
-    //console.log(allowedTablesBySecurityForMe);
     forbiddenTables = allTables.filter( t => !allowedTablesBySecurityForMe.includes( t )  );
     return forbiddenTables;
   }

--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -699,7 +699,26 @@ export class DashboardController {
         }
       }
     }
-    //console.log('Tablas PERMITIDAS PARA el usuario por el');
+    /** puedo ver la tabla porque puedo ver datos de una columna */
+    if (dataModelObject.ds.metadata.model_granted_roles !== undefined) {
+      for (var i = 0; i < dataModelObject.ds.metadata.model_granted_roles.length; i++ ) {
+        if ( /** puedo ver valores de una columna de la tabla */
+          dataModelObject.ds.metadata.model_granted_roles[i].global === false &&
+          dataModelObject.ds.metadata.model_granted_roles[i].none === false &&
+          dataModelObject.ds.metadata.model_granted_roles[i].value.length > 0
+        ) {
+          if (dataModelObject.ds.metadata.model_granted_roles[i].groups !== undefined ) {
+            for (var j = 0; j < dataModelObject.ds.metadata.model_granted_roles[i].groups.length; j++ ) {
+              if (  userGroups.includes( dataModelObject.ds.metadata.model_granted_roles[i].groups[j] )  ) {
+                allowedTablesBySecurityForMe.push(  dataModelObject.ds.metadata.model_granted_roles[i].table );
+              }  
+            }
+          }
+        }
+      }
+    }
+
+    //console.log('Tablas PERMITIDAS PARA el usuario por el GRUPO ');
     //console.log(allowedTablesBySecurityForMe);
     forbiddenTables = allTables.filter( t => !allowedTablesBySecurityForMe.includes( t )  );
     return forbiddenTables;

--- a/eda/eda_api/lib/services/custom/custom.ts
+++ b/eda/eda_api/lib/services/custom/custom.ts
@@ -78,6 +78,7 @@ export function queryBuilderServiceCustomGetTreePermissions(target: Object, prop
                  filter_table: permission.table,
                  filter_column: permission.column,
                  filter_type: 'in',
+                 isGlobal: 'security',
                  filter_dynamic: permission.dynamic?permission.dynamic:false,
                  filter_elements: [{ value1: permission.value }]
              };

--- a/eda/eda_api/lib/services/query-builder/query-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/query-builder.service.ts
@@ -546,6 +546,7 @@ export abstract class QueryBuilderService {
                         filter_column: permission.column,
                         filter_dynamic: permission.dynamic?permission.dynamic:false,
                         filter_type: 'in',
+                        isGlobal: 'security',
                         filter_elements: [{ value1: permission.value }]
                     };
 
@@ -597,6 +598,7 @@ export abstract class QueryBuilderService {
                         filter_table: permission.table,
                         filter_column: permission.column,
                         filter_type: 'in',
+                        isGlobal: 'security',
                         filter_dynamic: permission.dynamic?permission.dynamic:false,
                         filter_elements: [{ value1: permission.value }]
                     };
@@ -991,6 +993,12 @@ export abstract class QueryBuilderService {
     }
 
     public getEqualFilters = (filters) => {
+        /**
+         * LOS FILTROS TIENEN DIFERENTES NIVELES GLOBAL = A NIVEL DE DASHBOARD - LOCAL = A NIVEL DE PANEL - SEGURIDAD = QUE VIENEN DE LA SEGURIDAD
+         * LOS FILTORS SE CONCATENAN CON UN AND NORMALMENTE. PERO SI PONGO FILTROS SOBRE LA MISMA COLUMNA AL MISMO NIVEL (ISGLOBAL) SE CONCATENAN
+         * CON UN OR. QUE ES EL FUNCIONAMIENTO ESPERADO.
+         * 
+          */
         let filterMap = new Map();
         let toRemove = [];
         filters.forEach(filter => {

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
@@ -57,10 +57,13 @@ export class GlobalFilterComponent implements OnInit {
 
     // métode per descobrir o amagar el botó de filtrar al dashboard
     private setFilterButtonVisibilty(): void {
-        this.globalFilters = this.globalFilters.filter((f: any) => {
-            return (f.visible != "hidden" && f.visible == "readOnly") ||
-                (f.visible != "hidden" && f.visible == "public")
-        });
+        setTimeout(() => {
+            this.globalFilters = this.globalFilters.filter((f: any) => {
+                return (f.visible != "hidden" && f.visible == "readOnly") ||
+                    (f.visible != "hidden" && f.visible == "public")
+            });
+         }, 1);
+
 
         this.globalFilters.forEach(a => {
             if (a.visible == "public") {


### PR DESCRIPTION
## Descripción del Cambio
Investigando esta funcionalidad se ha detectado una carencia en el filtrado de los gurupos de seguridad. Por eso hay dos commmits. No se estaba aplicando bien la vibilidad de las tablas a nivel de grupo.
Por otro lado se han hecho cambios cosméticos para que la lógica sea más entendible.
A modo de resumen. Los filtros se aplican por niveles. A nivel de seguridad, a nivel de informe y a nivel de panel.


## Issue(s) resuelto(s)
- solves #132 

## Pruebas a realizar para validar el cambio
Hacer un informe con un usuario con múltiples grupos de seguridad y comprobar que los aplica todos con un OR. adicionalmente si se aplican grupos de seguridad a nivel de informe o de panel se aplican con un AND


