### PR TITLE
Hotfix - APP - no actualizar contraseña si no procede

### DIFF
--- a/eda/eda_api/lib/module/admin/users/user.controller.ts
+++ b/eda/eda_api/lib/module/admin/users/user.controller.ts
@@ -294,7 +294,7 @@ export class UserController {
 
                     user.role = groups;
 
-                    user.password = 'password_protected';
+                    user.password = ':)';
                     return res.status(200).json({ ok: true, user });
                 });
             });


### PR DESCRIPTION

## Descripción del Cambio
Cuando se recupera un usuario se le pone el pass :) y luego en el user-detail.component,  al salvarlo,  si es este carácter no se actualiza. (107).
Había una descoordinación. Porque aqui se ponía "proteted-password" y allí se controlaba ":)"


## Issue(s) resuelto(s)

- solves #207 

## Pruebas a realizar para validar el cambio
Actualizar un usuario y comprobar que no se cambia el password


