### PR TITLE
Enhancement - APP - Impedir guardar informe a usuarios sin permiso sobre cualquier panel o filtro 

### DIFF
--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -293,7 +293,10 @@ export class DashboardController {
 			
             const includesAdmin = req.user.role.includes("135792467811111111111110")
 
+            let is_filtered = false;
+
             if (!includesAdmin) {
+              console.log('epaaaaaaaaaAAAA AQUIIIII');
               try {
                 // Poso taules prohivides a false
                 if (uniquesForbiddenTables.length > 0) {
@@ -305,7 +308,8 @@ export class DashboardController {
                           toJson.ds.model.tables[x].table_name
                         )
                       ) {
-                        toJson.ds.model.tables[x].visible = false
+                        toJson.ds.model.tables[x].visible = false;
+                        is_filtered = true;
                       }
                     } catch (e) {
                       console.log('Error evaluating role permission')
@@ -348,10 +352,12 @@ export class DashboardController {
                       if (notAllowedColumns.length > 0) {
                         dashboard.config.panel[
                           i
-                        ].content.query.query.fields = MyFields
+                        ].content.query.query.fields = MyFields;
+                        is_filtered = true;
                       }
                     }
                   }
+                  
                 }
               } catch (error) {
 
@@ -360,11 +366,11 @@ export class DashboardController {
 
             }
 
-
             const ds = {
               _id: datasource._id,
               model: toJson.ds.model,
-              name: toJson.ds.metadata.model_name
+              name: toJson.ds.metadata.model_name,
+              is_filtered: is_filtered,
             }
 
             insertServerLog(
@@ -617,9 +623,6 @@ export class DashboardController {
         }
       }
     }
