### PR TITLE
Enhancement - Idiomas - Incluir traducciones having/where

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
@@ -58,11 +58,11 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     public cumulativeSumTooltip: string = $localize`:@@cumulativeSumTooltip:Si activas ésta función se calculará la suma acumulativa 
                                             para los campos numéricos que eligas. Sólo se puede activar si la fecha está agregada por mes, semana o dia.`
 
-    public filterBeforeAfter = {
+    public filterBeforeAfter = {    
         filterBeforeGrouping: true, // valor por defecto true ==> WHERE / valor false ==> HAVING
         elements: [
-            {label: 'Aplicar el filtro sobre todos los registros.', value: true},
-            {label: 'Aplicar el filtro sobre los resultados.', value: false},
+            { label: $localize`:@@whereMessageLabel:Aplicar el filtro sobre todos los registros`, value: true },
+            { label: $localize`:@@havingMessageLabel:Aplicar el filtro sobre los resultados`, value: false },
         ],
     }
     public filterBeforeAfterSelected: any;

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -1378,8 +1378,11 @@ export class EdaBlankPanelComponent implements OnInit {
             const values = filter.filter_elements[0]?.value1;
             const values2 = filter.filter_elements[1]?.value2;
 
+            const whereMessage: string = $localize`:@@whereMessage: Filtro sobre todos los registros`;
+            const havingMessage: string = $localize`:@@havingMessage: Filtro sobre los resultados`;
+        
             // Nomenclatura:  WHERE => Filtro sobre todos los registros | HAVING => Filtro sobre los resultados
-            const filterBeforeGroupingText = filter.filterBeforeGrouping ? 'Filtro sobre todos los registros' : 'Filtro sobre los resultados'
+            const filterBeforeGroupingText = filter.filterBeforeGrouping ? whereMessage : havingMessage
 
             // Agregación
             const aggregation = filter.aggregation_type;

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4347,6 +4347,14 @@
         <source>Filtro sobre los resultados</source>
         <target>Filtre sobre els resultats</target>
       </trans-unit>
+      <trans-unit id="whereMessageLabel">
+        <source>Aplicar el filtro sobre todos los registros</source>
+        <target>Aplicar el filtre sobre tots els registres</target>
+      </trans-unit>
+      <trans-unit id="havingMessageLabel">
+        <source>Aplicar el filtro sobre los resultados</source>
+        <target>Aplicar el filtre sobre els resultats</target>
+      </trans-unit>
       <trans-unit id="aggregationText">
         <source>Agregación</source>
         <target>Agregació</target>

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4349,11 +4349,11 @@
       </trans-unit>
       <trans-unit id="whereMessageLabel">
         <source>Aplicar el filtro sobre todos los registros</source>
-        <target>Aplicar el filtre sobre tots els registres</target>
+        <target>Aplica el filtre sobre tots els registres</target>
       </trans-unit>
       <trans-unit id="havingMessageLabel">
         <source>Aplicar el filtro sobre los resultados</source>
-        <target>Aplicar el filtre sobre els resultats</target>
+        <target>Aplica el filtre sobre els resultats</target>
       </trans-unit>
       <trans-unit id="aggregationText">
         <source>Agregación</source>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4303,7 +4303,7 @@
       </trans-unit>
       <trans-unit id="havingMessageLabel">
         <source>Aplicar el filtro sobre los resultados</source>
-        <target>Apply el on results</target>
+        <target>Apply filter on results</target>
       </trans-unit>
       <trans-unit id="aggregationText">
         <source>Agregación</source>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4297,6 +4297,14 @@
         <source>Filtro sobre los resultados</source>
         <target>Filter on results</target>
       </trans-unit>
+      <trans-unit id="whereMessageLabel">
+        <source>Aplicar el filtro sobre todos los registros</source>
+        <target>Apply filter on all records</target>
+      </trans-unit>
+      <trans-unit id="havingMessageLabel">
+        <source>Aplicar el filtro sobre los resultados</source>
+        <target>Apply el on results</target>
+      </trans-unit>
       <trans-unit id="aggregationText">
         <source>Agregación</source>
         <target>Aggregation</target>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4326,6 +4326,14 @@
         <source>Filtro sobre los resultados</source>
         <target>Filtro sobre los resultados</target>
       </trans-unit>
+      <trans-unit id="whereMessageLabel">
+        <source>Aplicar el filtro sobre todos los registros</source>
+        <target>Aplicar el filtro sobre todos los registros</target>
+      </trans-unit>
+      <trans-unit id="havingMessageLabel">
+        <source>Aplicar el filtro sobre los resultados</source>
+        <target>Aplicar el filtro sobre los resultados</target>
+      </trans-unit>
       <trans-unit id="aggregationText">
         <source>Agregación</source>
         <target>Agregación</target>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -4327,6 +4327,14 @@
         <source>Filtro sobre los resultados</source>
         <target>Filtra os resultados</target>
       </trans-unit>
+      <trans-unit id="whereMessageLabel">
+        <source>Aplicar el filtro sobre todos los registros</source>
+        <target>Aplique o filtro en todos os rexistros</target>
+      </trans-unit>
+      <trans-unit id="havingMessageLabel">
+        <source>Aplicar el filtro sobre los resultados</source>
+        <target>Aplicar o filtro aos resultados</target>
+      </trans-unit>
       <trans-unit id="aggregationText">
         <source>Agregación</source>
         <target>Agregación</target>


### PR DESCRIPTION
- Relacionado con: https://github.com/SinergiaTIC/SinergiaDA/pull/259
## Descripción
Se incluye la internacionalización de algunas cadenas de texto a las que no se les había aplicado anteriormente.

## Pruebas a realizar 
Revisar, además de las cadenas presentes, las cadenas relacionadas con: `whereMessage`, `havingMessage` y `aggregationText`.
