### PR TITLE
Hotfix -  APP - Los filtros del informe van siempre al where

### DIFF
--- a/eda/eda_app/src/app/services/api/global-filters.service.ts
+++ b/eda/eda_app/src/app/services/api/global-filters.service.ts
@@ -331,7 +331,8 @@ export class GlobalFiltersService {
             isGlobal: true,
             applyToAll: globalFilter.applyToAll,
             autorelation: globalFilter.autorelation,
-            valueListSource: globalFilter.selectedColumn.valueListSource
+            valueListSource: globalFilter.selectedColumn.valueListSource,
+            filterBeforeGrouping: true, // Para todos los filtros globales es Where
         }
 
         return formatedFilter;


### PR DESCRIPTION
## Descripción del Cambio

Al hacer el cambio de los tipos de filtros aplicados se nos pasó definir el tipo de filtro que aplica para los  filtros generales del informe. ( where o having ). 

Los filtros generales del informe van naturalmente al where. Las fechas van al where. Los textos van al where y los números. Al ser una lista desplegable de  los valores existentes en bbdd van también al where. Quizás los valores se quisieran meter en el havign pero entonces habría que cambiar el tipo de filtro por un text input. 

## Issue(s) resuelto(s)
- solves  #278 

## Pruebas a realizar para validar el cambio
Realizar un informe con filltros de panel en el where y en el having y hacer filtros de informe.

