### PR TITLE
Hotfix -  API - Corregir error al crear fuente de datos MySQL

### DIFF
--- a/eda/eda_api/lib/services/connection/db-systems/mysql-connection.ts
+++ b/eda/eda_api/lib/services/connection/db-systems/mysql-connection.ts
@@ -57,28 +57,25 @@ export class MysqlConnection extends AbstractConnection {
         return createConnection(mySqlConn);
     }
 
+    // SDA CUSTOM - Change tryConnection to use mysql2/promise
     async tryConnection(): Promise<any> {
         try {
-            return new Promise((resolve, reject) => {
-                const mySqlConn ={ "host": this.config.host,    "port": this.config.port,     "database": this.config.database, "user": this.config.user, "password": this.config.password };
-                this.client = createConnection(mySqlConn);
-                console.log('\x1b[32m%s\x1b[0m', 'Connecting to MySQL database...\n');
-                this.client.connect((err:Error , connection: SqlConnection): void => {
-                    if (err) {
-                        return reject(err);
-                    }
-                    if (connection) {
-                        this.itsConnected();
-                        this.client.end();
-                        return resolve(connection);
-                    }
-                });
-            })
+            const mySqlConn ={ "host": this.config.host,    "port": this.config.port,     "database": this.config.database, "user": this.config.user, "password": this.config.password };
+            this.client = await createConnection(mySqlConn);
+            console.log('\x1b[32m%s\x1b[0m', 'Connecting to MySQL database...\n');
+            this.itsConnected();
 
+            // Close connection
+            await this.client.end();
+
+            return this.client;
+    
         } catch (err) {
+            console.log('\x1b[31m%s\x1b[0m', 'Error connecting to MySQL database\n');
             throw err;
         }
     }
+    // END SDA CUSTOM
 
     async generateDataModel(optimize:number, filter:string): Promise<any> {
         try {


### PR DESCRIPTION
## Descripción del Cambio
- solves #289

Se corrige el error detectado en el issue #289, este error estaba provocado porque la función _tryConnection()_ no se había adaptado para usar la librería `mysql2/promise`, que se cambió en el PR https://github.com/SinergiaTIC/SinergiaDA/pull/256. 
En los cambios se hace lo siguiente 
- Se elimina new Promise() ya que createConnection() ya devuelve una promesa
- Se usa await con createConnection() en lugar de usar callbacks
- Se elimina la llamada a .connect() ya que la conexión se establece automáticamente al crear la conexión con mysql2/promise
- Usé await con this.client.end() para cerrar la conexión de manera apropiada
- Se añade un mensaje de error en consola para el caso de que la conexión no pueda establecerse

Se ha comprobado que la función _tryConnection_ solamente se ejecuta al crear una nueva conexión o al pulsar el botón "Comprobar conexión" en una conexión ya existente, y se ha comprobado que no afectaba al establecimiento normal de la conexión de las fuentes de datos ya existentes.

## Pruebas a realizar para validar el cambio
- Con el código del PR, crear una conexión a una fuente de datos de MySQL y verificar que se establece correctamente
- Alterar algún dato de una conexión existente provocando el fallo de la conexión y verificar que el error es mostrado en la consola.

