### PR TITLE
Mejora -  API - Cambiar el prefijo SDA_ por SCRM_

### DIFF
--- a/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
+++ b/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
@@ -145,7 +145,7 @@ export class CleanModel {
             // Recuperando los permisos provenientes de SinergiaDA 
             // la propiedad source --> "EDA" indica que el permiso proviene de la applicacion y no de la base de datos
             const userRoles = mgsmap[0].filter( (r:any) => {
-                return r?.source === 'SDA' && !r.groupsName.find( e => e.startsWith('SDA_'))
+                return r?.source === 'SDA' && !r.groupsName.find( e => e.startsWith('SCRM_'))
             });
 
             // Agregando los permisos agregados previamente en la aplicacion. 

--- a/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
+++ b/eda/eda_api/lib/module/updateModel/service/cleanModel.ts
@@ -91,7 +91,7 @@ export class CleanModel {
             }
 
 
-            //recuperamos los model_granted_roles de mongo, donde se han añadido permisos para SDA_*
+            //recuperamos los model_granted_roles de mongo, donde se han añadido permisos para SCRM_*
             const finder = await DataSourceSchema.find({_id: "111111111111111111111111" }) ; 
             let mgs = [];
             const mgsmap = _.cloneDeep(finder.map(e => mgs = e.ds.metadata.model_granted_roles));


### PR DESCRIPTION
Se cambia el prefijo de los grupos prodecentes de SinergiaCRM de `SDA_ ` a `SCRM_` para facilitar la comprensión del funcionamineto y evitar confusiones.

**Como probarlo:**
- Por inspección de código. Todas las aparciciones de `SDA_` deben quedar sustituidas




**NOTA:**
Además del código es necesario ejecutar la siguiente query  en las insatancias para renombrar los grupos ya existentes,  manteniendo las asignaciones de informes, usuarios, etc.
Además aprovechando, se elimina el grupo obsoleto `NO_SINERGIACRM_USERS`

```javascript
db.groups.bulkWrite([
  // 1. Eliminar el grupo con name='NO_SINERGIACRM_USERS'
  {
    deleteOne: {
      filter: { name: "NO_SINERGIACRM_USERS" }
    }
  },
  // 2. Renombrar grupos que comienzan con "SDA_" a "SCRM_"
  {
    updateMany: {
      filter: { name: { $regex: "^SDA_" } },
      update: [
        {
          $set: {
            name: {
              $concat: [
                "SCRM_",
                { $substr: ["$name", 4, { $strLenCP: "$name" }] }
              ]
            }
          }
        }
      ]
    }
  }
])
```
