### PR TITLE
Enhancement - APP - Incluir mapas de capas en SinergiaDA

### DIFF
--- a/eda/eda_app/src/app/module/pages/data-sources/data-source-detail/sda-data-source-detail.component.html
+++ b/eda/eda_app/src/app/module/pages/data-sources/data-source-detail/sda-data-source-detail.component.html
@@ -328,7 +328,7 @@
                     </div>
 
 
-            <div style="margin-bottom: 1rem;" class="col-12 hidden">
+            <div style="margin-bottom: 1rem;" class="col-12">
 
                 <h4 style="margin-bottom: 4px; border-bottom: 1px solid #d4d4d4;"> {{functionalities}} </h4>
 
@@ -336,9 +336,9 @@
 
                     <button pButton type="button" icon="pi pi-map" [label]="addMap" class="p-button-secondary"
                         (click)="openNewMapDialog()" style="margin-bottom: 1px;"> </button>
-                    <button pButton type="button" icon="pi pi-plus" [label]="addView" class="p-button-secondary"
+                    <button pButton type="button" icon="pi pi-plus" [label]="addView" class="p-button-secondary hidden"
                         (click)="openNewViewDialog()" style="margin-bottom: 1px;"> </button>
-                    <button pButton type="button" icon="pi pi-plus" [label]="addCSV" class="p-button-secondary"
+                    <button pButton type="button" icon="pi pi-plus" [label]="addCSV" class="p-button-secondary hidden"
                         (click)="openCSVDialog()" style="margin-bottom: 1px;"> </button>
                 </span>
             </div>


### PR DESCRIPTION
## Descripción del Cambio

Se incluye el apartado **Mapas** en la edición de las fuentes de datos. Anteriormente, esta opción estaba restringida porque se encontraba dentro de un bloque de código junto con **Añadir vista** y **Añadir tabla desde CSV**. La propiedad hidden se aplicaba a todo el bloque, impidiendo el acceso a la edición de Mapas.

Ahora, se ha reorganizado el código para que la restricción solo afecte a las opciones que no deben estar disponibles, permitiendo así la edición de Mapas.
