### PR TITLE
Enhancement - API - Modificar permisos de grupos para incluir todos los grupos del usuario 

### DIFF
--- a/eda/eda_api/lib/module/updateModel/service/usersAndGroupsToMongo.ts
+++ b/eda/eda_api/lib/module/updateModel/service/usersAndGroupsToMongo.ts
@@ -59,8 +59,7 @@ export class userAndGroupsToMongo {
           console.log(
             'usuario ' +
             user.name +
-            ' NO SE HA PODIDO METER EN LA BBDD DE MONGO'
-          )
+            ' (Could not insert into the MongoDB database.)'          )
         }
       } else {
         await User.findOneAndUpdate({ name: users[i].name }, { password: users[i].password });

--- a/eda/eda_api/lib/module/updateModel/service/usersAndGroupsToMongo.ts
+++ b/eda/eda_api/lib/module/updateModel/service/usersAndGroupsToMongo.ts
@@ -59,7 +59,7 @@ export class userAndGroupsToMongo {
           console.log(
             'usuario ' +
             user.name +
-            ' repetido, no se ha introducido en la bbdd'
+            ' NO SE HA PODIDO METER EN LA BBDD DE MONGO'
           )
         }
       } else {

--- a/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
+++ b/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
@@ -143,7 +143,7 @@ export class updateModel {
                                                                                   res.status(500).json({'status' : 'ko'})
                                                                                 }
     
-                                                                                console.log('Generando el modelo');
+                                                                                console.log('Generating model');
                                                                                 
                                                                                 try {
                                                                                 modelToExport = updateModel.createModel(tables, columns, relations, grantedRolesAt, ennumeration, res);
@@ -167,7 +167,6 @@ export class updateModel {
                 })
 
         } catch (e) {
-            //res.send(500)
             console.log('Error : ', e);
         }
         
@@ -188,10 +187,10 @@ export class updateModel {
                     columns = [...new Set(dataset.map(item => tabla === item.tabla ? item.column : null))].filter(item => item != null);
                     const sql = ' select ' + columns.toString() + ' from ' + tabla + ' limit 1   \n'
                     let nexSql = sql.replace("select ,", "select ").replace(", from", " from ");
-                   // console.log(nexSql);
+                   
                     await con.query(nexSql).then((ress, errrr) => {
                         if (errrr) throw errrr;
-                        //console.log(ress);
+                   
                         console.count("Query resuelta satisfactoriamente" );
                     })
                 });
@@ -228,12 +227,16 @@ export class updateModel {
         const mongoGroups = await  Group.find(); 
 
         fullTablePermissionsForRoles.forEach((line) => {
+
             let match = mongoGroups.filter(i => { return i.name === line.group })
+
             let mongoId: String;
             let mongoGroup: String;
+
             if (match.length == 1 && line.group !== undefined) {
                 mongoId = match[0]._id.toString()
                 mongoGroup = match[0].name.toString()
+
               if( line.name != null ){
                   // Si es un grupo convertido en usuario
                   const found = usersFound.find(i => i.email == line.name)
@@ -259,6 +262,9 @@ export class updateModel {
                     type: "groups"
                     }
               }
+
+
+
                 destGrantedRoles.push(gr);
             }
         });
@@ -266,6 +272,7 @@ export class updateModel {
 
 
         fullTablePermissionsForUsers.forEach(line => {
+
             const found = usersFound.find(i => i.email == line.name)
             if (found) {
                 gr3 = {
@@ -320,7 +327,7 @@ export class updateModel {
                       value: [valueAt]
                     }
                 }
-                console.log(gr4);
+                
                 destGrantedRoles.push(gr4)
             }
         });
@@ -367,7 +374,6 @@ export class updateModel {
             visible = false
           }
     
-          //console.log(  res[i].table ); 
           var tabla = {
             table_name: tables[i].table,
             columns: [],

--- a/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
+++ b/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
@@ -101,7 +101,7 @@ export class updateModel {
                             where bridge_table   != ''  `).then(async rows => {
                             let relations = rows;
                             //seleccionamos usuarios
-                            await connection.query('SELECT name as name, user_name as email, password as password, active as active FROM  sda_def_users;')
+                            await connection.query('SELECT name as name, user_name as email, password as password, active as active FROM sda_def_users where password  is not null ;')
                                 .then(async users => {
                                     let users_crm = users
                                     //seleccionamos roles de EDA

--- a/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
+++ b/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
@@ -306,9 +306,8 @@ export class updateModel {
                     permission: true,
                     type: "users"
                 }
+                destGrantedRoles.push(gr3);
             }
-            destGrantedRoles.push(gr3)
-
         })
 
 


### PR DESCRIPTION
## Descripción del Cambio
Se modifica el update-model para que se recojan las recomendaciones indicadas en el issue #243 y así hacer la seguridad más compacta agrupando los roles en una única sub-consulta con un in  del estilo  **_where `group` in  (  'SCRM_G1','SCRM_G2' )_**   esto reduce el tamaño del modelo de datos y mejora en eficiencia de la bbdd.



## Issue(s) resuelto(s)

- solves #243 


## Pruebas a realizar para validar el cambio
Hacer consultas con un usuario que pertenezca a más de un grupo y comprobar que el resultado es el esperado. 

La siguente consulta es el resultado de este PR. y se puede observar que la sub-consulta relativa a los grupos ya se comporta cómo debe_


SELECT cast(sum(`sda_stic_payment_commitments`.`N`) as decimal(32,0) ) as `(n) Compromisos de Pago`, `sda_stic_payment_commitments`.`name` as `Nombre` 
FROM sda_stic_payment_commitments
where 1 = 1 
and ( `sda_stic_payment_commitments`.`id`  in **(select record_id from sda_def_security_group_records where `group` in  (  'SCRM_G1','SCRM_G2' ) and `table` =  'sda_stic_payment_commitments' )** 
  or `sda_stic_payment_commitments`.`assigned_user_name`  in (select `assigned_user_name` from sda_stic_payment_commitments where `assigned_user_name` = 'u1' ) 
  ) 
group by `sda_stic_payment_commitments`.`name`
order by `(n) Compromisos de Pago` Desc



## Información Adicional
Este PR se debe integrar despues del pr https://github.com/SinergiaTIC/SinergiaDA/pull/244 puesto que depende de él.

