### PR TITLE
 Hotfix - API - Error en construcción de queries para filtros de campos desplegables :: Retro-compatibilidad

### DIFF
--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -921,6 +921,7 @@ export class DashboardController {
 
 
       /** por compatibilidad. Si no tengo el tipo de columna en el filtro lo añado */
+      /** por compatibilidad. Si no tengo el el tipo de agregación en el filtro.....*/
       if(myQuery.filters){
         for (const filter of myQuery.filters) {
           if (!filter.filter_column_type) {
@@ -930,6 +931,10 @@ export class DashboardController {
               const filterColumn = filterTable.columns.find((c) => c.column_name == filter.filter_column);
               filter.filter_column_type = filterColumn?.column_type || 'text';
             }
+          }
+          /** por compatibilidad. Si no tengo el el tipo de agregación en el filtro lo pongo en el where*/ 
+          if(! filter.hasOwnProperty('filterBeforeGrouping') ){
+            filter.filterBeforeGrouping = true;
           }
         }
       }


### PR DESCRIPTION

## Descripción del Cambio
Tras la incorporación  de la posibilidad de elegir donde se hace el filtro. En el where o en el having. No se ha tenido en cuenta la retro-compatibilidad con informes hechos con el sistema antiguo. Se añade una opción por defecto por la cual, si el campo no está informado se informa automáticamente cómo filtro de where. Que es la única opción disponible en los informes antiguos.

## Issue(s) resuelto(s)
<!-- Indicar el #<número> del/los issues resiueltos por este Pull Request -->
- solves  #296 


## Pruebas a realizar para validar el cambio
Las descritas en el issue. Hacer un informe con un filtro en la rama master y despues intentar ejecutarlo en la rama reporting.

