### PR TITLE
Enhancement -  API - Optimización básica de updateModel

### DIFF
--- a/eda/eda_api/lib/module/updateModel/service/usersAndGroupsToMongo.ts
+++ b/eda/eda_api/lib/module/updateModel/service/usersAndGroupsToMongo.ts
@@ -35,6 +35,7 @@ import mongoose, {
 } from 'mongoose'
 import User, { IUser } from '../../admin/users/model/user.model'
 import Group, { IGroup } from '../../admin/groups/model/group.model'
+import { each } from 'lodash';
 
 mongoose.set('useFindAndModify', false);
 
@@ -202,19 +203,10 @@ export class userAndGroupsToMongo {
       }
     });
 
-    // Add admin user to EDA_ADMIN group
-    await mongoGroups.find(i => i.name ===  'EDA_ADMIN').users.push('135792467811111111111111')
-    let user = await mongoUsers.find(i => i.email ===  ('eda@jortilles.com') ) ;
-    if(user){
-      user.role.push('135792467811111111111110');
-    }else{
-      user = await mongoUsers.find(i => i.email ===  ('eda@sinergiada.org' ) )
-      if(user){
-        user.role.push('135792467811111111111110');
-      }else{
-        console.log('Error: Failed to assign admin role to user');
-      }
-    }
+    // Ensure add all admins to EDA_ADMIN group, this include eda@sinergiada.org
+    let admins = await mongoUsers.filter(i => i.role.includes('135792467811111111111110'));
+    const edaAdminGroup = mongoGroups.find(i => i.name === 'EDA_ADMIN');
+    edaAdminGroup.users = admins.map(admin => admin._id);
 
     // Save changes to database
     await mongoGroups.forEach(async r => {

--- a/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
+++ b/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
@@ -111,7 +111,9 @@ export class updateModel {
               )
               .then(async rows => {
                 let relations = rows;
-                // Select users: Since the sda_def_user_groups view has set a limitation on the number of users coming from SinergiaCRM, this view is used to filter the users that should be active in SDA, through a left join with the sda_def_user_groups table. If the user is in this table, they are active, otherwise inactive.
+                // Select users: Since the sda_def_user_groups view has set a limitation on the number of users
+                // coming from SinergiaCRM, this view is used to filter the users that should be active in SDA,
+                // through a left join with the sda_def_user_groups table. If the user is in this table, they are active, otherwise inactive.
                 await connection
                   .query(`
                        SELECT
@@ -128,7 +130,9 @@ export class updateModel {
                   )
                   .then(async users => {
                     let users_crm = users;
-                    // Select EDA roles/groups: The sda_def_user_groups table is used to filter the groups/roles that should be created in SDA, omitting those that are not present in this table (i.e., they have no users) despite being in sda_def_groups (which by default contains all the groups from SinergiaCRM).
+                    // Select EDA roles/groups: The sda_def_user_groups table is used to filter the groups/roles
+                    // that should be created in SDA, omitting those that are not present in this table (i.e., they have no users)
+                    // despite being in sda_def_groups (which by default contains all the groups from SinergiaCRM).
                     await connection
                       .query(`
                          SELECT
@@ -270,6 +274,15 @@ export class updateModel {
   }
 
   /** Generates and processes model roles */
+  /**
+   * Retrieves the granted roles for a model based on various permissions.
+   * @param fullTablePermissionsForRoles - The permissions for roles with full table access.
+   * @param crmTables - The CRM tables.
+   * @param fullTablePermissionsForUsers - The permissions for users with full table access.
+   * @param dynamicPermisssionsForGroup - The dynamic permissions for groups.
+   * @param dynamicPermisssionsForUser - The dynamic permissions for users.
+   * @returns An array of granted roles for the model.
+   */
   static async grantedRolesToModel(
     fullTablePermissionsForRoles: any,
     crmTables: any,
@@ -287,7 +300,11 @@ export class updateModel {
     const usersFound = await User.find();
     const mongoGroups = await Group.find();
  
-    // Función para verificar permisos duplicados
+    /**
+     * Checks if there is an existing permission for a full table access.
+     * @param newRole - The new role to check against existing permissions.
+     * @returns True if there is an existing permission, false otherwise.
+     */
     const hasExistingFullTablePermission = (newRole: any) => {
         return destGrantedRoles.some(existing => 
             existing.column === "fullTable" && 
@@ -321,7 +338,7 @@ export class updateModel {
             type: "users"
           };
                 
-                // Verificar duplicados antes de agregar
+                // Verify duplicates before adding
                 if (!hasExistingFullTablePermission(gr)) {
                     destGrantedRoles.push(gr);
                 }
@@ -355,6 +372,7 @@ export class updateModel {
           permission: true,
           type: "users"
         };
+        // Verify duplicates before adding
         if (!hasExistingFullTablePermission(gr3)) {
         destGrantedRoles.push(gr3);
         }
@@ -608,7 +626,7 @@ export class updateModel {
     // Format tables as JSON
     console.timeLog("UpdateModel", "(Start JSON formatting)");
     
-    // Load and configure base model
+    // Load and configure base model using path library to avoid errors reading the file
     let main_model = await JSON.parse(fs.readFileSync(path.join(__dirname, '../../../config/base_datamodel.json'), "utf-8"));
     
     main_model.ds.connection.host = sinergiaDatabase.sinergiaConn.host;

--- a/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
+++ b/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
@@ -14,7 +14,7 @@ const mariadb = require("mariadb");
 const sinergiaDatabase = require("../../../config/sinergiacrm.config");
 
 export class updateModel {
-/** Updates the SinergiaDA data model of an instance */
+  /** Updates the SinergiaDA data model of an instance */
   static async update(req: Request, res: Response) {
     let crm_to_eda: any = {};
     let modelToExport: any = {};
@@ -67,7 +67,7 @@ export class updateModel {
             " where bridge_table != '' ";
           await connection.query(my_query).then(async rows => {
             let columns = rows;
-             // Select relationships
+            // Select relationships
             await connection
               .query(
                 ` 
@@ -356,7 +356,7 @@ export class updateModel {
           type: "users"
         };
         if (!hasExistingFullTablePermission(gr3)) {
-          destGrantedRoles.push(gr3);
+        destGrantedRoles.push(gr3);
         }
       }
     });
@@ -605,18 +605,12 @@ export class updateModel {
 
   /** Formats and pushes the final model to MongoDB */
   static async extractJsonModelAndPushToMongo(tables: any, grantedRoles: any, res: any) {
-    // Inicio del formateo JSON
+    // Format tables as JSON
     console.timeLog("UpdateModel", "(Start JSON formatting)");
     
-    // Cargar y configurar modelo base
-    let main_model = await JSON.parse(
-      fs.readFileSync(
-        path.join(__dirname, '../../../config/base_datamodel.json'), 
-        "utf-8"
-      )
-    );
- 
-    // Configurar conexión
+    // Load and configure base model
+    let main_model = await JSON.parse(fs.readFileSync(path.join(__dirname, '../../../config/base_datamodel.json'), "utf-8"));
+    
     main_model.ds.connection.host = sinergiaDatabase.sinergiaConn.host;
     main_model.ds.connection.database = sinergiaDatabase.sinergiaConn.database;
     main_model.ds.connection.port = sinergiaDatabase.sinergiaConn.port;

--- a/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
+++ b/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
@@ -111,7 +111,7 @@ export class updateModel {
               )
               .then(async rows => {
                 let relations = rows;
-                // Select users
+                // Select users: Since the sda_def_user_groups view has set a limitation on the number of users coming from SinergiaCRM, this view is used to filter the users that should be active in SDA, through a left join with the sda_def_user_groups table. If the user is in this table, they are active, otherwise inactive.
                 await connection
                   .query(`
                        SELECT
@@ -128,7 +128,7 @@ export class updateModel {
                   )
                   .then(async users => {
                     let users_crm = users;
-                    // Select EDA roles
+                    // Select EDA roles/groups: The sda_def_user_groups table is used to filter the groups/roles that should be created in SDA, omitting those that are not present in this table (i.e., they have no users) despite being in sda_def_groups (which by default contains all the groups from SinergiaCRM).
                     await connection
                       .query(`
                          SELECT


### PR DESCRIPTION
### 1. Reducción del tiempo de ejecución
- solves #250 

Por un lado se implementa cierta mejora para evitar los problemas de rendimiento al procesar updateModel en escenarios con un número elevado de usuarios y grupos de seguridad. En estos casos e ha visto que un escenario con 1400 usuarios y 2300 grupos de seguridad puede hacer que el sistema se colapse y no termine.

Para reducir este tiempo se han acometido los siguientes cambios:
- Puesto que en sinergiaCRM se limita el número de usuarios a 100 (por defecto), y esta limitación se establece en la creación de la vista _sda_def_user_groups_, se utiliza esta vista para filtrar los usuarios que deben crearse en SinergiaDA (solo los existentes en esta vista) y para filtrar los grupos de seguridad que deben trasladarse a SinergiaDA (solo los existentes en la vista).
- Se crea la función _hasExistingFullTablePermission_ que chequea si ya existen permisos previamente concedidos para la misma combinación de usuario/grupo y tabla, de manera que se evita añadir permisos duplicados, lo que implica un ahorro de tiempo de proceso, pues estos permisos deben ser _limpiados_ posteriormente en cleanModel.
- Se elimina una llamada redundante para añadir los permisos encerrados en la variables `gr4` https://github.com/SinergiaTIC/SinergiaDA/blob/262a1a90eaf24777243331824068d7f1425bf850/eda/eda_api/lib/module/updateModel/updateModel.controller.ts#L371-L372
- Se añaden varias llamadas `console.timeLog` para controlar el tiempo de proceso de cada una de las partes de procesamiento.
- Se añade la librería _path_ para utilizarla al construir la ruta en la que se guarda el fichero metadata.json, ya que se ha visto que en algunas circunstancias daba error.


**Pruebas a realizar**
Realizar diferentes llamadas a updateModel en diferentes escenarios, con diferente número de usuarios y grupos y verificar que en base a lo indicados en las tablas sda_def_users, sda_def_groups, sda_def_user_groups y sda_def_permissions:
- Los usuarios y grupos son trasladados correctamente a SinergiaDA.
- Los permisos de usuario y grupo son trasladados correctamente a SinergiaDA.
- Verificar la mejora del tiempo que tarda en ejecutarse updateModel respecto a la rama reporting
- Verificar que el fichero metadata.json se construye correctamente y se guarda correctamente . 
- Verificar el funcionamiento de la instancia tras ejecutar updateModel.


### 2. Se asegura que todos los administradores formen parte del grupo EDA_ADMIN

- closes #257 
Se resuelve el problema en la sincronización entre usuarios y grupos durante la ejecución del método `updateModel`. Los documentos de usuario mantienen correctamente las referencias a sus grupos en el array `role`, pero no ocurre lo mismo en la dirección opuesta: los documentos de grupos no siempre reflejan correctamente los _usuarios administradores_ que tienen ese grupo asignado en su array `users`.

En https://github.com/SinergiaTIC/SinergiaDA/pull/264/commits/fe9a8f811bcf426d7d9b1ebc4cd29371250b6562 se refactoriza el código que añade los usuarios administradores al array users del grupo EDA_ADMIN

**Pruebas a realizar**
1. En mongoDB eliminar algún elemento del array role del grupo EDA_ADMIN. 
2. Ejecutar updateModel y verificar que todos los usuarios administradores (además de eda@sinergiada.org) se añaden al array
3. Entrar en los usuarios administradores y verificar que no aparecen duplicados.