-    //console.log('Tablas prohividas para el grupo');
-    //console.log(forbiddenTables);
-
 
     /** allowed tables by security */
     if (dataModelObject.ds.metadata.model_granted_roles !== undefined) {

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -59,6 +59,7 @@ export class EdaBlankPanelComponent implements OnInit {
     @Output() remove: EventEmitter<any> = new EventEmitter();
     @Output() duplicate: EventEmitter<any> = new EventEmitter();
     @Output() action: EventEmitter<IPanelAction> = new EventEmitter<IPanelAction>();
+    @Output() notAllowedFilter: EventEmitter<any> = new EventEmitter();
 
     /** propietats que s'injecten al dialog amb les propietats específiques de cada gràfic. */
     public configController: EdaDialogController;
@@ -439,6 +440,7 @@ export class EdaBlankPanelComponent implements OnInit {
             try {
                 const response = await QueryUtils.switchAndRun(this, panelContent.query);
                 this.chartLabels = this.chartUtils.uniqueLabels(response[0]);
+                this.notAllowedFilter.emit(this.chartLabels); // Emitimos el valor de no permitido si fuera el caso.
                 this.chartData = response[1].map(item => item.map(a => a == null ? NULL_VALUE : a)); // canviem els null per valor customitzable
                 this.buildGlobalconfiguration(panelContent);
             } catch (err) {

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
@@ -44,10 +44,10 @@
     <ng-template #panelTemplate let-panel>
         <ng-container [ngSwitch]="panel.type">
 
-            <eda-blank-panel *ngSwitchCase="0" #edaPanel [panel]="panel" [inject]="inject" (remove)="onRemovePanel($event)" (action)="onPanelAction($event)" (duplicate)="onDuplicatePanel($event)" >
+            <eda-blank-panel *ngSwitchCase="0" #edaPanel [panel]="panel" [inject]="inject" (remove)="onRemovePanel($event)" (action)="onPanelAction($event)" (duplicate)="onDuplicatePanel($event)" (notAllowedFilter)="notAllowedFilterFunction($event)">
             </eda-blank-panel>
 
-            <eda-title-panel *ngSwitchCase="1" #edaPanel [id]="panel.id" [panel]="panel" [inject]="inject" (remove)="onRemovePanel($event)" (duplicate)="onDuplicatePanel($event)" class="eda-text-panel">
+            <eda-title-panel *ngSwitchCase="1" #edaPanel [id]="panel.id" [panel]="panel" [inject]="inject" (remove)="onRemovePanel($event)" (duplicate)="onDuplicatePanel($event)" class="eda-text-panel" (notAllowedFilter)="notAllowedFilterFunction($event)">
             </eda-title-panel>
 
         </ng-container>

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -109,6 +109,7 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
     public Seconds_to_refresh = $localize`:@@seconds_to_refresh:Intervalo de recarga`;
     public canIeditTooltip = $localize`:@@canIeditTooltip:Si esta opción está seleccionada sólo el propietario del informe y los administradores podrán guardar los cambios`;
     //public globalFilter: any;
+    public notDataAllowed: boolean = false;
 
     constructor(
         private router: Router,
@@ -564,12 +565,20 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
         const user = sessionStorage.getItem('user');
         const userID = JSON.parse(user)._id;
 
+        // Buscamos en todos los paneles si existe un con los campos vacios, lo cual indica que no tiene permisos para visualizar la data
+        if(this.panels.some(panel => panel.content?.query.query.fields.length===0)){
+            this.notDataAllowed=true;
+        }
+
         this.inject = {
             dataSource: this.dataSource,
             dashboard_id: this.dashboard.id,
             applyToAllfilter: this.applyToAllfilter,
-            isObserver: this.grups.filter(group => group.name === 'EDA_RO' && group.users.includes(userID)).length !== 0
+            isObserver: (this.grups.filter(group => group.name === 'EDA_RO' && group.users.includes(userID)).length !== 0) || this.notDataAllowed, // No permite la visibilidad a las opciones, depende de la variable notDataAllowed
         }
+        
+        // No permite la visibilidad al sidebar, depende de la variable notDataAllowed
+        this.display_v.edit_mode = !this.notDataAllowed;
     }
 
     private setPanelSizes(panel) {

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -560,6 +560,10 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
         });
     }
 
+    public notAllowedFilterFunction(event) {
+        if(event[0]==='noFilterAllowed') this.display_v.edit_mode = false;
+    }
+
     // Dashboard Panels
     private initializePanels(): void {
         const user = sessionStorage.getItem('user');

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -583,6 +583,11 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
         
         // No permite la visibilidad al sidebar, depende de la variable notDataAllowed
         this.display_v.edit_mode = !this.notDataAllowed;
+
+        // Verifica que el si el dashboard si esta filtrado o no. 
+        if(this.dashboard.datasSource.is_filtered) {
+            this.display_v.edit_mode = false;
+        }
     }
 
     private setPanelSizes(panel) {

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4305,11 +4305,11 @@
       </trans-unit>
       <trans-unit id="noDataAllowed">
         <source>Este panel no está disponible por falta de permisos</source>
-        <target>Aquest panell no està disponible per manca de permisos</target>
+        <target>Aquest panell no està disponible per manca de permisos, l'informe s'obre en mode de només lectura</target>
       </trans-unit>
       <trans-unit id="noFilterAllowed">
         <source>Este panel no está disponible por falta de permisos en un filtro</source>
-        <target>Aquest panell no està disponible per manca de permisos en un filtre</target>
+        <target>Aquest panell no està disponible per manca de permisos en un filtre, l'informe s'obre en mode de només lectura</target>
       </trans-unit>
       <trans-unit id="DatePickerYearPreviousYearFull">
         <source>El año pasado, completo</source>

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4305,11 +4305,11 @@
       </trans-unit>
       <trans-unit id="noDataAllowed">
         <source>Este panel no está disponible por falta de permisos</source>
-        <target>Aquest panell no està disponible per manca de permisos, l'informe s'obre en mode de només lectura</target>
+        <target>Aquest panell no està disponible per manca de permisos, l'informe s'obre en mode de només lectura.</target>
       </trans-unit>
       <trans-unit id="noFilterAllowed">
         <source>Este panel no está disponible por falta de permisos en un filtro</source>
-        <target>Aquest panell no està disponible per manca de permisos en un filtre, l'informe s'obre en mode de només lectura</target>
+        <target>Aquest panell no està disponible per manca de permisos en un filtre, l'informe s'obre en mode de només lectura.</target>
       </trans-unit>
       <trans-unit id="DatePickerYearPreviousYearFull">
         <source>El año pasado, completo</source>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4279,11 +4279,11 @@
       </trans-unit>
       <trans-unit id="noDataAllowed">
         <source>Este panel no está disponible por falta de permisos</source>
-        <target>This panel is not available due to lack of permissions, the report opens in read-only mode</target>
+        <target>This panel is not available due to lack of permissions, the report opens in read-only mode.</target>
       </trans-unit>
       <trans-unit id="noFilterAllowed">
         <source>Este panel no está disponible por falta de permisos en un filtro</source>
-        <target>This panel is not available due to lack of permissions on a filter, the report opens in read-only mode</target>
+        <target>This panel is not available due to lack of permissions on a filter, the report opens in read-only mode.</target>
       </trans-unit>
       <trans-unit id="DatePickerYearPreviousYearFull">
         <source>El año pasado, completo</source>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4279,11 +4279,11 @@
       </trans-unit>
       <trans-unit id="noDataAllowed">
         <source>Este panel no está disponible por falta de permisos</source>
-        <target>This panel is not available due to lack of permissions</target>
+        <target>This panel is not available due to lack of permissions, the report opens in read-only mode</target>
       </trans-unit>
       <trans-unit id="noFilterAllowed">
         <source>Este panel no está disponible por falta de permisos en un filtro</source>
-        <target>This panel is not available due to lack of permissions on a filter</target>
+        <target>This panel is not available due to lack of permissions on a filter, the report opens in read-only mode</target>
       </trans-unit>
       <trans-unit id="DatePickerYearPreviousYearFull">
         <source>El año pasado, completo</source>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4308,11 +4308,11 @@
       </trans-unit>
       <trans-unit id="noDataAllowed">
         <source>Este panel no está disponible por falta de permisos</source>
-        <target>Este panel no está disponible por falta de permisos</target>
+        <target>Este panel no está disponible por falta de permisos, el informe se abre en modo de solo lectura</target>
       </trans-unit>
       <trans-unit id="noFilterAllowed">
         <source>Este panel no está disponible por falta de permisos en un filtro</source>
-        <target>Este panel no está disponible por falta de permisos en un filtro</target>
+        <target>Este panel no está disponible por falta de permisos en un filtro, el informe se abre en modo de solo lectura</target>
       </trans-unit>
       <trans-unit id="DatePickerYearPreviousYearFull">
         <source>El año pasado, completo</source>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4308,11 +4308,11 @@
       </trans-unit>
       <trans-unit id="noDataAllowed">
         <source>Este panel no está disponible por falta de permisos</source>
-        <target>Este panel no está disponible por falta de permisos, el informe se abre en modo de solo lectura</target>
+        <target>Este panel no está disponible por falta de permisos, el informe se abre en modo de solo lectura.</target>
       </trans-unit>
       <trans-unit id="noFilterAllowed">
         <source>Este panel no está disponible por falta de permisos en un filtro</source>
-        <target>Este panel no está disponible por falta de permisos en un filtro, el informe se abre en modo de solo lectura</target>
+        <target>Este panel no está disponible por falta de permisos en un filtro, el informe se abre en modo de solo lectura.</target>
       </trans-unit>
       <trans-unit id="DatePickerYearPreviousYearFull">
         <source>El año pasado, completo</source>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -4309,11 +4309,11 @@
       </trans-unit>
       <trans-unit id="noDataAllowed">
         <source>Este panel no está disponible por falta de permisos</source>
-        <target>Este panel non está dispoñible por falta de permisos, o informe ábrese en modo de só lectura</target>
+        <target>Este panel non está dispoñible por falta de permisos, o informe ábrese en modo de só lectura.</target>
       </trans-unit>
       <trans-unit id="noFilterAllowed">
         <source>Este panel no está disponible por falta de permisos en un filtro</source>
-        <target>Este panel non está dispoñible debido á falta de permisos nun filtro, o informe ábrese en modo de só lectura</target>
+        <target>Este panel non está dispoñible debido á falta de permisos nun filtro, o informe ábrese en modo de só lectura.</target>
       </trans-unit>
       <trans-unit id="DatePickerYearPreviousYearFull">
         <source>El año pasado, completo</source>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -4309,11 +4309,11 @@
       </trans-unit>
       <trans-unit id="noDataAllowed">
         <source>Este panel no está disponible por falta de permisos</source>
-        <target>Este panel non está dispoñible por falta de permisos</target>
+        <target>Este panel non está dispoñible por falta de permisos, o informe ábrese en modo de só lectura</target>
       </trans-unit>
       <trans-unit id="noFilterAllowed">
         <source>Este panel no está disponible por falta de permisos en un filtro</source>
-        <target>Este panel non está dispoñible debido á falta de permisos nun filtro</target>
+        <target>Este panel non está dispoñible debido á falta de permisos nun filtro, o informe ábrese en modo de só lectura</target>
       </trans-unit>
       <trans-unit id="DatePickerYearPreviousYearFull">
         <source>El año pasado, completo</source>


### PR DESCRIPTION
Si no tienes permisos para ver un panel no tienes permisos para editar el informe no para guardarlo. Pasas a estar en modo read only


## Descripción del Cambio
Se comprueba en un dashboard si hay algún panel que no se pueda visualizar por permisos. Cómo que se quita la configuración del panel no se puede guardar porque se pierde la configuración. 

## Issue(s) resuelto(s)
- solves #204

## Pruebas a realizar para validar el cambio
Seguir las instrucciones descritas en el issue. 
1. Crear un informe con un usuario administrador con un panel con permisos.
2. Entrar al informe con un usuario que ni tiene permisos para ver ese panel.
3. Comprobar que no se puede guardar.


