### PR TITLE
Hotfix -  Incidencia - EDA - No se elimina filtro de informe

### DIFF
--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
@@ -102,7 +102,10 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
             const columnName = this.globalFilter.selectedColumn.column_name;
             // Recupero el display name que le haya podido poner.
             const display_name_alias = this.globalFilter.selectedColumn.display_name.default;
+
             this.globalFilter.selectedColumn = _.cloneDeep(this.globalFilter.selectedTable.columns.find((col: any) => col.column_name == columnName));
+
+
             this.getColumnsByTable();
             this.loadColumnValues();
             this.findPanelPathTables();
@@ -153,16 +156,30 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
     }
 
     public initTablesForFilter() {
-        const queryTables = [];
-        const excludedTables = this.modelTables.filter((t: any) => t.visible === false).map((t: any) => t.table_name);
+                
+        const queryTables = []; // si aparece
+        const excludedTables = this.modelTables.filter((t: any) => t.visible === false).map((t: any) => t.table_name); // Si aparece
 
-        for (const panel of this.filteredPanels) {
-            //tables const tmpPanel = this.params.panels.find(p => p.id === panel.id);
-            const panelQuery = panel.content.query.query;
-
-            for (const field of panelQuery.fields) {
-                const table_id = field.table_id.split('.')[0];
-                if (!queryTables.includes(table_id)) queryTables.push(table_id);
+        // La lista filteredPanels está vacia debido a que todos los paneles estan desactivados. 
+        if(this.filteredPanels.length===0){
+            for (const panel of this.allPanels) {
+                //tables const tmpPanel = this.params.panels.find(p => p.id === panel.id);
+                const panelQuery = panel.content.query.query;
+    
+                for (const field of panelQuery.fields) {
+                    const table_id = field.table_id.split('.')[0];
+                    if (!queryTables.includes(table_id)) queryTables.push(table_id);
+                }
+            }
+        } else {
+            for (const panel of this.filteredPanels) {
+                //tables const tmpPanel = this.params.panels.find(p => p.id === panel.id);
+                const panelQuery = panel.content.query.query;
+    
+                for (const field of panelQuery.fields) {
+                    const table_id = field.table_id.split('.')[0];
+                    if (!queryTables.includes(table_id)) queryTables.push(table_id);
+                }
             }
         }
 
@@ -178,6 +195,7 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
     }
 
     public onAddPanelForFilter(panel: any) {
+
         if (panel.avaliable) {
             if(panel.content.query.query.queryMode != 'SQL') { // los paneles SQL no se pueden activar
                 panel.active = !panel.active;
@@ -188,7 +206,7 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
                 this.initTablesForFilter();
                 this.findPanelPathTables();
             } 
-            // else this.clearFilterPaths(panel);
+            else this.clearFilterPaths(panel);
         }
 
         if (!panel.avaliable) {

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
@@ -187,9 +187,8 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
             if (panel.active) {
                 this.initTablesForFilter();
                 this.findPanelPathTables();
-            } else {
-                this.clearFilterPaths(panel);
-            }
+            } 
+            // else this.clearFilterPaths(panel);
         }
 
         if (!panel.avaliable) {

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
@@ -160,10 +160,9 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
         const queryTables = []; // si aparece
         const excludedTables = this.modelTables.filter((t: any) => t.visible === false).map((t: any) => t.table_name); // Si aparece
 
-        // La lista filteredPanels está vacia debido a que todos los paneles estan desactivados. 
+       // filteredPanels list is empty because all panels are disabled. 
         if(this.filteredPanels.length===0){
             for (const panel of this.allPanels) {
-                //tables const tmpPanel = this.params.panels.find(p => p.id === panel.id);
                 const panelQuery = panel.content.query.query;
     
                 for (const field of panelQuery.fields) {
@@ -173,7 +172,6 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
             }
         } else {
             for (const panel of this.filteredPanels) {
-                //tables const tmpPanel = this.params.panels.find(p => p.id === panel.id);
                 const panelQuery = panel.content.query.query;
     
                 for (const field of panelQuery.fields) {


### PR DESCRIPTION

## Descripción del Cambio
Cuando se  abre el dialogo del filtro  se comprueba si está vinculado a algún panel o no y así no se produce el error.

- solves #186 

## Pruebas a realizar para validar el cambio
Reproducir los pasos del issue y comprobar que funciona correctamente. 

1. Crear un filtro sin seleccionar ningún panel.
2. Guardar el informe.
3. Intentar eliminar el filtro.
4. Observar que funciona correctamente.
