### PR TITLE
Hotfix - API - Corrección de doble relación entre usuarios y grupos(roles)

### DIFF
--- a/eda/eda_api/lib/module/updateModel/service/usersAndGroupsToMongo.ts
+++ b/eda/eda_api/lib/module/updateModel/service/usersAndGroupsToMongo.ts
@@ -133,59 +133,20 @@ export class userAndGroupsToMongo {
     });
 
     // Helper functions to check user existence in CRM
-    const userExistsInCRM = (user, crmUsers) => {
+    const userExistsInCRM = (user: any, crmUsers: any) => {
       return crmUsers.some(crmUser => crmUser.email === user.email && crmUser.active == 1); 
     };
 
-    const userExistedInCRM = (user, crmUsers) => {
+    const userExistedInCRM = (user: any, crmUsers: any) => {
       return crmUsers.some(crmUser => crmUser.email === user.email); 
     };
 
-    // Synchronize groups and users
-    await mongoGroups.forEach(async (group) => {
-      if (group.name.startsWith('SCRM_')) {
-        // For SCRM_ groups, maintain SDA users and sync with CRM
-        const crmUsersInGroup = crmRoles
-          .filter(role => role.name === group.name)
-          .map(role => mongoUsers.find(u => u.email === role.user_name))
-          .filter(user => user)
-          .map(user => user._id);
-        
-        group.users = [
-          ...group.users.filter(userId => {
-            const user = mongoUsers.find(u => u._id.toString() === userId.toString());
-            return user &&  !userExistsInCRM( user, crmUsers);
-          }),
-          ...crmUsersInGroup
-        ];
-
-        // Add new CRM users to the group
-        const newCrmUsersInGroup = crmRoles
-          .filter(role => role.name === group.name)
-          .map(role => mongoUsers.find(u => u.email === role.user_name &&  userExistsInCRM(u, crmUsers)  ))
-          .filter(user => user && !group.users.includes(user._id))
-          .map(user => user._id);
-          
-        group.users = [...group.users, ...newCrmUsersInGroup];
-
-      } else {
-        // For non-SCRM_ groups, maintain SDA users and update CRM users
-        group.users = group.users.filter(userId => {
-          const user = mongoUsers.find(u => u._id.toString() === userId.toString());
-          if (!user) return false;
-          if (userExistedInCRM(user, crmUsers)) {
-            return userExistsInCRM(user, crmUsers) ;
-          } else {
-            return true;
-          }
-        });
-      }
-    });
-
-    // Update user roles
-    await mongoUsers.forEach(async (user) => {
-      if( userExistsInCRM( user, crmUsers)) { 
-        // Update CRM users, maintain non-SCRM_ roles
+    // Synchronize groups and users, avoiding duplicates
+    const BATCH_SIZE = 50;
+    for (let i = 0; i < mongoUsers.length; i += BATCH_SIZE) {
+        const userBatch = mongoUsers.slice(i, i + BATCH_SIZE);
+        await Promise.all(userBatch.map(async (user) => {
+            if (userExistsInCRM(user, crmUsers)) {
         const nonCRMRoles = user.role.filter(roleId => {
           const group = mongoGroups.find(g => g._id.toString() === roleId.toString() && !g.name.startsWith('SCRM_')  );
           return group;
@@ -196,71 +157,86 @@ export class userAndGroupsToMongo {
           .filter(role => role.user_name === user.email)
           .map(role => mongoGroups.find(g => g.name === role.name))
           .filter(group => group)
-          .map(group => group._id);
-        
-        user.role = [...new Set([...nonCRMRoles, ...crmRolesForUser])];
-      }
-    });
+          .map(group => group._id.toString());  // Convert to string for comparison
 
-    // Add admin user to EDA_ADMIN group
-    await mongoGroups.find(i => i.name ===  'EDA_ADMIN').users.push('135792467811111111111111')
-    let user = await mongoUsers.find(i => i.email ===  ('eda@jortilles.com') ) ;
-    if(user){
-      user.role.push('135792467811111111111110');
-    }else{
-      user = await mongoUsers.find(i => i.email ===  ('eda@sinergiada.org' ) )
-      if(user){
-        user.role.push('135792467811111111111110');
-      }else{
-        console.log('Error: Failed to assign admin role to user');
-      }
+        const allRoles = [...nonCRMRoles.map(r => r.toString()), ...crmRolesForUser];
+        const uniqueRoles = [...new Set(allRoles)].map(r => mongoose.Types.ObjectId(r));
+
+            try {
+                await User.updateOne(
+                    { email: user.email },
+                    { $set: { role: uniqueRoles } }
+                );
+            } catch (err) {
+                console.log('Error updating user roles:', err);
+            }
+        }
+        }));
     }
 
-    // Save changes to database
-    await mongoGroups.forEach(async r => {
-      try {
-        await Group.updateOne({ name: r.name }, { $unset: { users: {} } })
-          .then(function () {
-          })
-          .catch(function (error) {
-            console.log(error)
-          })
-      } catch (err) {
-        console.log(err);
-      }
-      try {
-        await Group.updateOne({ name: r.name }, { $addToSet: { users: r.users } })
-          .then(function () {
-          })
-          .catch(function (error) {
-            console.log(error)
-          })
-      } catch (err) {
-        console.log(err);
-      }
-    })    
+    // Procesar grupos en lotes para evitar duplicados en users
+    for (let i = 0; i < mongoGroups.length; i += BATCH_SIZE) {
+        const groupBatch = mongoGroups.slice(i, i + BATCH_SIZE);
+        await Promise.all(groupBatch.map(async (group) => {
+            try {
+                const usersInGroup = mongoUsers
+                    .filter(user => user.role.some(roleId => 
+                        roleId.toString() === group._id.toString()
+                    ))
+                    .map(user => user._id.toString());
 
-    const newGroupsInMongo =  await Group.find(); 
-    const newGroupsIDInMongo = newGroupsInMongo.map(g=>g._id.toString());
- 
-    // Update user roles
-    await mongoUsers.forEach(async user => {
-      user.role = user.role.filter( r => newGroupsIDInMongo.includes(r.toString() ) )
-      try {
-        await User.updateOne({ email: user.email }, { $unset : {role: {}} })
-          .then(function () {
-          })
-          .catch(function (error) {
-            console.log(error) 
-          })
-      
-        await User.updateOne({ email: user.email }, { $addToSet : {role: user.role} })
-          .then(function () {
-          })
-          .catch(function (error) {
-            console.log(error) 
-          })
-      } catch (err) {}
-    })
-  }
+                // Corrección del tipado
+                const uniqueUsers = Array.from(new Set(usersInGroup))
+                    .map(u => mongoose.Types.ObjectId(u as string));
+
+                await Group.updateOne(
+                    { _id: group._id },
+                    { $set: { users: uniqueUsers } }
+                );
+            } catch (err) {
+                console.log('Error updating group users:', err);
+            }
+        }));
+
+    // Admin user management
+    await mongoGroups.find(i => i.name === 'EDA_ADMIN').users.push('135792467811111111111111');
+    let user = await mongoUsers.find(i => i.email === ('eda@jortilles.com'));
+    if (user) {
+        user.role.push('135792467811111111111110');
+    } else {
+        user = await mongoUsers.find(i => i.email === ('eda@sinergiada.org'));
+        if (user) {
+            user.role.push('135792467811111111111110');
+        } else {
+            console.log('Error: Failed to assign admin role to user');
+        }
+    }
+
+    const newGroupsInMongo = await Group.find();
+    const newGroupsIDInMongo = newGroupsInMongo.map(g => g._id.toString());
+
+    // Final user roles update con tipado corregido
+    for (let i = 0; i < mongoUsers.length; i += BATCH_SIZE) {
+        const userBatch = mongoUsers.slice(i, i + BATCH_SIZE);
+        await Promise.all(userBatch.map(async (user) => {
+            const validRoles = user.role
+                .map(r => r.toString())
+                .filter(r => newGroupsIDInMongo.includes(r));
+
+            // Corrección del tipado
+            const uniqueRoles = Array.from(new Set(validRoles))
+                .map(r => mongoose.Types.ObjectId(r as string));
+
+            try {
+                await User.updateOne(
+                    { email: user.email },
+                    { $set: { role: uniqueRoles } }
+                );
+            } catch (err) {
+                console.log('Error updating final user roles:', err);
+            }
+        }));
+    }
+}
+}
 }


### PR DESCRIPTION
- closes #257 
Se ha encontrado un problema en la sincronización entre usuarios y grupos durante la ejecución del método `updateModel`. Los documentos de usuario mantienen correctamente las referencias a sus grupos en el array `role`, pero no ocurre lo mismo en la dirección opuesta: los documentos de grupos no siempre reflejan correctamente los usuarios que tienen ese grupo asignado en su array `users`.

Además, se han detectado casos donde aparecen IDs duplicados tanto en el array `role` de usuarios como en el array `users` de grupos.

## Solución implementada
1. Rediseño del proceso de sincronización de usuarios y grupos bidireccional:
   - Los roles de usuarios se actualizan basándose en los grupos existentes
   - El array `users` de cada grupo se actualiza reflejando todos los usuarios que tienen ese grupo en sus roles

2. Implementación de procesamiento por lotes para manejar muchos registros, ya que se ha visto que el proceso fallaría en escenarios con 1400/2400 usuarios/grupos:
   - Introducción de un tamaño de lote configurable (BATCH_SIZE)
   - Uso de Promise.all para procesar los lotes de manera eficiente
   - Evita el error "Maximum call stack size exceeded" con conjuntos grandes de datos

