### PR TITLE
Hotfix - API - Bug rangos en paneles anteriores a los rangos

### DIFF
--- a/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
@@ -94,10 +94,10 @@ export class MySqlBuilderService extends QueryBuilderService {
 
   public queryAddedRange(fields, myQuery) {
 
-    if(fields.find(field => field.ranges.length!==0)) {
+    if(fields.find(field => field.ranges?.length > 0)) {
 
       if(fields.find(field => field.aggregation_type === 'count_distinct' || field.aggregation_type === 'sum' || field.aggregation_type === 'count')) {
-        const fieldRango = fields.find(field => field.ranges.length!==0)
+        const fieldRango = fields.find(field => field.ranges.length > 0)
         myQuery = fieldRango.withRanges + myQuery + fieldRango.orderRanges;
         return myQuery
       } else {

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
@@ -398,7 +398,7 @@ export const PanelInteractionUtils = {
             handleColumn.ranges = contentColumn.ranges || false;
 
             // Si posee Rango el column_type debe ser de tipo 'text'
-            if(handleColumn.ranges.length!==0){
+            if(handleColumn.ranges.length > 0){
               handleColumn.column_type = 'text'
             }
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
@@ -395,7 +395,7 @@ export const PanelInteractionUtils = {
             handleColumn.joins = contentColumn.joins || [];
             handleColumn.ordenation_type = contentColumn.ordenation_type;
             handleColumn.autorelation = contentColumn.autorelation || false;
-            handleColumn.ranges = contentColumn.ranges;
+            handleColumn.ranges = contentColumn.ranges || false;
 
             // Si posee Rango el column_type debe ser de tipo 'text'
             if(handleColumn.ranges.length!==0){


### PR DESCRIPTION

## Descripción del Cambio
La comprobación que se hace para determinar si hay rangos no tenía en cuenta la posibilidad de que el panel fuera anterior y que no exisitiera la propiedad ranges en el campo. 
Se hace esa comprobación condicional. 


## Issue(s) resuelto(s)
- solves Isue comunidado por meet

## Pruebas a realizar para validar el cambio
Renderizar informes con paneles "antiguos" y comprobar que ya no falla.

## Información Adicional
