### PR TITLE
Hotfix - API - Deshacer filtrado por valores vacío en filtros  de informe

### DIFF
--- a/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
@@ -50,9 +50,9 @@ export class MySqlBuilderService extends QueryBuilderService {
     myQuery += this.getHavingFilters(havingFilters);
 
 
-    /**SDA CUSTOM */  if (forSelector === true) {
-    /**SDA CUSTOM */     myQuery += `\n UNION \n SELECT '' `;
-    /**SDA CUSTOM */   }
+    /**SDA CUSTOM */ // if (forSelector === true) {
+    /**SDA CUSTOM */ //    myQuery += `\n UNION \n SELECT '' `;
+    /**SDA CUSTOM */ //  }
 
 
     // OrderBy


### PR DESCRIPTION
## Descripción del Cambio
En este PR se comentan las lineas incluidas en el PR https://github.com/SinergiaTIC/SinergiaDA/pull/252 que forzaban la inclusión de un elemento de cadena vacía en todos los filtros de informe. 

Se deshace debido a que no funciona correctamente con los filtros de tipo numérico, como se indica en el issue https://github.com/SinergiaTIC/SinergiaDA/issues/282. Apesar de que se ha abordado en el PR https://github.com/SinergiaTIC/SinergiaDA/pull/285 la fucnionalidad no puede publicarse hasta que no esté verificado su correcto funcionamiento en los diferentes tipos de columna. 

## Pruebas a realizar para validar el cambio
- Verificar que no se fuerza la inclusión de valores vacíos en los filtros de informe, en ningún tipo de campo.
- Verificar de manera expresa que no se puede filtrar por un elemento vacío en alguna columna de tipo numérico, evitandose el error descrito en el Issue #282
