### PR TITLE
Hotfix - API+APP  - Mantener los permisos de usuario asignados sobre tablas de SinergiaDA

### DIFF
--- a/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
+++ b/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
@@ -145,7 +145,8 @@ export class CleanModel {
             // Recuperando los permisos provenientes de SinergiaDA 
             // la propiedad source --> "EDA" indica que el permiso proviene de la applicacion y no de la base de datos
             const userRoles = mgsmap[0].filter( (r:any) => {
-                return r?.source === 'SDA' 
+                console.log(r);
+                return r?.source === 'SDA'   && ! r.groupsName[0].toString().startsWith("SDA_")
             });
 
             // Agregando los permisos agregados previamente en la aplicacion. 

--- a/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
+++ b/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
@@ -138,26 +138,21 @@ export class CleanModel {
             model_granted_roles = objetosUnicosGrupos.concat(objetosUnicosUsuarios);
 
             model_granted_roles.forEach( r=> {
-
                 r.source = 'update_model';
-                //console.log(r);
             }
             );
 
-            const userRoles = mgsmap.filter( r=> { console.log(r.hasOwnProperty('source'));
-               return r.hasOwnProperty('source') == false }   );
+            // Recuperando los permisos provenientes de SinergiaDA 
+            // la propiedad source --> "EDA" indica que el permiso proviene de la applicacion y no de la base de datos
+            const userRoles = mgsmap[0].filter( (r:any) => {
+                return r?.source === 'EDA' 
+            });
 
+            // Agregando los permisos agregados previamente en la aplicacion. 
+            const all_roles =   [ ...model_granted_roles, ...userRoles];   
+            main_model.ds.metadata.model_granted_roles = all_roles;
 
-            //console.log(userRoles);
-            //Ronald. Aqui añadimos una etiqueta que nos diga que viene del update model.
-            //"source": "update_model"
-
-            //const all_roles =   [ ...model_granted_roles, ...userRoles];   
-            //main_model.ds.metadata.model_granted_roles = all_roles;
             return main_model;
-
         }
-        
-        
     }
 

