### PR TITLE
Hotfix  - API  - Administrador pierde acceso a paneles después de que un usuario no administrador guarde el informe

### DIFF
--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -274,6 +274,7 @@ export class DashboardController {
               return next(new HttpException(400, 'Datasouce not found with id'))
             }
             let toJson = JSON.parse(JSON.stringify(datasource))
+            let filteredData = false // allow to determine if we are filtering data to the dashboard to avoid overwrite it by a dummy user.
 
             // Filtre de seguretat per les taules. Si no es te permis sobre una taula es posa com a oculta.
             // Per si de cas es fa servir a una relació.
@@ -335,7 +336,8 @@ export class DashboardController {
                             dashboard.config.panel[i].content.query.query.fields[
                             c
                             ]
-                          )
+                          );
+                          filteredData = true;
                         } else {
                           MyFields.push(
                             dashboard.config.panel[i].content.query.query.fields[
@@ -359,11 +361,11 @@ export class DashboardController {
 
             }
 
-
             const ds = {
               _id: datasource._id,
               model: toJson.ds.model,
-              name: toJson.ds.metadata.model_name
+              name: toJson.ds.metadata.model_name,
+              filtered: filteredData 
             }
 
             insertServerLog(

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
@@ -138,7 +138,7 @@
 
 
     <hr>
-    <div *ngIf="display_v.edit_mode && canIedit()" class="right-sidebar-blocks-options block-options-bg pointer mt-1" (click)="saveDashboard()">
+    <div *ngIf="display_v.edit_mode && canIedit()" class="right-sidebar-blocks-options block-options-bg pointer mt-1" (click)="filtered ? userNotAllowed() : saveDashboard()">
         <div>
             <i id="saveDashboard" class="fa fa-save"></i>
             <span i18n="@@opcionGuardar" class="ml-2">GUARDAR</span>

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -1295,6 +1295,6 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
     /*SDA CUSTOM*/}
 
     userNotAllowed() {
-        this.alertService.addError('Usuario no permitido');
+        this.alertService.addError($localize`:@@userNotAllowed:El usuario no tiene permisos para guardar en el informe`);
     }
 }

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -380,7 +380,7 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
             err => me.alertService.addError(err)
         );
 
-        // Check url for filters in params
+        // Check url for filters in params 
         this.getUrlParams();
 
         if (me.id) {

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -110,6 +110,8 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
     public canIeditTooltip = $localize`:@@canIeditTooltip:Si esta opción está seleccionada sólo el propietario del informe y los administradores podrán guardar los cambios`;
     //public globalFilter: any;
 
+    public filtered = Boolean;
+
     constructor(
         private router: Router,
         private route: ActivatedRoute,
@@ -384,6 +386,9 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
         if (me.id) {
             me.dashboardService.getDashboard(me.id).subscribe(
                 res => {
+                    // Filtering if the user is an Admin or a dummy user
+                    this.filtered = res.datasource.filtered;
+
                     /** res - retorna 2 objectes, el dashboard i el datasource per separat  */
                     const config = res.dashboard.config;
                     // Estableix els permisos d'edició i propietat...
@@ -1288,4 +1293,8 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
     /*SDA CUSTOM*/    ? this.visibleTypes
     /*SDA CUSTOM*/    : this.visibleTypes.filter(type => type.value !== 'shared');
     /*SDA CUSTOM*/}
+
+    userNotAllowed() {
+        this.alertService.addError('Usuario no permitido');
+    }
 }

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4315,6 +4315,10 @@
         <source>El año pasado, completo</source>
         <target>L'any passat, complet</target>
       </trans-unit>
+      <trans-unit id="userNotAllowed">
+        <source>El usuario no tiene permisos para guardar en el informe.</source>
+        <target>L'usuari no té permisos per desar a l'informe.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4289,6 +4289,10 @@
         <source>El año pasado, completo</source>
         <target>Last year, complete</target>
       </trans-unit>
+      <trans-unit id="userNotAllowed">
+        <source>El usuario no tiene permisos para guardar en el informe.</source>
+        <target>The user does not have permissions to save the report.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4318,6 +4318,10 @@
         <source>El año pasado, completo</source>
         <target>El año pasado, completo</target>
       </trans-unit>
+      <trans-unit id="userNotAllowed">
+        <source>El usuario no tiene permisos para guardar en el informe.</source>
+        <target>El usuario no tiene permisos para guardar en el informe.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -4319,6 +4319,10 @@
         <source>El año pasado, completo</source>
         <target>El año pasado, completo</target>
       </trans-unit>
+      <trans-unit id="userNotAllowed">
+        <source>El usuario no tiene permisos para guardar en el informe.</source>
+        <target>O usuario non ten permisos para gardar no informe.</target>
+      </trans-unit>    
     </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.pl.xlf
+++ b/eda/eda_app/src/locale/messages.pl.xlf
@@ -3945,6 +3945,10 @@ Login<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/>
   <source>El año pasado, completo</source>
   <target>W zeszłym roku, kompletne</target>
 </trans-unit>
+<trans-unit id="userNotAllowed">
+  <source>El usuario no tiene permisos para guardar en el informe.</source>
+  <target>Użytkownik nie ma uprawnień do zapisu w raporcie.</target>
+</trans-unit>  
 </body>
 </file>
 </xliff>


### PR DESCRIPTION
## Descripción del Cambio
Se implementa una lógica por la que. Si un usuario no puede ver alguno de los paneles no pueda guardar el informe. Esto se hace para evitar que guarde y se pierda la configuración del informe.

## Issue(s) resuelto(s)
- solves #204 

## Pruebas a realizar para validar el cambio
1. Crear un informe con uno o varios paneles.
2. Acceder con un usuario que no tenga permisos para ver alguno de los paneles.
3. Intentar guardar. No debería dejarte y debería salir una advertencia de que no puedes.
