### PR TITLE
Hotfix - APP+API Error paneles SQL con Seguridad  + Impedir guardar informe a usuario sin permiso

### DIFF
--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -343,7 +343,13 @@ export class DashboardController {
                           is_filtered= true;
                         } 
                       }
-
+                      if(dashboard.config.panel[i].content.query.query.queryMode == 'SQL'){
+                        for(let j=0; j<uniquesForbiddenTables.length; j++ ){
+                          if ( dashboard.config.panel[i].content.query.query.SQLexpression.toUpperCase().indexOf( uniquesForbiddenTables[j].toUpperCase()   ) > 0  ) {  
+                            is_filtered= true;
+                          } 
+                        }
+                      }
                     }
                   }
                 }

--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -318,39 +318,27 @@ export class DashboardController {
                   // Oculto columnes als panells
                   for (let i = 0; i < dashboard.config.panel.length; i++) {
                     if (dashboard.config.panel[i].content != undefined) {
-                      let MyFields = []
-                      let notAllowedColumns = []
-                      for (
-                        let c = 0;
-                        c <
-                        dashboard.config.panel[i].content.query.query.fields
-                          .length;
-                        c++
-                      ) {
-                        if (
-                          uniquesForbiddenTables.includes(
-                            dashboard.config.panel[i].content.query.query.fields[
-                              c
-                            ].table_id
-                          )
-                        ) {
+                      let MyFields = [];
+                      let notAllowedColumns = [];
+
+                      for ( let c = 0; c < dashboard.config.panel[i].content.query.query.fields.length; c++ ) {
+                        if ( uniquesForbiddenTables.includes( dashboard.config.panel[i].content.query.query.fields[ c ].table_id.split('.')[0]  ) ) { /** split('.')[0]  esto se hace para el  filtro en modo arbol */
                           notAllowedColumns.push(
-                            dashboard.config.panel[i].content.query.query.fields[
-                            c
-                            ]
+                            dashboard.config.panel[i].content.query.query.fields[ c ]
                           )
                         } else {
                           MyFields.push(
-                            dashboard.config.panel[i].content.query.query.fields[
-                            c
-                            ]
+                            dashboard.config.panel[i].content.query.query.fields[ c ]
                           )
                         }
                       }
                       if (notAllowedColumns.length > 0) {
-                        dashboard.config.panel[
-                          i
-                        ].content.query.query.fields = MyFields;
+                        dashboard.config.panel[ i ].content.query.query.fields = MyFields;
+                        is_filtered= true;
+                      }
+                      // SI NO TENGO PERMISOS SOBRE LA TABLA PRINCIPAL DEL ARBOL NO VEO NADA 
+                      if( dashboard.config.panel[i].content.query.query.queryMode == 'EDA2'  &&  uniquesForbiddenTables.includes( dashboard.config.panel[i].content.query.query.rootTable ) ) {
+                        dashboard.config.panel[ i ].content.query.query.fields = [];
                         is_filtered= true;
                       }
                     }

--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -336,6 +336,14 @@ export class DashboardController {
                         dashboard.config.panel[ i ].content.query.query.fields = [];
                         is_filtered= true;
                       }
+
+                      // si no tengo permiso sobre los filtros.
+                      for ( let c = 0; c < dashboard.config.panel[i].content.query.query.filters.length; c++ ) {
+                        if ( uniquesForbiddenTables.includes( dashboard.config.panel[i].content.query.query.filters[c].filter_table.split('.')[0]   ) ) { /** split('.')[0]  esto se hace para el  filtro en modo arbol */
+                          is_filtered= true;
+                        } 
+                      }
+
                     }
                   }
                 }

--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -302,13 +302,8 @@ export class DashboardController {
                   // Poso taules prohivides a false
                   for (let x = 0; x < toJson.ds.model.tables.length; x++) {
                     try {
-                      if (
-                        uniquesForbiddenTables.includes(
-                          toJson.ds.model.tables[x].table_name
-                        )
-                      ) {
-                        toJson.ds.model.tables[x].visible = false
-                        is_filtered= true;
+                      if ( uniquesForbiddenTables.includes( toJson.ds.model.tables[x].table_name ) ) {
+                        toJson.ds.model.tables[x].visible = false;
                       }
                     } catch (e) {
                       console.log('Error evaluating role permission')
@@ -421,6 +416,7 @@ export class DashboardController {
         const createdAt=dashboard.config.createdAt
         dashboard.config = body.config
         dashboard.config.createdAt = createdAt
+        dashboard.user = req.user._id
         dashboard.group = body.group
         /**avoid dashboards without name */
         if (dashboard.config.title === null) { dashboard.config.title = '-' };

--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -1149,6 +1149,7 @@ export class DashboardController {
       /**Security check */
       const allowed = DashboardController.securityCheck(dataModel, req.user)
       if (!allowed) {
+        console.log('SQL Query not allowed by security');
         return next(
           new HttpException(
             500,
@@ -1196,7 +1197,7 @@ export class DashboardController {
           return next(new HttpException(500,'Queries in format "select x from A, B" are not suported'));
         }
 
-        console.log('\x1b[32m%s\x1b[0m', `QUERY for user ${req.user.name}, with ID: ${req.user._id},  at: ${formatDate(new Date())} `);
+        console.log('\x1b[32m%s\x1b[0m', `SQL QUERY for user ${req.user.name}, with ID: ${req.user._id},  at: ${formatDate(new Date())} `);
         console.log(query)
         console.log('\n-------------------------------------------------------------------------------\n');
 

--- a/eda/eda_app/angular.json
+++ b/eda/eda_app/angular.json
@@ -20,9 +20,6 @@
                     "ca": {
                         "translation": "src/locale/prod_messages.ca.xlf"
                     },
-                    "pl": {
-                        "translation": "src/locale/messages.pl.xlf"
-                    }, 
                     "gl": {
                         "translation": "src/locale/prod_messages.gl.xlf"
                     }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -247,9 +247,13 @@ export class EdaBlankPanelComponent implements OnInit {
 
                 if (modeSQL || queryMode=='SQL') {
                     this.currentSQLQuery = contentQuery.query.SQLexpression;
-
-                    this.sqlOriginTable = this.tables.filter(t => t.table_name === contentQuery.query.fields[0].table_id)
+                    try{
+                        this.sqlOriginTable = this.tables.filter(t => t.table_name === contentQuery.query.fields[0].table_id)
                         .map(table => ({ label: table.display_name.default, value: table.table_name }))[0];
+                    }catch(e){
+                        console.log('Si hay filtros de seguridad puede que no se encuentre la tabla de origen');
+                    }
+
                 }
 
                 this.loadChartsData(this.panel.content);

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
@@ -51,29 +51,36 @@ export const QueryUtils = {
         const response = await ebp.dashboardService.executeQuery(queryData).toPromise();
         return response;
       } else {
-        const response = await ebp.dashboardService.executeSqlQuery(query).toPromise();
+        let response = await ebp.dashboardService.executeSqlQuery(query).toPromise();
         const numFields = response[0].length;
         const types = new Array(numFields);
         types.fill(null);
-        for (let row = 0; row < response[1].length; row++) {
-          response[1][row].forEach((field, i) => {
-            if (types[i] === null) {
-              if (typeof field === 'number') {
-                types[i] = 'numeric';
-              } else if (typeof field === 'string') {
-                types[i] = 'text';
-              }
-            }
-          });
-          if (!types.includes(null)) {
-            break;
-          }
-        }
 
-        ebp.currentQuery = [];
-        types.forEach((type, i) => {
-          ebp.currentQuery.push(QueryUtils.createColumn(response[0][i], type, ebp.sqlOriginTable));
-        });
+        /** SI NO ESTA FILTRADO POR LA SEGURIDAD */
+        if( response.toString().indexOf( 'noDataAllowed' ) < 1 ) {
+          for (let row = 0; row < response[1].length; row++) {
+            response[1][row].forEach((field, i) => {
+              if (types[i] === null) {
+                if (typeof field === 'number') {
+                  types[i] = 'numeric';
+                } else if (typeof field === 'string') {
+                  types[i] = 'text';
+                }
+              }
+            });
+            if (!types.includes(null)) {
+              break;
+            }
+          }
+
+          ebp.currentQuery = [];
+          types.forEach((type, i) => {
+            ebp.currentQuery.push(QueryUtils.createColumn(response[0][i], type, ebp.sqlOriginTable));
+          });
+        }else{
+          //Not allowed data. Lo convierto en objeto.
+          response = [ ['noDataAllowed'],[]];
+        }
         return response;
       }
     } catch (err) {

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -579,6 +579,10 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
         
         // No permite la visibilidad al sidebar, depende de la variable notDataAllowed
         this.display_v.edit_mode = !this.notDataAllowed;
+        // Verifica que el si el dashboard si esta filtrado o no. 
+        if(this.dashboard.datasSource.is_filtered) {
+            this.display_v.edit_mode = false;
+        }
     }
 
     private setPanelSizes(panel) {

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -583,10 +583,6 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
         if(this.dashboard.datasSource.is_filtered) {
             this.display_v.edit_mode = false;
         }
-        // Si soy el propietario del informe se habilita todo el control.
-        if( this.dashboard.user == this.userService.user._id){
-            this.display_v.edit_mode = true;
-        }
     }
 
     private setPanelSizes(panel) {

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -664,16 +664,18 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
  * @returns  - el array de filtros del informe informando cual es oculto por la seguridad
  */
     private checkFiltersVisibility( filters, tables){
-        filters.forEach(  (f) => {
-            f.selectedColumn.visible =  ( 
-                  ( tables.filter((t)=> t.table_name == f.selectedTable.table_name   )[0]?.visible  == true )    &&
-                  ( tables.filter((t)=> t.table_name == f.selectedTable.table_name   )[0]?.columns.filter( (c)=>c.column_name == f.selectedColumn.column_name )[0]?.visible  == true )   
-                                        )
-            // si he puesto el valor a false deshabilito el que pueda gaurdar.
-            if(f.selectedColumn.visible  == false ){
-                this.notDataAllowed = true;
-            }
-        })
+        if(filters && filters.length >0 ){
+            filters.forEach(  (f) => {
+                f.selectedColumn.visible =  ( 
+                    ( tables.filter((t)=> t.table_name == f.selectedTable.table_name   )[0]?.visible  == true )    &&
+                    ( tables.filter((t)=> t.table_name == f.selectedTable.table_name   )[0]?.columns.filter( (c)=>c.column_name == f.selectedColumn.column_name )[0]?.visible  == true )   
+                                            )
+                // si he puesto el valor a false deshabilito el que pueda gaurdar.
+                if(f.selectedColumn.visible  == false ){
+                    this.notDataAllowed = true;
+                }
+            })
+        }
         return filters;
     }
 

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -109,6 +109,7 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
     public Seconds_to_refresh = $localize`:@@seconds_to_refresh:Intervalo de recarga`;
     public canIeditTooltip = $localize`:@@canIeditTooltip:Si esta opción está seleccionada sólo el propietario del informe y los administradores podrán guardar los cambios`;
     //public globalFilter: any;
+    public notDataAllowed: boolean = false;
 
     constructor(
         private router: Router,
@@ -564,12 +565,20 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
         const user = sessionStorage.getItem('user');
         const userID = JSON.parse(user)._id;
 
+        // Buscamos en todos los paneles si existe un con los campos vacios, lo cual indica que no tiene permisos para visualizar la data
+        if(this.panels.some(panel => panel.content?.query.query.fields.length===0)){
+            this.notDataAllowed=true;
+        }
+
         this.inject = {
             dataSource: this.dataSource,
             dashboard_id: this.dashboard.id,
             applyToAllfilter: this.applyToAllfilter,
-            isObserver: this.grups.filter(group => group.name === 'EDA_RO' && group.users.includes(userID)).length !== 0
+            isObserver: (this.grups.filter(group => group.name === 'EDA_RO' && group.users.includes(userID)).length !== 0) || this.notDataAllowed, // No permite la visibilidad a las opciones, depende de la variable notDataAllowed
         }
+        
+        // No permite la visibilidad al sidebar, depende de la variable notDataAllowed
+        this.display_v.edit_mode = !this.notDataAllowed;
     }
 
     private setPanelSizes(panel) {

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -583,6 +583,10 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
         if(this.dashboard.datasSource.is_filtered) {
             this.display_v.edit_mode = false;
         }
+        // Si soy el propietario del informe se habilita todo el control.
+        if( this.dashboard.user == this.userService.user._id){
+            this.display_v.edit_mode = true;
+        }
     }
 
     private setPanelSizes(panel) {

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -669,6 +669,10 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
                   ( tables.filter((t)=> t.table_name == f.selectedTable.table_name   )[0]?.visible  == true )    &&
                   ( tables.filter((t)=> t.table_name == f.selectedTable.table_name   )[0]?.columns.filter( (c)=>c.column_name == f.selectedColumn.column_name )[0]?.visible  == true )   
                                         )
+            // si he puesto el valor a false deshabilito el que pueda gaurdar.
+            if(f.selectedColumn.visible  == false ){
+                this.notDataAllowed = true;
+            }
         })
         return filters;
     }

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -393,7 +393,7 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
                     this.checkVisibility(res.dashboard);
                     me.setDashboardCreator(res.dashboard);
                     me.title = config.title; // Titul del dashboard, utilitzat per visualització
-                    me.gFilter.initGlobalFilters(config.filters||[]); // Filtres del dashboard
+                    me.gFilter.initGlobalFilters(   this.checkFiltersVisibility( config.filters , res.datasource.model.tables ) ||[]); // Filtres del dashboard
                     me.dataSource = res.datasource; // DataSource del dashboard
                     me.datasourceName = res.datasource.name;
                     me.applyToAllfilter = config.applyToAllfilter || { present: false, refferenceTable: null, id: null };
@@ -417,13 +417,6 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
                     if (config.visible === 'group' && res.dashboard.group) {
                         grp = res.dashboard.group;
                     }
-
-
-/**SDA CUSTOM */    if(  res.datasource.hasOwnProperty('is_filtered') &&  res.datasource.is_filtered == true){
-/**SDA CUSTOM */        if (res.dashboard.config.panel){
-/**SDA CUSTOM */            res.dashboard.config.panel = res.dashboard.config.panel.filter( (p)=> p.content.query.query.queryMode != 'SQL' )
-/**SDA CUSTOM */       }
-/**SDA CUSTOM */    }
 
                     // Si el dashboard no te cap panel es crea un automatic
                     if (!res.dashboard.config.panel) {
@@ -660,6 +653,24 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
         }catch(e){
             // todavia no se han seteado me.grups o me.dashboard.goup.
         }
+    }
+
+
+
+/** 
+ * Comprueba la configuración de seguridad de los filtros y pone la columna a invisible si el filtro no es visible para el usuario por motivos de filtro de seguridad
+ * @param filters - recibe el array de filtros del informe
+ * @param tables - recibe el array de tablas del modelo.
+ * @returns  - el array de filtros del informe informando cual es oculto por la seguridad
+ */
+    private checkFiltersVisibility( filters, tables){
+        filters.forEach(  (f) => {
+            f.selectedColumn.visible =  ( 
+                  ( tables.filter((t)=> t.table_name == f.selectedTable.table_name   )[0]?.visible  == true )    &&
+                  ( tables.filter((t)=> t.table_name == f.selectedTable.table_name   )[0]?.columns.filter( (c)=>c.column_name == f.selectedColumn.column_name )[0]?.visible  == true )   
+                                        )
+        })
+        return filters;
     }
 
     private checkVisibility(dashboard) {

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.html
@@ -17,13 +17,13 @@
 
     
         <div *ngFor="let filter of globalFilters" class="filter-set d-flex align-items-center">
-            <span *ngIf="isAdmin || isDashboardCreator || ['public', 'readOnly'].includes(filter.visible)" class="filter-name filters-size">
+            <span *ngIf="( isAdmin || isDashboardCreator || ['public', 'readOnly'].includes(filter.visible) )  &&  filter.selectedColumn.visible " class="filter-name filters-size">
                 {{getFilterLabel(filter)}}:
             </span>
             
             
             <ng-container 
-            *ngIf="isAdmin || isDashboardCreator || ['public', 'readOnly'].includes(filter.visible)" 
+            *ngIf="( isAdmin || isDashboardCreator ||   ['public', 'readOnly'].includes(filter.visible) ) &&  filter.selectedColumn.visible  " 
             [ngSwitch]="getFilterType(filter)" >
                 <div *ngSwitchCase="'date'">
                     <eda-date-picker 
@@ -44,7 +44,7 @@
                 </div>
                 <div *ngSwitchDefault>
                     <!-- {{ filter | json }} -->
-                    <p-multiSelect *ngIf="filter.data && (isAdmin || isDashboardCreator || filter.visible === 'public' || filter.visible === 'readOnly' ) "
+                    <p-multiSelect *ngIf="filter.data && ( isAdmin || isDashboardCreator ||   ['public', 'readOnly'].includes(filter.visible) ) &&  filter.selectedColumn.visible"
                         [options]="filter.data"
                         [(ngModel)]="filter.selectedItems"
                         [maxSelectedLabels]="3"

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4305,11 +4305,11 @@
       </trans-unit>
       <trans-unit id="noDataAllowed">
         <source>Este panel no está disponible por falta de permisos</source>
-        <target>Aquest panell no està disponible per manca de permisos</target>
+        <target>Aquest panell no està disponible per manca de permisos, l'informe s'obre en mode de només lectura</target>
       </trans-unit>
       <trans-unit id="noFilterAllowed">
         <source>Este panel no está disponible por falta de permisos en un filtro</source>
-        <target>Aquest panell no està disponible per manca de permisos en un filtre</target>
+        <target>Aquest panell no està disponible per manca de permisos en un filtre, l'informe s'obre en mode de només lectura</target>
       </trans-unit>
       <trans-unit id="DatePickerYearPreviousYearFull">
         <source>El año pasado, completo</source>

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4305,11 +4305,11 @@
       </trans-unit>
       <trans-unit id="noDataAllowed">
         <source>Este panel no está disponible por falta de permisos</source>
-        <target>Aquest panell no està disponible per manca de permisos, l'informe s'obre en mode de només lectura</target>
+        <target>Aquest panell no està disponible per manca de permisos, l'informe s'obre en mode de només lectura.</target>
       </trans-unit>
       <trans-unit id="noFilterAllowed">
         <source>Este panel no está disponible por falta de permisos en un filtro</source>
-        <target>Aquest panell no està disponible per manca de permisos en un filtre, l'informe s'obre en mode de només lectura</target>
+        <target>Aquest panell no està disponible per manca de permisos en un filtre, l'informe s'obre en mode de només lectura.</target>
       </trans-unit>
       <trans-unit id="DatePickerYearPreviousYearFull">
         <source>El año pasado, completo</source>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4279,11 +4279,11 @@
       </trans-unit>
       <trans-unit id="noDataAllowed">
         <source>Este panel no está disponible por falta de permisos</source>
-        <target>This panel is not available due to lack of permissions, the report opens in read-only mode</target>
+        <target>This panel is not available due to lack of permissions, the report opens in read-only mode.</target>
       </trans-unit>
       <trans-unit id="noFilterAllowed">
         <source>Este panel no está disponible por falta de permisos en un filtro</source>
-        <target>This panel is not available due to lack of permissions on a filter, the report opens in read-only mode</target>
+        <target>This panel is not available due to lack of permissions on a filter, the report opens in read-only mode.</target>
       </trans-unit>
       <trans-unit id="DatePickerYearPreviousYearFull">
         <source>El año pasado, completo</source>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4279,11 +4279,11 @@
       </trans-unit>
       <trans-unit id="noDataAllowed">
         <source>Este panel no está disponible por falta de permisos</source>
-        <target>This panel is not available due to lack of permissions</target>
+        <target>This panel is not available due to lack of permissions, the report opens in read-only mode</target>
       </trans-unit>
       <trans-unit id="noFilterAllowed">
         <source>Este panel no está disponible por falta de permisos en un filtro</source>
-        <target>This panel is not available due to lack of permissions on a filter</target>
+        <target>This panel is not available due to lack of permissions on a filter, the report opens in read-only mode</target>
       </trans-unit>
       <trans-unit id="DatePickerYearPreviousYearFull">
         <source>El año pasado, completo</source>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4308,11 +4308,11 @@
       </trans-unit>
       <trans-unit id="noDataAllowed">
         <source>Este panel no está disponible por falta de permisos</source>
-        <target>Este panel no está disponible por falta de permisos</target>
+        <target>Este panel no está disponible por falta de permisos, el informe se abre en modo de solo lectura</target>
       </trans-unit>
       <trans-unit id="noFilterAllowed">
         <source>Este panel no está disponible por falta de permisos en un filtro</source>
-        <target>Este panel no está disponible por falta de permisos en un filtro</target>
+        <target>Este panel no está disponible por falta de permisos en un filtro, el informe se abre en modo de solo lectura</target>
       </trans-unit>
       <trans-unit id="DatePickerYearPreviousYearFull">
         <source>El año pasado, completo</source>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4308,11 +4308,11 @@
       </trans-unit>
       <trans-unit id="noDataAllowed">
         <source>Este panel no está disponible por falta de permisos</source>
-        <target>Este panel no está disponible por falta de permisos, el informe se abre en modo de solo lectura</target>
+        <target>Este panel no está disponible por falta de permisos, el informe se abre en modo de solo lectura.</target>
       </trans-unit>
       <trans-unit id="noFilterAllowed">
         <source>Este panel no está disponible por falta de permisos en un filtro</source>
-        <target>Este panel no está disponible por falta de permisos en un filtro, el informe se abre en modo de solo lectura</target>
+        <target>Este panel no está disponible por falta de permisos en un filtro, el informe se abre en modo de solo lectura.</target>
       </trans-unit>
       <trans-unit id="DatePickerYearPreviousYearFull">
         <source>El año pasado, completo</source>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -4309,11 +4309,11 @@
       </trans-unit>
       <trans-unit id="noDataAllowed">
         <source>Este panel no está disponible por falta de permisos</source>
-        <target>Este panel non está dispoñible por falta de permisos, o informe ábrese en modo de só lectura</target>
+        <target>Este panel non está dispoñible por falta de permisos, o informe ábrese en modo de só lectura.</target>
       </trans-unit>
       <trans-unit id="noFilterAllowed">
         <source>Este panel no está disponible por falta de permisos en un filtro</source>
-        <target>Este panel non está dispoñible debido á falta de permisos nun filtro, o informe ábrese en modo de só lectura</target>
+        <target>Este panel non está dispoñible debido á falta de permisos nun filtro, o informe ábrese en modo de só lectura.</target>
       </trans-unit>
       <trans-unit id="DatePickerYearPreviousYearFull">
         <source>El año pasado, completo</source>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -4309,11 +4309,11 @@
       </trans-unit>
       <trans-unit id="noDataAllowed">
         <source>Este panel no está disponible por falta de permisos</source>
-        <target>Este panel non está dispoñible por falta de permisos</target>
+        <target>Este panel non está dispoñible por falta de permisos, o informe ábrese en modo de só lectura</target>
       </trans-unit>
       <trans-unit id="noFilterAllowed">
         <source>Este panel no está disponible por falta de permisos en un filtro</source>
-        <target>Este panel non está dispoñible debido á falta de permisos nun filtro</target>
+        <target>Este panel non está dispoñible debido á falta de permisos nun filtro, o informe ábrese en modo de só lectura</target>
       </trans-unit>
       <trans-unit id="DatePickerYearPreviousYearFull">
         <source>El año pasado, completo</source>


### PR DESCRIPTION

## Descripción del Cambio
Este PR es la conjunción del PR#288 y el PR#277 que van íntimamente ligados.

Descripción general del cambio. Ahora. Cuando un usuario carga un informe y se le aplican seguridad se informa al dashboard de forma general ( antes no se hacía así para proteger la información de que se estaba aplicando seguridad).  Cuando hay algún filtro que impide ver alguna columna de algún panel algún filtro del informe, etc. Cualquier filtro de seguridad que suponga alterar el normal funcionamiento del informe no permite guardarlo. Lo pode en modo consulta sólo. 

Por otro lado se ha cambiado el comportamiento de las consultas SQL  para que se aplique la seguridad "modo SinergiaDA" en vez del modo EDA. No se aplica sobre todas las tablas relacionadas que tienen seguridad sinó que "solo" se aplica a las tablas que se usan en la consulta.

## Issue(s) resuelto(s)

- solves  #204 y  #282

## Pruebas a realizar para validar el cambio
Para las consultas SQL:
Realizar informes con paneles SQL y comprobar la consulta SQL que se genera para validar que es correcta y se le aplican correctamente los filtros. Igualmente tampoco puede guardar el informe. 


Para las comprobaciones del issue 204:

Crear un informe con un usuario administrador con un panel con permisos.
Entrar al informe con un usuario que ni tiene permisos para ver ese panel.
Comprobar que no se puede guardar.
Comprobar que tampoco puede guardar si los filtros no son visibles.


