### PR TITLE
Enhancement - API - Establecer límite de tiempo al ejecutar consultas

### DIFF
--- a/eda/eda_api/lib/services/connection/db-systems/mysql-connection.ts
+++ b/eda/eda_api/lib/services/connection/db-systems/mysql-connection.ts
@@ -1,4 +1,4 @@
-import { createConnection, createPool, Connection as SqlConnection } from 'mysql2';
+import { createConnection, createPool, Connection as SqlConnection } from 'mysql2/promise';
 import { MySqlBuilderService } from "../../query-builder/qb-systems/mySql-builder.service";
 import { AbstractConnection } from "../abstract-connection";
 import { AggregationTypes } from "../../../module/global/model/aggregation-types";
@@ -35,8 +35,7 @@ export class MysqlConnection extends AbstractConnection {
                     queueLimit: 0,
                     enableKeepAlive: true,
                     keepAliveInitialDelay: 0
-                    
-                };
+                                    };
 
                 poolManager.createPool(this.config.database, mySqlConn);
                 this.pool = poolManager.getPool(this.config.database);

--- a/eda/eda_api/lib/services/connection/db-systems/mysql-connection.ts
+++ b/eda/eda_api/lib/services/connection/db-systems/mysql-connection.ts
@@ -157,20 +157,20 @@ export class MysqlConnection extends AbstractConnection {
     
     
     // SDA CUSTOM JCH (add timeout to individual queries)
-    // 
-    /* async execQuery(query: string): Promise<any> {
-         try {
-             this.client.query = util.promisify(this.client.query);
-             const rows = await this.client.query(query);
-             // console.log(this.client.itsConnected());
-             // if (!this.pool && this.client.itsConnected() ) this.client.end();
-             return rows;
-         } catch (err) {
-             console.log(err);
-             throw err;
-         }
-     }
-     */
+    // https://github.com/SinergiaTIC/SinergiaDA/pull/256/files
+    //  async execQuery(query: string): Promise<any> {
+    //      try {
+    //          this.client.query = util.promisify(this.client.query);
+    //          const rows = await this.client.query(query);
+    //          // console.log(this.client.itsConnected());
+    //          // if (!this.pool && this.client.itsConnected() ) this.client.end();
+    //          return rows;
+    //      } catch (err) {
+    //          console.log(err);
+    //          throw err;
+    //      }
+    //  }
+     
     /**
     * Executes a MySQL query with a timeout constraint
     * 
@@ -184,7 +184,7 @@ export class MysqlConnection extends AbstractConnection {
             this.client.query = util.promisify(this.client.query);
 
             // Add timeout constraint to the query
-            const queryWithTimeout = `SET STATEMENT max_statement_time=60000 FOR ${query}`;
+            const queryWithTimeout = `SET STATEMENT max_statement_time=3 FOR ${query}`;
 
             // Create timeout promise that rejects after 60 seconds
             const timeoutPromise = new Promise((_, reject) => {
@@ -208,6 +208,7 @@ export class MysqlConnection extends AbstractConnection {
             console.log(err);
             throw err;
         }
+
     }
     //  END SDA CUSTOM
 


### PR DESCRIPTION
Se ha visto que cuando se ejecuta una query que tarda mucho tiempo puede afectar negativamente a la instancias de SinergiaCRM,por el hecho de que quede la query colgada y pueda afectar a otros procesos de iserción o modificación de registros de SinergiaCRM


Para evitarlo en las conexiones MariaDB/MySQL se establece un límite de 60 segundos para la ejecución de cualquier query individual, entendiendo que ninguna consulta (panel o filtro) en SinergiaDA pueda tardar más de este tiempo.

60s Este es el tiempo establecido por defecto, pero puede modificarse añadiendo el el valor deseado, en segundos en `sinergiaConn`, en el fichero _eda/eda_api/config/sinergiacrm.config.js_:

```javascript
module.exports = {
                        sinergiaConn:{
                            host: "172.17.0.1",
                            database: "sinergiacrm",
                            ....
                            maxStatementTime: 50
                        }
                    };
```


**Cómo probarlo**
- Preparar queries que sean especialmente pesadas, se pueden forzar creando consultas SQL del tipo `SELECT id,sleep(10) from sda_contacts`, lo que demorará la consulta el tiempo suficiente para alcanzar el límite de 60 segundos.
- Verificar que la consulta se cierra automáticamente al alcanzar este tiempo y no queda resto de ella al ejecutar `SHOW processlists` 