### PR TITLE
Mejora  -  API  - Preventivo añadidos espacios al final  de lineas SQL

### DIFF
--- a/eda/eda_api/lib/services/query-builder/query-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/query-builder.service.ts
@@ -708,7 +708,10 @@ export abstract class QueryBuilderService {
         const schema = this.dataModel.ds.connection.schema;
         const modelPermissions = this.dataModel.ds.metadata.model_granted_roles;
         let query = userQuery.SQLexpression;
-
+        
+        // añado un espacio en blanco al final de cada linea para asegurar que no se juntan palabras
+        let reg = new RegExp(`\n`, "g");
+        query = query.replace(reg, ` `);
 
         if (modelPermissions.length > 0) {
 


### PR DESCRIPTION
## Descripción del Cambio
A raiz del issue   #199  se ha detectado que en ocasiones, cuando en una consulta SQL hay un salto de linea. Se junta la última palabra de la primera linea con la primera palabra de la siguiente. 
Se añade un espacio en blanco al final de cada linea para evitar que esto ocurra


## Issue(s) resuelto(s)
- solves   #199

## Pruebas a realizar para validar el cambio
Hacer una consulta SQL con un inner join. antes de generaba una consulta inconsistente y ahora ya no.
