### PR TITLE
Incidencia - APP - Almacenar número de columnas en opciones del gráfico

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/charts-config-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/charts-config-utils.ts
@@ -75,8 +75,9 @@ export const ChartsConfigUtils = {
           addTrend: ebp.panelChart.props.config && ebp.panelChart.props.config.getConfig() ? ebp.panelChart.props.config.getConfig()['addTrend'] : false,
           addComparative: ebp.panelChart.props.config && ebp.panelChart.props.config.getConfig() ? ebp.panelChart.props.config.getConfig()['addComparative'] : false,
           showLabels: ebp.panelChart.props.config && ebp.panelChart.props.config.getConfig() ? ebp.panelChart.props.config.getConfig()['showLabels'] : false,
-          showLabelsPercent: ebp.panelChart.props.config && ebp.panelChart.props.config.getConfig() ? ebp.panelChart.props.config.getConfig()['showLabelsPercent'] : false
-      };
+          showLabelsPercent: ebp.panelChart.props.config && ebp.panelChart.props.config.getConfig() ? ebp.panelChart.props.config.getConfig()['showLabelsPercent'] : false,
+          numberOfColumns: ebp.panelChart.props.config && ebp.panelChart.props.config.getConfig() ? ebp.panelChart.props.config.getConfig()['numberOfColumns'] : null
+        };
   }
     return new ChartConfig(config);
 


### PR DESCRIPTION

## Descripción del Cambio

Cuando en un gráfico de tipo histograma seleccionas el número de columnas en las opciones del gráfico, al guardar y volver a cargar el informe, la información se pierde, ya que no se estaba guardando en la base de datos el valor del número de columnas.

## Pruebas a realizar para validar el cambio

1. Crear un panel con visualización de tipo histograma.
2. En la opción de edición del gráfico, modificar el número de columnas y confirmar.
3. Guardar el informe.
4. Recargar el informe y verificar que se mantiene el número de columnas seleccionado.

