### PR TITLE
Enhancement - API - Permitir filtrar "vacío" a nivel informe 

### DIFF
--- a/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
@@ -51,6 +51,12 @@ export class MySqlBuilderService extends QueryBuilderService {
     //HAVING 
     myQuery += this.getHavingFilters(havingFilters);
 
+
+    /**SDA CUSTOM */  if (forSelector === true) {
+    /**SDA CUSTOM */     myQuery += `\n UNION \n SELECT '' `;
+    /**SDA CUSTOM */   }
+
+
     // OrderBy
     const orderColumns = this.queryTODO.fields.map(col => {
       let out;


### PR DESCRIPTION
## Descripción del Cambio
Se añade "union select '' " a las consultas para los selectores para forzar que siempre haya la opción de filtrar por la cadena vacía haya o no haya ese valor en la tabla.


## Issue(s) resuelto(s)
<!-- Indicar el #<número> del/los issues resiueltos por este Pull Request -->
- solves  #183 

## Pruebas a realizar para validar el cambio
Hacer un informe con filtros y verificar que se añade la oción "vaclía" en todos los selectores
