### PR TITLE
Hotfix - API - Error en UpdateModel al incluir usuarios sin contraseña

### DIFF
--- a/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
+++ b/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
@@ -101,7 +101,7 @@ export class updateModel {
                             where bridge_table   != ''  `).then(async rows => {
                             let relations = rows;
                             //seleccionamos usuarios
-                            await connection.query('SELECT name as name, user_name as email, password as password, active as active FROM  sda_def_users;')
+                            await connection.query('SELECT name as name, user_name as email, password as password, active as active FROM sda_def_users where password  is not null ;')
                                 .then(async users => {
                                     let users_crm = users
                                     //seleccionamos roles de EDA


### PR DESCRIPTION
## Descripción del Cambio
Cuando viene un usuario sin contraseña el update model falla por un error al tratar los nulos.
Teniendo en cuenta que los usuarios que no han puesto la contraseña todoavía no tienen acceso a la aplicación.
Estos usuarios se descartan añadiendo un where a la consulta que recupera los usuarios  "where password  is not null " 

## Issue(s) resuelto(s)
- solves  #242


## Pruebas a realizar para validar el cambio
Teniendo un usuario  que no ha establecido su contraseña ejecutar el update model.  y comprobar que no entra.



