### PR TITLE
Hotfix - API -  Permisos de usuario no se contemplaban bien

### DIFF
--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -1254,8 +1254,8 @@ export class DashboardController {
 
 
     if (dataModel.ds.metadata.model_granted_roles.length > 0) {
-      const users = []
-      const roles = []
+      const users = [];
+      const roles = [];
       let anyOne = 'false'
 
       //Get users with permission
@@ -1267,14 +1267,14 @@ export class DashboardController {
             }
             break
           case 'users':
-            permission.users.forEach(user => {
-              if (!users.includes(user)) users.push(user)
+            permission.users.forEach(u => {
+              if ( !users.includes(u.toString()) )  users.push(u.toString());
             })
             break
           case 'groups':
             user.role.forEach(role => {
               if (permission.groups.includes(role)) {
-                if (!roles.includes(role)) roles.push(role)
+                if (!roles.includes(role.toString())) roles.push(role.toString())
               }
             })
         }


### PR DESCRIPTION
## Descripción del Cambio
Cuando se comprueban los usuarios que tienen permiso para ver el modelo. La comparación no se estaba resolviendo bien. Se fuerza a que los permisos se comparen a nivel de cadena

## Issue(s) resuelto(s)
- solves  comunicado en un meet.
- 

## Pruebas a realizar para validar el cambio
Hacer un informe para un usuario con permisos asignados a nivel de usuario ( por ejemlo u3 en nuestras pruebas) y comprobar que si que puede hacer consultas.