--- a/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
+++ b/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
@@ -145,7 +145,7 @@ export class CleanModel {
             // Recuperando los permisos provenientes de SinergiaDA 
             // la propiedad source --> "EDA" indica que el permiso proviene de la applicacion y no de la base de datos
             const userRoles = mgsmap[0].filter( (r:any) => {
-                return r?.source === 'EDA' 
+                return r?.source === 'SDA' 
             });
 
             // Agregando los permisos agregados previamente en la aplicacion. 

--- a/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
+++ b/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
@@ -145,7 +145,6 @@ export class CleanModel {
             // Recuperando los permisos provenientes de SinergiaDA 
             // la propiedad source --> "EDA" indica que el permiso proviene de la applicacion y no de la base de datos
             const userRoles = mgsmap[0].filter( (r:any) => {
-                console.log(r);
                 return r?.source === 'SDA' && !r.groupsName.find( e => e.startsWith('SDA_'))
             });
 

--- a/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
+++ b/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
@@ -137,7 +137,23 @@ export class CleanModel {
             
             model_granted_roles = objetosUnicosGrupos.concat(objetosUnicosUsuarios);
 
-            main_model.ds.metadata.model_granted_roles = model_granted_roles;
+            model_granted_roles.forEach( r=> {
+
+                r.source = 'update_model';
+                //console.log(r);
+            }
+            );
+
+            const userRoles = mgsmap.filter( r=> { console.log(r.hasOwnProperty('source'));
+               return r.hasOwnProperty('source') == false }   );
+
+
+            //console.log(userRoles);
+            //Ronald. Aqui añadimos una etiqueta que nos diga que viene del update model.
+            //"source": "update_model"
+
+            //const all_roles =   [ ...model_granted_roles, ...userRoles];   
+            //main_model.ds.metadata.model_granted_roles = all_roles;
             return main_model;
 
         }

--- a/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
+++ b/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
@@ -146,7 +146,7 @@ export class CleanModel {
             // la propiedad source --> "EDA" indica que el permiso proviene de la applicacion y no de la base de datos
             const userRoles = mgsmap[0].filter( (r:any) => {
                 console.log(r);
-                return r?.source === 'SDA'   && ! r.groupsName[0].toString().startsWith("SDA_")
+                return r?.source === 'SDA' && !r.groupsName.find( e => e.startsWith('SDA_'))
             });
 
             // Agregando los permisos agregados previamente en la aplicacion. 

--- a/eda/eda_app/src/app/module/pages/data-sources/data-source-detail/column-permissions-dialog/column-permission-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/data-sources/data-source-detail/column-permissions-dialog/column-permission-dialog.component.ts
@@ -109,7 +109,7 @@ export class ColumnPermissionDialogComponent extends EdaDialogAbstract {
                 global : this.all ? true : false,
                 dynamic : this.dynamic, 
                 type : 'users',
-                /*SDA Custom */ source: 'EDA'
+                /*SDA Custom */ source: 'SDA'
             };
         }
         else if(this.type === 'groups'){
@@ -123,7 +123,7 @@ export class ColumnPermissionDialogComponent extends EdaDialogAbstract {
                 global : this.all ? true : false,
                 dynamic : this.dynamic, 
                 type : 'groups',
-                /*SDA Custom */ source: 'EDA'
+                /*SDA Custom */ source: 'SDA'
             };
         }
         this.onClose(EdaDialogCloseEvent.NEW, permissionFilter);

--- a/eda/eda_app/src/app/module/pages/data-sources/data-source-detail/column-permissions-dialog/column-permission-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/data-sources/data-source-detail/column-permissions-dialog/column-permission-dialog.component.ts
@@ -108,7 +108,8 @@ export class ColumnPermissionDialogComponent extends EdaDialogAbstract {
                 column : this.column.column_name,
                 global : this.all ? true : false,
                 dynamic : this.dynamic, 
-                type : 'users'
+                type : 'users',
+                /*SDA Custom */ source: 'EDA'
             };
         }
         else if(this.type === 'groups'){
@@ -121,7 +122,8 @@ export class ColumnPermissionDialogComponent extends EdaDialogAbstract {
                 column : this.column.column_name,
                 global : this.all ? true : false,
                 dynamic : this.dynamic, 
-                type : 'groups'
+                type : 'groups',
+                /*SDA Custom */ source: 'EDA'
             };
         }
         this.onClose(EdaDialogCloseEvent.NEW, permissionFilter);

--- a/eda/eda_app/src/app/module/pages/data-sources/data-source-detail/model-permissions-dialog/model-permission-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/data-sources/data-source-detail/model-permissions-dialog/model-permission-dialog.component.ts
@@ -114,7 +114,7 @@ export class ModelPermissionDialogComponent extends EdaDialogAbstract {
                     global : true,
                     permission : this.permission,
                     type : 'groups',
-                    source: 'EDA'
+                    /*SDA Custom */ source: 'EDA'
                 };
             }
         }

--- a/eda/eda_app/src/app/module/pages/data-sources/data-source-detail/model-permissions-dialog/model-permission-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/data-sources/data-source-detail/model-permissions-dialog/model-permission-dialog.component.ts
@@ -86,7 +86,8 @@ export class ModelPermissionDialogComponent extends EdaDialogAbstract {
                 column : "fullModel",
                 global : true,
                 permission : this.anyoneCanSee ? true : false,
-                type : 'anyoneCanSee'
+                type : 'anyoneCanSee',
+                /*SDA Custom */  source: 'EDA'
             };
         }else{
 
@@ -99,7 +100,8 @@ export class ModelPermissionDialogComponent extends EdaDialogAbstract {
                     column : "fullModel",
                     global : true,
                     permission : this.permission ? true : false,
-                    type : 'users'
+                    type : 'users',
+                   /*SDA Custom */ source: 'EDA'
                 };
             }
             else if(this.type === 'groups'){
@@ -111,7 +113,8 @@ export class ModelPermissionDialogComponent extends EdaDialogAbstract {
                     column : "fullModel",
                     global : true,
                     permission : this.permission,
-                    type : 'groups'
+                    type : 'groups',
+                    source: 'EDA'
                 };
             }
         }

