### PR TITLE
Hotfix - APP - Traducir cadena del login

### DIFF
--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -49,7 +49,7 @@
       </trans-unit>
       <trans-unit id="passwordLogin" datatype="html">
         <source>Contraseña</source>
-        <target>Contrasenya</target>
+        <target>Contraseña</target>
       </trans-unit>
       <trans-unit id="aggTmean">
         <source>Media</source>


### PR DESCRIPTION
## Descripción del Cambio
Se ha corregido la traducción de la cadena `passwordLogin` en el archivo de español:  `eda/eda_app/src/locale/stic_messages.es.xlf`. La traducción anterior era incorrecta, por lo que se ha actualizado con la versión correcta.

