### PR TITLE
Incidencia - APP - Eliminar la opción de "Nuevo informe" del sidebar cuando el usuario sea un observador.

### DIFF
--- a/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.ts
+++ b/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.ts
@@ -141,6 +141,7 @@ export class HomeSdaComponent implements OnInit {
   public ngOnInit() {
     this.init();
     this.ifAnonymousGetOut();
+    this.setIsObserver();
     this.currentUser = JSON.parse(sessionStorage.getItem("user"));
   }
 
@@ -165,6 +166,7 @@ export class HomeSdaComponent implements OnInit {
         this.grups = res;
         this.isObserver =
           this.grups.filter(group => group.name === "EDA_RO" && group.users.includes(userID)).length !== 0;
+          this.sidebarService.setIsObserver(this.isObserver);
       },
       err => this.alertService.addError(err)
     );

--- a/eda/eda_app/src/app/services/shared/sidebar.service.ts
+++ b/eda/eda_app/src/app/services/shared/sidebar.service.ts
@@ -53,10 +53,10 @@ export class SidebarService extends ApiService {
     getToggleSideNav(): Observable<boolean> {
         return this.hideSideNavSubj.asObservable();
     }
-    private isObserverSubject = new BehaviorSubject<boolean>(false);
-    isObserver$ = this.isObserverSubject.asObservable();
+    /* SDA CUSTOM*/ private isObserverSubject = new BehaviorSubject<boolean>(false);
+    /* SDA CUSTOM*/ isObserver$ = this.isObserverSubject.asObservable();
   
-    setIsObserver(value: boolean) {
-      this.isObserverSubject.next(value);
-    }
+    /* SDA CUSTOM*/ setIsObserver(value: boolean) {
+    /* SDA CUSTOM*/    this.isObserverSubject.next(value);
+    /* SDA CUSTOM*/ }
 }

--- a/eda/eda_app/src/app/services/shared/sidebar.service.ts
+++ b/eda/eda_app/src/app/services/shared/sidebar.service.ts
@@ -53,5 +53,10 @@ export class SidebarService extends ApiService {
     getToggleSideNav(): Observable<boolean> {
         return this.hideSideNavSubj.asObservable();
     }
-
+    private isObserverSubject = new BehaviorSubject<boolean>(false);
+    isObserver$ = this.isObserverSubject.asObservable();
+  
+    setIsObserver(value: boolean) {
+      this.isObserverSubject.next(value);
+    }
 }

--- a/eda/eda_app/src/app/shared/components/sidebar/sidebar.component.html
+++ b/eda/eda_app/src/app/shared/components/sidebar/sidebar.component.html
@@ -86,12 +86,12 @@
                             </a>
                         </li>
                         <li>
-                            <div *ngIf="!isObserver">
-                                <a  class="waves-effect waves-dark" (click)="createDashboard = true;">
-                                    <i class="mdi mdi-view-dashboard"></i>
-                                    <span i18n="@@tituloNuevoInforme"> Nuevo informe</span>
-                                </a>
-                            </div>
+<!--SDA CUSTOM-->       <div *ngIf="!isObserver">
+<!--SDA CUSTOM-->            <a  class="waves-effect waves-dark" (click)="createDashboard = true;">
+<!--SDA CUSTOM-->                <i class="mdi mdi-view-dashboard"></i>
+<!--SDA CUSTOM-->                <span i18n="@@tituloNuevoInforme"> Nuevo informe</span>
+<!--SDA CUSTOM-->            </a>
+<!--SDA CUSTOM-->       </div>
                         </li>
                     </ul>
                 </li>

--- a/eda/eda_app/src/app/shared/components/sidebar/sidebar.component.html
+++ b/eda/eda_app/src/app/shared/components/sidebar/sidebar.component.html
@@ -86,10 +86,12 @@
                             </a>
                         </li>
                         <li>
-                            <a  class="waves-effect waves-dark" (click)="createDashboard = true;">
-                                <i class="mdi mdi-view-dashboard"></i>
-                                <span i18n="@@tituloNuevoInforme"> Nuevo informe</span>
-                            </a>
+                            <div *ngIf="!isObserver">
+                                <a  class="waves-effect waves-dark" (click)="createDashboard = true;">
+                                    <i class="mdi mdi-view-dashboard"></i>
+                                    <span i18n="@@tituloNuevoInforme"> Nuevo informe</span>
+                                </a>
+                            </div>
                         </li>
                     </ul>
                 </li>

--- a/eda/eda_app/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/eda/eda_app/src/app/shared/components/sidebar/sidebar.component.ts
@@ -23,7 +23,7 @@ export class SidebarComponent implements OnInit {
     public logoSidebar: string;
     public homeLink = '/home'
     public createDashboard: boolean = false;
-    public isObserver: boolean = false;
+    /* SDA CUSTOM*/ public isObserver: boolean = false;
 
     constructor(
         public router: Router,
@@ -54,9 +54,9 @@ export class SidebarComponent implements OnInit {
             data => this.dataSourceMenu = data,
             err => this.alertService.addError(err)
         );
-        this.sidebarService.isObserver$.subscribe(value => {
-            this.isObserver = value;
-          });
+        /* SDA CUSTOM*/ this.sidebarService.isObserver$.subscribe(value => {
+        /* SDA CUSTOM*/     this.isObserver = value;
+        /* SDA CUSTOM*/  });
 
         
     }

--- a/eda/eda_app/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/eda/eda_app/src/app/shared/components/sidebar/sidebar.component.ts
@@ -23,6 +23,7 @@ export class SidebarComponent implements OnInit {
     public logoSidebar: string;
     public homeLink = '/home'
     public createDashboard: boolean = false;
+    public isObserver: boolean = false;
 
     constructor(
         public router: Router,
@@ -53,7 +54,9 @@ export class SidebarComponent implements OnInit {
             data => this.dataSourceMenu = data,
             err => this.alertService.addError(err)
         );
-        
+        this.sidebarService.isObserver$.subscribe(value => {
+            this.isObserver = value;
+          });
 
         
     }


### PR DESCRIPTION
## Descripción del Cambio
Se ha modificado el servicio del sidebar y los componentes del sidebar y home-sda para que ahora el botón "Nuevo Informe" tenga en cuenta si el usuario es "isObserver". Esta propiedad ya se tenía en cuenta en el home para ocultar el botón de creación, y se ha extendido al sidebar para mantener la coherencia.

## Pruebas a realizar para validar el cambio

1. Ingresar con un usuario del grupo EDA_RO y verificar que no aparece la opción "Nuevo Informe" en el sidebar.
2. Ingresar con un usuario administrador y verificar que sí aparece la opción "Nuevo Informe".