### PR TITLE
Feature - API - Gestionar cache de SinergiaDA según lo configurado en SinergiaCRM 

### DIFF
--- a/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
+++ b/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
@@ -584,11 +584,15 @@ export class updateModel {
         quantity: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_quantity').value,
         hours: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_hours').value,
         minutes: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_minutes').value,
-        enabled: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_enabled').value,
+        enabled: true,
       }
     } else {
       main_model.ds.metadata.cache_config = {
-        enabled: "0"
+        units: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_units').value,
+        quantity: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_quantity').value,
+        hours: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_hours').value,
+        minutes: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_minutes').value,
+        enabled: false,
       }
     }
     // Fin de la verificación.

--- a/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
+++ b/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
@@ -577,6 +577,7 @@ export class updateModel {
 
     // Verificando si desde Sinergia CRM viene enabled la información del cache 
     let sda_config_cache_enabled_value = cache_configSDA.find( v => v.key === 'sda_config_cache_enabled').value
+    // Se pueden configurar mas variables
     if(sda_config_cache_enabled_value === "1") {
       main_model.ds.metadata.cache_config = {
         units: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_units').value,
@@ -584,6 +585,10 @@ export class updateModel {
         hours: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_hours').value,
         minutes: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_minutes').value,
         enabled: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_enabled').value,
+      }
+    } else {
+      main_model.ds.metadata.cache_config = {
+        enabled: "0"
       }
     }
     // Fin de la verificación.

--- a/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
+++ b/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
@@ -130,7 +130,7 @@ export class updateModel {
                                                                               .then(async customUserPermissionsValue => {
                                                                                 let customUserPermissions = customUserPermissionsValue;
                                                                                 
-                                                                                await connection.query("select * from sda_def_config")
+                                                                                await connection.query("select `key`, `value` from sda_def_config")
                                                                                   .then(async cacheConfigSDA => {
                                                                                     let cache_config_SDA = cacheConfigSDA;
 
@@ -575,27 +575,35 @@ export class updateModel {
     main_model.ds.model.tables = tables; //añadimos el parámetro en la columna adecuada
     main_model.ds.metadata.model_granted_roles = await grantedRoles;
 
-    // Verificando si desde Sinergia CRM viene enabled la información del cache 
-    let sda_config_cache_enabled_value = cache_configSDA.find( v => v.key === 'sda_config_cache_enabled').value
-    // Se pueden configurar mas variables
-    if(sda_config_cache_enabled_value === "1") {
-      main_model.ds.metadata.cache_config = {
-        units: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_units').value,
-        quantity: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_quantity').value,
-        hours: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_hours').value,
-        minutes: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_minutes').value,
-        enabled: true,
-      }
-    } else {
-      main_model.ds.metadata.cache_config = {
-        units: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_units').value,
-        quantity: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_quantity').value,
-        hours: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_hours').value,
-        minutes: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_minutes').value,
-        enabled: false,
-      }
+
+
+    try{
+        // Verificando si desde Sinergia CRM viene enabled la información del cache 
+        let sda_config_cache_enabled_value = cache_configSDA.find( v => v.key === 'sda_config_cache_enabled').value
+        // Se pueden configurar mas variables
+        if(sda_config_cache_enabled_value === "1") {
+          main_model.ds.metadata.cache_config = {
+            units: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_units').value,
+            quantity: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_quantity').value,
+            hours: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_hours').value,
+            minutes: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_minutes').value,
+            enabled: true,
+          }
+        } else {
+          main_model.ds.metadata.cache_config = {
+            units: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_units').value,
+            quantity: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_quantity').value,
+            hours: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_hours').value,
+            minutes: cache_configSDA.find( (v: any) => v.key === 'sda_config_cache_minutes').value,
+            enabled: false,
+          }
+        }
+
+    }catch( e){
+      console.log('\n \n \n IT IS MISSING SOME OF THE CACHE CONFIGURATION. WE DISABLE IT! \n \n \n ')
+      main_model.ds.metadata.cache_config.enabled = false;
     }
-    // Fin de la verificación.
+
 
     try {
         const cleanM = new CleanModel; 


### PR DESCRIPTION
## Descripción del Cambio
Se actualiza el update model para poder definir la caché en función de lo que venda de SinergiaCRM

## Issue(s) resuelto(s)
- solves  #217 

## Pruebas a realizar para validar el cambio
Ejecutar el update model y comprobar  que la configuración de la cache es la que viene de base de datos.
SI SE PRODUCE ALGÚN ERROR SE PONE LA CACHE A FALSE.


