### PR TITLE
Mejora -  API - Ocultar informes públicos a usuarios no administradores

### DIFF
--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -25,7 +25,8 @@ export class DashboardController {
         privates = await DashboardController.getPrivateDashboards(req);
         group = await DashboardController.getGroupsDashboards(req);
         publics = await DashboardController.getPublicsDashboards();
-        shared = await DashboardController.getSharedDashboards();
+        // Hide public (shared) reports to normal users
+        /*SDA CUSTOM*/ // shared = await DashboardController.getSharedDashboards();
       }
 
       // Asegurarse de que la información del grupo esté incluida para dashboards de tipo "group"

--- a/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.ts
+++ b/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.ts
@@ -160,7 +160,6 @@ export class HomeSdaComponent implements OnInit {
   }
   
   private initDashboardTypes(): void {
-    // Filtrar los tipos basados en si el usuario es admin
     this.dashboardTypes = this.defaultDashboardTypes.filter(type => {
       if (type.type === 'shared') {
         return this.isAdmin;
@@ -168,7 +167,6 @@ export class HomeSdaComponent implements OnInit {
       return true;
     });
 
-    // Actualizar los tipos filtrados
     this.filteredTypes = [...this.dashboardTypes];
   }
 

--- a/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.ts
+++ b/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.ts
@@ -63,6 +63,32 @@ export class HomeSdaComponent implements OnInit {
     color: string;
   }> = [
     {
+      type: "public",
+      label: $localize`:@@Common:Común`,
+      icon: "fa-circle",
+      color: "#add8e7"
+    },
+    {
+      type: "group",
+      label: $localize`:@@Group:Grupo`,
+      icon: "fa-circle",
+      color: "#ffd971"
+    },
+    {
+      type: "private",
+      label: $localize`:@@Private:Privado`,
+      icon: "fa-circle",
+      color: "#ee4e36"
+    }
+  ];
+  
+  private defaultDashboardTypes: Array<{
+    type: string;
+    label: string;
+    icon: string;
+    color: string;
+  }> = [
+    {
       type: "shared",
       label: $localize`:@@Public:Público`,
       icon: "fa-circle",
@@ -131,7 +157,18 @@ export class HomeSdaComponent implements OnInit {
 
     // Set view mode from local storage or default to table view
     this.viewMode = (localStorage.getItem("preferredViewMode") as "table" | "card") || "table";
+  }
+  
+  private initDashboardTypes(): void {
+    // Filtrar los tipos basados en si el usuario es admin
+    this.dashboardTypes = this.defaultDashboardTypes.filter(type => {
+      if (type.type === 'shared') {
+        return this.isAdmin;
+      }
+      return true;
+    });
 
+    // Actualizar los tipos filtrados
     this.filteredTypes = [...this.dashboardTypes];
   }
 
@@ -153,6 +190,7 @@ export class HomeSdaComponent implements OnInit {
     this.initDashboards();
     this.initTags();
     this.initGroups();
+    this.initDashboardTypes(); 
   }
 
   /**
@@ -225,6 +263,7 @@ export class HomeSdaComponent implements OnInit {
         this.isAdmin = res.isAdmin;
         this.IsDataSourceCreator = res.isDataSourceCreator;
 
+        this.initDashboardTypes();
         this.initTags();
         this.initGroups();
         this.filterDashboards();
@@ -240,12 +279,18 @@ export class HomeSdaComponent implements OnInit {
    */
   private initTags(): void {
     const uniqueTags = Array.from(new Set(this.allDashboards.map(db => db.config.tag))).sort();
+    const filteredUniqueTags = uniqueTags.filter(tag => {
+      if (tag === 'shared') {
+        return this.isAdmin;
+      }
+      return true;
+    });
     this.tags = [
       {
         value: null,
         label: this.noTagLabel
       },
-      ...uniqueTags.map(tag => ({
+      ...filteredUniqueTags.map(tag => ({
         value: tag,
         label: tag
       }))
@@ -363,7 +408,13 @@ export class HomeSdaComponent implements OnInit {
    * Filters tags based on the search term.
    */
   public filterTags() {
-    this.filteredTags = this.tags.filter(tag => tag.label.toLowerCase().includes(this.tagSearchTerm.toLowerCase()));
+    this.filteredTags = this.tags
+      .filter(tag => {
+        if (tag.value === 'shared') {
+          return this.isAdmin;
+        }
+        return tag.label.toLowerCase().includes(this.tagSearchTerm.toLowerCase());
+      });
   }
 
 /**


### PR DESCRIPTION
## Descripción del Cambio
Se ocultan los informes públicos a los usuarios no administradores, para evitar que puedan ser abiertos y/o compartidos por estos usuarios, evitando una potencial brecha de seguridad, ya que los usuarios no administradores pueden estar afectados por restricciones que no aplicarían si lo abren de manera externa, por ejemplo en una ventana de incognito.

## Pruebas a realizar para validar el cambio
Verificar que un usuario no administrador no tiene acceso de ningún tipo a informes públicos.