--- a/eda/eda_app/src/app/module/pages/data-sources/data-source-detail/model-permissions-dialog/model-permission-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/data-sources/data-source-detail/model-permissions-dialog/model-permission-dialog.component.ts
@@ -87,7 +87,7 @@ export class ModelPermissionDialogComponent extends EdaDialogAbstract {
                 global : true,
                 permission : this.anyoneCanSee ? true : false,
                 type : 'anyoneCanSee',
-                /*SDA Custom */  source: 'EDA'
+                /*SDA Custom */  source: 'SDA'
             };
         }else{
 
@@ -101,7 +101,7 @@ export class ModelPermissionDialogComponent extends EdaDialogAbstract {
                     global : true,
                     permission : this.permission ? true : false,
                     type : 'users',
-                   /*SDA Custom */ source: 'EDA'
+                   /*SDA Custom */ source: 'SDA'
                 };
             }
             else if(this.type === 'groups'){
@@ -114,7 +114,7 @@ export class ModelPermissionDialogComponent extends EdaDialogAbstract {
                     global : true,
                     permission : this.permission,
                     type : 'groups',
-                    /*SDA Custom */ source: 'EDA'
+                    /*SDA Custom */ source: 'SDA'
                 };
             }
         }

--- a/eda/eda_app/src/app/module/pages/data-sources/data-source-detail/table-permissions-dialog/table-permission-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/data-sources/data-source-detail/table-permissions-dialog/table-permission-dialog.component.ts
@@ -87,7 +87,8 @@ export class TablePermissionDialogComponent extends EdaDialogAbstract {
                 column : "fullTable",
                 global : true,
                 permission : this.permission ? true : false,
-                type : 'users'
+                type : 'users',
+              /*SDA Custom */      source: 'EDA'
             };
         }
         else if(this.type === 'groups'){
@@ -99,7 +100,8 @@ export class TablePermissionDialogComponent extends EdaDialogAbstract {
                 column : "fullTable",
                 global : true,
                 permission : this.permission,
-                type : 'groups'
+                type : 'groups',
+            /*SDA Custom */ source: 'EDA'
             };
         }
         this.onClose(EdaDialogCloseEvent.NEW, permissionFilter);

--- a/eda/eda_app/src/app/module/pages/data-sources/data-source-detail/table-permissions-dialog/table-permission-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/data-sources/data-source-detail/table-permissions-dialog/table-permission-dialog.component.ts
@@ -88,7 +88,7 @@ export class TablePermissionDialogComponent extends EdaDialogAbstract {
                 global : true,
                 permission : this.permission ? true : false,
                 type : 'users',
-              /*SDA Custom */      source: 'EDA'
+              /*SDA Custom */      source: 'SDA'
             };
         }
         else if(this.type === 'groups'){
@@ -101,7 +101,7 @@ export class TablePermissionDialogComponent extends EdaDialogAbstract {
                 global : true,
                 permission : this.permission,
                 type : 'groups',
-            /*SDA Custom */ source: 'EDA'
+            /*SDA Custom */ source: 'SDA'
             };
         }
         this.onClose(EdaDialogCloseEvent.NEW, permissionFilter);


### PR DESCRIPTION


## Descripción del Cambio
Cuando se crea un permiso desde el fornt-end se le añade una etiqueta source: 'SDA' que nos permite identificar que permisos vienen del front-end

## Issue(s) resuelto(s)
<!-- Indicar el #<número> del/los issues resiueltos por este Pull Request -->
- solves #208

## Pruebas a realizar para validar el cambio
Añadir permisos desde el front-end de SDA, ejecutar el update-model y comprobar que siguen ahi.

