### PR TITLE
Improvement - API - Mejorar queries de usuarios y grupos 

### DIFF
--- a/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
+++ b/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
@@ -123,15 +123,20 @@ export class updateModel {
                   .then(async users => {
                     let users_crm = users;
                     /*
-                    * Retrieves EDA roles and groups
+                    * Retrieves EDA roles and groups based on active membership:
+                    * - Only includes groups/roles that have active users in sda_def_user_groups
+                    * - Excludes empty groups from sda_def_groups (which mirrors all SinergiaCRM groups)
+                    * - This ensures roles are only created in SDA when they have assigned users
                     */
                     await connection
                       .query(`
-                      SELECT "EDA_USER_ROLE" AS role, b.name, "" AS user_name 
-                      FROM sda_def_groups b 
-                      UNION 
-                      SELECT "EDA_USER_ROLE" AS role, g.name AS name , g.user_name 
-                      FROM sda_def_user_groups g `
+                        
+                         SELECT
+                           "EDA_USER_ROLE" as role,
+                           g.name as name ,
+                           g.user_name
+                         FROM
+                           sda_def_user_groups g; `
                       )
                       .then(async role => {
                         let roles = role;

--- a/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
+++ b/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
@@ -112,51 +112,26 @@ export class updateModel {
               .then(async rows => {
                 let relations = rows;
                 /*
-                * Retrieves users and their active status based on group membership:
-                * - The sda_def_user_groups view enforces user limitations from SinergiaCRM
-                * - Users are considered active if they either:
-                *   a) Have an entry in sda_def_user_groups
-                *   b) Are marked as active in sda_def_users but don't belong to any group (e.g., administrators)
+                * Retrieves users and their active status
                 */
                 await connection
                   .query(`
-                        SELECT 
-                          u.name,
-                          u.user_name as email,
-                          u.password,
-                          CASE 
-                              WHEN g.user_name IS NOT NULL THEN 1
-                              WHEN (g.user_name IS NULL AND u.active = 1) THEN 1
-                              ELSE 0
-                          END as active
-                        FROM sda_def_users u
-                        LEFT JOIN sda_def_user_groups g ON u.user_name = g.user_name
-                        WHERE u.password IS NOT NULL`
+                      SELECT name as name, user_name as email, password as password, active as active 
+                      FROM sda_def_users 
+                      WHERE password IS NOT NULL`
                       )
                   .then(async users => {
                     let users_crm = users;
                     /*
-                    * Retrieves EDA roles and groups based on active membership:
-                    * - Only includes groups/roles that have active users in sda_def_user_groups
-                    * - Excludes empty groups from sda_def_groups (which mirrors all SinergiaCRM groups)
-                    * - This ensures roles are only created in SDA when they have assigned users
+                    * Retrieves EDA roles and groups
                     */
                     await connection
                       .query(`
-                         SELECT
-                           "EDA_USER_ROLE" as role,
-                           b.name,
-                           "" as user_name
-                         FROM
-                           sda_def_groups b
-                         INNER JOIN sda_def_user_groups sdug ON sdug.name = b.name
-                         union
-                         SELECT
-                           "EDA_USER_ROLE" as role,
-                           g.name as name ,
-                           g.user_name
-                         FROM
-                           sda_def_user_groups g; `
+                      SELECT "EDA_USER_ROLE" AS role, b.name, "" AS user_name 
+                      FROM sda_def_groups b 
+                      UNION 
+                      SELECT "EDA_USER_ROLE" AS role, g.name AS name , g.user_name 
+                      FROM sda_def_user_groups g `
                       )
                       .then(async role => {
                         let roles = role;


### PR DESCRIPTION
## Descripción
Se elimina la restricción que limitaba la creación de usuarios en SinergiaDA solo a aquellos presentes en `sda_def_user_groups`. La sincronización ahora contempla todos los usuarios activos de SinergiaDA.

Esta modificación funciona en conjunto con la limitación existente en *rebuild* de SinergiaCRM que restringe la ejecución cuando hay más usuarios no administradores que los definidos en `$sugar_config['stic_sinergiada']['max_users_processed']`.

Adicionalmente, se optimiza la consulta que obtiene los Grupos de Seguridad que se sincronizan con SinergiaDA, filtrando por los existentes en la vista `sda_def_user_groups`.

## Cómo reproducirlo
1. Ejecutar update model
2. Verificar grupos SCRM_ presentes en SinergiaDA. Tienen que coincidir exactamente con los grupos presentes en la tabla `sda_def_user_groups`
3. Comprobar la creación de usuarios activos en SinergiaDA independientemente de su número

