### PR TITLE
Hotfix - APP - Corrección de visibilidad de filtros en informes EDA y modo árbol. 

### DIFF
--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -141,6 +141,8 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
 
     // ng cycle lives
     public ngOnInit(): void {
+
+      console.log('abc');
         this.dashboard = new Dashboard({});
 
         this.initializeDashboard();
@@ -393,6 +395,7 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
                     this.checkVisibility(res.dashboard);
                     me.setDashboardCreator(res.dashboard);
                     me.title = config.title; // Titul del dashboard, utilitzat per visualització
+                    console.log('recuperando DS');
                     me.gFilter.initGlobalFilters(   this.checkFiltersVisibility( config.filters , res.datasource.model.tables ) ||[]); // Filtres del dashboard
                     me.dataSource = res.datasource; // DataSource del dashboard
                     me.datasourceName = res.datasource.name;
@@ -576,10 +579,10 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
             applyToAllfilter: this.applyToAllfilter,
             isObserver: (this.grups.filter(group => group.name === 'EDA_RO' && group.users.includes(userID)).length !== 0) || this.notDataAllowed, // No permite la visibilidad a las opciones, depende de la variable notDataAllowed
         }
-        
+
         // No permite la visibilidad al sidebar, depende de la variable notDataAllowed
         this.display_v.edit_mode = !this.notDataAllowed;
-        // Verifica que el si el dashboard si esta filtrado o no. 
+        // Verifica que el si el dashboard si esta filtrado o no.
         if(this.dashboard.datasSource.is_filtered) {
             this.display_v.edit_mode = false;
         }
@@ -661,25 +664,42 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
 
 
 
-/** 
+/**
  * Comprueba la configuración de seguridad de los filtros y pone la columna a invisible si el filtro no es visible para el usuario por motivos de filtro de seguridad
  * @param filters - recibe el array de filtros del informe
  * @param tables - recibe el array de tablas del modelo.
  * @returns  - el array de filtros del informe informando cual es oculto por la seguridad
  */
     private checkFiltersVisibility( filters, tables){
+      console.log('filters',filters);
+      console.log('tables', tables);
+
         if(filters && filters.length >0 ){
-            filters.forEach(  (f) => {
-                f.selectedColumn.visible =  ( 
-                    ( tables.filter((t)=> t.table_name == f.selectedTable.table_name   )[0]?.visible  == true )    &&
-                    ( tables.filter((t)=> t.table_name == f.selectedTable.table_name   )[0]?.columns.filter( (c)=>c.column_name == f.selectedColumn.column_name )[0]?.visible  == true )   
-                                            )
-                // si he puesto el valor a false deshabilito el que pueda gaurdar.
-                if(f.selectedColumn.visible  == false ){
-                    this.notDataAllowed = true;
-                }
-            })
+          filters.forEach((f) => {
+            if (f.selectedColumn && f.selectedTable) {
+              f.selectedColumn.visible = (
+                (tables.filter((t) => t.table_name == f.selectedTable.table_name)[0]?.visible == true) &&
+                (tables.filter((t) => t.table_name == f.selectedTable.table_name)[0]?.columns.filter((c) => c.column_name == f.selectedColumn.column_name)[0]?.visible == true)
+              )
+              // si he puesto el valor a false deshabilito el que pueda guardar.
+              if (f.selectedColumn.visible == false) {
+                this.notDataAllowed = true;
+              }
+            } else {
+              f.column.value.visible = (
+                (tables.filter((t) => t.table_name == f.table.label)[0]?.visible == true) &&
+                (tables.filter((t) => t.table_name == f.table.label)[0]?.columns.filter((c) => c.column_name == f.column.value.column_name)[0]?.visible == true)
+              )
+              // si he puesto el valor a false deshabilito el que pueda guardar.
+              if (f.column.value.visible == false) {
+                this.notDataAllowed = true;
+              }
+            }
+          })
         }
+      console.log('filters2',filters);
+      console.log('tables2', tables);
+
         return filters;
     }
 

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -576,10 +576,10 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
             applyToAllfilter: this.applyToAllfilter,
             isObserver: (this.grups.filter(group => group.name === 'EDA_RO' && group.users.includes(userID)).length !== 0) || this.notDataAllowed, // No permite la visibilidad a las opciones, depende de la variable notDataAllowed
         }
-
+        
         // No permite la visibilidad al sidebar, depende de la variable notDataAllowed
         this.display_v.edit_mode = !this.notDataAllowed;
-        // Verifica que el si el dashboard si esta filtrado o no.
+        // Verifica que el si el dashboard si esta filtrado o no. 
         if(this.dashboard.datasSource.is_filtered) {
             this.display_v.edit_mode = false;
         }
@@ -661,7 +661,7 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
 
 
 
-/**
+/** 
  * Comprueba la configuración de seguridad de los filtros y pone la columna a invisible si el filtro no es visible para el usuario por motivos de filtro de seguridad
  * @param filters - recibe el array de filtros del informe
  * @param tables - recibe el array de tablas del modelo.

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -670,18 +670,18 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
     private checkFiltersVisibility( filters, tables){
         if(filters && filters.length >0 ){
             filters.forEach(  (f) => {
-        // Check if filter is designed in EDA2 mode (tree mode)
+        /*SDA CUSTOM*/ // Check if filter is designed in EDA2 mode (tree mode)
         /*SDA CUSTOM*/ if (f.selectedColumn && f.selectedTable) {
                 f.selectedColumn.visible =  (
                     ( tables.filter((t)=> t.table_name == f.selectedTable.table_name)[0]?.visible  == true )    &&
                     ( tables.filter((t)=> t.table_name == f.selectedTable.table_name)[0]?.columns.filter( (c)=>c.column_name == f.selectedColumn.column_name )[0]?.visible  == true )
                                             )
-          // Check if the column is not visible and is not admin then limit hide side bar functionality
+          /*SDA CUSTOM*/ // Check if the column is not visible and is not admin then limit hide side bar functionality
           if (f.selectedColumn.visible == false && !this.userService.isAdmin) {
             this.notDataAllowed = true;
           }
         /*SDA CUSTOM*/ }
-        // if selectedColumn is not defined, the filter is designed in EDA mode
+        /*SDA CUSTOM*/ // if selectedColumn is not defined, the filter is designed in EDA mode
         /*SDA CUSTOM*/ else {
         /*SDA CUSTOM*/   f.column.value.visible = (
         /*SDA CUSTOM*/     (tables.filter((t) => t.table_name == f.table.value)[0]?.visible == true) &&

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -141,7 +141,6 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
 
     // ng cycle lives
     public ngOnInit(): void {
-
         this.dashboard = new Dashboard({});
 
         this.initializeDashboard();
@@ -394,7 +393,6 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
                     this.checkVisibility(res.dashboard);
                     me.setDashboardCreator(res.dashboard);
                     me.title = config.title; // Titul del dashboard, utilitzat per visualització
-                    console.log('recuperando DS');
                     me.gFilter.initGlobalFilters(   this.checkFiltersVisibility( config.filters , res.datasource.model.tables ) ||[]); // Filtres del dashboard
                     me.dataSource = res.datasource; // DataSource del dashboard
                     me.datasourceName = res.datasource.name;
@@ -671,34 +669,34 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
  */
     private checkFiltersVisibility( filters, tables){
         if(filters && filters.length >0 ){
-          filters.forEach((f) => {
-            // Check if filter is designed in EDA2 mode (tree mode)
-            if (f.selectedColumn && f.selectedTable) {
-              f.selectedColumn.visible = (
-                (tables.filter((t) => t.table_name == f.selectedTable.table_name)[0]?.visible == true) &&
-                (tables.filter((t) => t.table_name == f.selectedTable.table_name)[0]?.columns.filter((c) => c.column_name == f.selectedColumn.column_name)[0]?.visible == true)
-              )
-              // Check if the column is not visible and is not admin then limit hide side bar functionality
-              if (f.selectedColumn.visible == false && !this.userService.isAdmin) {
-                this.notDataAllowed = true;
-              }
-            }
-            // if selectedColumn is not defined, the filter is designed in EDA mode
-            else {
-              f.column.value.visible = (
-                (tables.filter((t) => t.table_name == f.table.label)[0]?.visible == true) &&
-                (tables.filter((t) => t.table_name == f.table.label)[0]?.columns.filter((c) => c.column_name == f.column.value.column_name)[0]?.visible == true)
-              )
-              // Check if the column is not visible and is not admin then limit hide side bar functionality
-              if (f.column.value.visible == false && !this.userService.isAdmin) {
-                this.notDataAllowed = true;
-              }
-            }
-          })
-        }
-
-        return filters;
+            filters.forEach(  (f) => {
+        // Check if filter is designed in EDA2 mode (tree mode)
+        /*SDA CUSTOM*/ if (f.selectedColumn && f.selectedTable) {
+                f.selectedColumn.visible =  (
+                    ( tables.filter((t)=> t.table_name == f.selectedTable.table_name)[0]?.visible  == true )    &&
+                    ( tables.filter((t)=> t.table_name == f.selectedTable.table_name)[0]?.columns.filter( (c)=>c.column_name == f.selectedColumn.column_name )[0]?.visible  == true )
+                                            )
+          // Check if the column is not visible and is not admin then limit hide side bar functionality
+          if (f.selectedColumn.visible == false && !this.userService.isAdmin) {
+            this.notDataAllowed = true;
+          }
+        /*SDA CUSTOM*/ }
+        // if selectedColumn is not defined, the filter is designed in EDA mode
+        /*SDA CUSTOM*/ else {
+        /*SDA CUSTOM*/   f.column.value.visible = (
+        /*SDA CUSTOM*/     (tables.filter((t) => t.table_name == f.table.value)[0]?.visible == true) &&
+        /*SDA CUSTOM*/     (tables.filter((t) => t.table_name == f.table.value)[0]?.columns.filter((c) => c.column_name == f.column.value.column_name)[0]?.visible == true)
+        /*SDA CUSTOM*/   )
+        /*SDA CUSTOM*/   // Check if the column is not visible and is not admin then limit hide side bar functionality
+        /*SDA CUSTOM*/   if (f.column.value.visible == false && !this.userService.isAdmin) {
+        /*SDA CUSTOM*/     this.notDataAllowed = true;
+        /*SDA CUSTOM*/   }
+        /*SDA CUSTOM*/ }
+      })
     }
+
+    return filters;
+  }
 
     private checkVisibility(dashboard) {
         if (!this.display_v.anonimous_mode && dashboard.config.visible !== 'shared') {

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -142,7 +142,6 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
     // ng cycle lives
     public ngOnInit(): void {
 
-      console.log('abc');
         this.dashboard = new Dashboard({});
 
         this.initializeDashboard();
@@ -671,11 +670,6 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
  * @returns  - el array de filtros del informe informando cual es oculto por la seguridad
  */
     private checkFiltersVisibility( filters, tables){
-      console.log('filters',filters);
-      console.log('tables', tables);
-      console.log('isAdmin', this.canIedit());
-
-
         if(filters && filters.length >0 ){
           filters.forEach((f) => {
             // Check if filter is designed in EDA2 mode (tree mode)
@@ -684,8 +678,8 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
                 (tables.filter((t) => t.table_name == f.selectedTable.table_name)[0]?.visible == true) &&
                 (tables.filter((t) => t.table_name == f.selectedTable.table_name)[0]?.columns.filter((c) => c.column_name == f.selectedColumn.column_name)[0]?.visible == true)
               )
-              // si he puesto el valor a false deshabilito el que pueda guardar.
-              if (f.selectedColumn.visible == false) {
+              // Check if the column is not visible and is not admin then limit hide side bar functionality
+              if (f.selectedColumn.visible == false && !this.userService.isAdmin) {
                 this.notDataAllowed = true;
               }
             }
@@ -695,15 +689,13 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
                 (tables.filter((t) => t.table_name == f.table.label)[0]?.visible == true) &&
                 (tables.filter((t) => t.table_name == f.table.label)[0]?.columns.filter((c) => c.column_name == f.column.value.column_name)[0]?.visible == true)
               )
-              // si he puesto el valor a false deshabilito el que pueda guardar.
-              if (f.column.value.visible == false) {
+              // Check if the column is not visible and is not admin then limit hide side bar functionality
+              if (f.column.value.visible == false && !this.userService.isAdmin) {
                 this.notDataAllowed = true;
               }
             }
           })
         }
-      console.log('filters2',filters);
-      console.log('tables2', tables);
 
         return filters;
     }

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -673,9 +673,12 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
     private checkFiltersVisibility( filters, tables){
       console.log('filters',filters);
       console.log('tables', tables);
+      console.log('isAdmin', this.canIedit());
+
 
         if(filters && filters.length >0 ){
           filters.forEach((f) => {
+            // Check if filter is designed in EDA2 mode (tree mode)
             if (f.selectedColumn && f.selectedTable) {
               f.selectedColumn.visible = (
                 (tables.filter((t) => t.table_name == f.selectedTable.table_name)[0]?.visible == true) &&
@@ -685,7 +688,9 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
               if (f.selectedColumn.visible == false) {
                 this.notDataAllowed = true;
               }
-            } else {
+            }
+            // if selectedColumn is not defined, the filter is designed in EDA mode
+            else {
               f.column.value.visible = (
                 (tables.filter((t) => t.table_name == f.table.label)[0]?.visible == true) &&
                 (tables.filter((t) => t.table_name == f.table.label)[0]?.columns.filter((c) => c.column_name == f.column.value.column_name)[0]?.visible == true)

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.html
@@ -2,75 +2,75 @@
 <!-- GLOBAL FILTERS  -->
 <!-- ============================================================== -->
 <div [ngClass]="{'noShow': hideFilters }" >
-    <!--   panel mode es per quan vull mostrat nomes un panell-->
-    <div *ngIf="globalFilters.length > 0" class="d-flex align-items-end" style="margin: 0.5em; gap: 10px; flex-wrap: wrap;" >
-        <button
-            *ngIf="isAdmin || isDashboardCreator || filterButtonVisibility.public"
-            id="dashFilterBtn"
-            [label]="filtrar"
-            pButton pRipple type="button"
-            icon="pi pi-filter"
-            style="height: 36px; min-width: 80px;"
-            (click)="dashboard.reloadPanelsWithTimeOut()"
-            class="p-button-raised p-button-outlined filters-size">
-        </button>
+  <!--   panel mode es per quan vull mostrat nomes un panell-->
+  <div *ngIf="globalFilters.length > 0" class="d-flex align-items-end" style="margin: 0.5em; gap: 10px; flex-wrap: wrap;" >
+      <button
+          *ngIf="isAdmin || isDashboardCreator || filterButtonVisibility.public"
+          id="dashFilterBtn"
+          [label]="filtrar"
+          pButton pRipple type="button"
+          icon="pi pi-filter"
+          style="height: 36px; min-width: 80px;"
+          (click)="dashboard.reloadPanelsWithTimeOut()"
+          class="p-button-raised p-button-outlined filters-size">
+      </button>
 
-    
-        <div *ngFor="let filter of globalFilters" class="filter-set d-flex align-items-center">
-            <span *ngIf="( isAdmin || isDashboardCreator || ['public', 'readOnly'].includes(filter.visible) )  &&  filter.selectedColumn.visible " class="filter-name filters-size">
-                {{getFilterLabel(filter)}}:
-            </span>
-            
-            
-            <ng-container 
-            *ngIf="( isAdmin || isDashboardCreator ||   ['public', 'readOnly'].includes(filter.visible) ) &&  filter.selectedColumn.visible  " 
-            [ngSwitch]="getFilterType(filter)" >
-                <div *ngSwitchCase="'date'">
-                    <eda-date-picker 
-                        [autoClear]="true"
-                        [inject]="datePickerConfigs[filter.id]"
-                        (onRemove)="removeGlobalFilter(filter, true)"
-                        (onDatesChanges)="processPickerEvent($event, filter)">
-        
-                        <ng-container footer>
-                            <button id="dashFilterConf"
-                                pButton pRipple type="button"
-                                icon="pi pi-cog"
-                                (click)="onShowGlobalFilter(false, filter)"
-                                class="p-button-rounded p-button-outlined filters-size">
-                            </button>
-                        </ng-container>
-                    </eda-date-picker>
-                </div>
-                <div *ngSwitchDefault>
-                    <!-- {{ filter | json }} -->
-                    <p-multiSelect *ngIf="filter.data && ( isAdmin || isDashboardCreator ||   ['public', 'readOnly'].includes(filter.visible) ) &&  filter.selectedColumn.visible"
-                        [options]="filter.data"
-                        [(ngModel)]="filter.selectedItems"
-                        [maxSelectedLabels]="3"
-                        [virtualScroll]="true"
-                        [defaultLabel]="getFilterLabel(filter)"
-                        [disabled]="disableGlobalFilter(filter)"
-                        itemSize="30"
-                        display="chip"
-                        class="customMultiselect filters-size"
-                        [style]="{'max-width': '250px', 'min-width':'200px', 'font-family':'var(--eda-filters-font-family)'}"
-                        [Show]="dropdownFiltersSize(filter)"
-                        (onChange)="setGlobalFilterItems(filter)">
-        
-                        <p-footer>
-                            <button *ngIf="dashboard.canIedit()" id="dashFilterConf"
-                                pButton pRipple type="button"
-                                icon="pi pi-cog"
-                                (click)="onShowGlobalFilter(false, filter)"
-                                class="p-button-rounded p-button-outlined filters-size">
-                            </button>
-                        </p-footer>
-                    </p-multiSelect>
-                </div>
-            </ng-container>
-        </div>
-    </div>
+
+      <div *ngFor="let filter of globalFilters" class="filter-set d-flex align-items-center">
+          <span *ngIf="( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible) )  &&  (filter.selectedColumn?.visible || filter.column?.value.visible) )" class="filter-name filters-size">
+              {{getFilterLabel(filter)}}:
+          </span>
+
+
+          <ng-container
+          *ngIf="( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible) )  &&  (filter.selectedColumn?.visible || filter.column?.value.visible) )  "
+          [ngSwitch]="getFilterType(filter)" >
+              <div *ngSwitchCase="'date'">
+                  <eda-date-picker
+                      [autoClear]="true"
+                      [inject]="datePickerConfigs[filter.id]"
+                      (onRemove)="removeGlobalFilter(filter, true)"
+                      (onDatesChanges)="processPickerEvent($event, filter)">
+
+                      <ng-container footer>
+                          <button id="dashFilterConf"
+                              pButton pRipple type="button"
+                              icon="pi pi-cog"
+                              (click)="onShowGlobalFilter(false, filter)"
+                              class="p-button-rounded p-button-outlined filters-size">
+                          </button>
+                      </ng-container>
+                  </eda-date-picker>
+              </div>
+              <div *ngSwitchDefault>
+                  <!-- {{ filter | json }} -->
+                  <p-multiSelect *ngIf="( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible) )  &&  (filter.selectedColumn?.visible || filter.column?.value.visible) )"
+                      [options]="filter.data"
+                      [(ngModel)]="filter.selectedItems"
+                      [maxSelectedLabels]="3"
+                      [virtualScroll]="true"
+                      [defaultLabel]="getFilterLabel(filter)"
+                      [disabled]="disableGlobalFilter(filter)"
+                      itemSize="30"
+                      display="chip"
+                      class="customMultiselect filters-size"
+                      [style]="{'max-width': '250px', 'min-width':'200px', 'font-family':'var(--eda-filters-font-family)'}"
+                      [Show]="dropdownFiltersSize(filter)"
+                      (onChange)="setGlobalFilterItems(filter)">
+
+                      <p-footer>
+                          <button *ngIf="dashboard.canIedit()" id="dashFilterConf"
+                              pButton pRipple type="button"
+                              icon="pi pi-cog"
+                              (click)="onShowGlobalFilter(false, filter)"
+                              class="p-button-rounded p-button-outlined filters-size">
+                          </button>
+                      </p-footer>
+                  </p-multiSelect>
+              </div>
+          </ng-container>
+      </div>
+  </div>
 </div>
 
 <!-- ============================================================== -->
@@ -79,9 +79,9 @@
 <dashboard-filter-dialog *ngIf="filterController" [controller]="filterController"></dashboard-filter-dialog>
 
 <app-global-filter-dialog *ngIf="globalFilter"
-    [(globalFilter)]="globalFilter"
-    [globalFilterList]="globalFilters"
-    [panels]="dashboard.panels"
-    [dataSource]="dashboard.dataSource"
-    (close)="onCloseGlobalFilter($event)">
+  [(globalFilter)]="globalFilter"
+  [globalFilterList]="globalFilters"
+  [panels]="dashboard.panels"
+  [dataSource]="dashboard.dataSource"
+  (close)="onCloseGlobalFilter($event)">
 </app-global-filter-dialog>

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.html
@@ -2,75 +2,78 @@
 <!-- GLOBAL FILTERS  -->
 <!-- ============================================================== -->
 <div [ngClass]="{'noShow': hideFilters }" >
-  <!--   panel mode es per quan vull mostrat nomes un panell-->
-  <div *ngIf="globalFilters.length > 0" class="d-flex align-items-end" style="margin: 0.5em; gap: 10px; flex-wrap: wrap;" >
-      <button
-          *ngIf="isAdmin || isDashboardCreator || filterButtonVisibility.public"
-          id="dashFilterBtn"
-          [label]="filtrar"
-          pButton pRipple type="button"
-          icon="pi pi-filter"
-          style="height: 36px; min-width: 80px;"
-          (click)="dashboard.reloadPanelsWithTimeOut()"
-          class="p-button-raised p-button-outlined filters-size">
-      </button>
+    <!--   panel mode es per quan vull mostrat nomes un panell-->
+    <div *ngIf="globalFilters.length > 0" class="d-flex align-items-end" style="margin: 0.5em; gap: 10px; flex-wrap: wrap;" >
+
+        <button
+            *ngIf="isAdmin || isDashboardCreator || filterButtonVisibility.public"
+            id="dashFilterBtn"
+            [label]="filtrar"
+            pButton pRipple type="button"
+            icon="pi pi-filter"
+            style="height: 36px; min-width: 80px;"
+            (click)="dashboard.reloadPanelsWithTimeOut()"
+            class="p-button-raised p-button-outlined filters-size">
+        </button>
 
 
-      <div *ngFor="let filter of globalFilters" class="filter-set d-flex align-items-center">
-          <span *ngIf="( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible) )  &&  (filter.selectedColumn?.visible || filter.column?.value.visible) )" class="filter-name filters-size">
-              {{getFilterLabel(filter)}}:
-          </span>
+        <div *ngFor="let filter of globalFilters" class="filter-set d-flex align-items-center">
+
+          <!-- SDA CUSTOM --> <span *ngIf="( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible)   &&  (filter.selectedColumn?.visible || filter.column?.value?.visible)) )" class="filter-name filters-size">
+                {{getFilterLabel(filter)}}:
+
+            </span>
 
 
-          <ng-container
-          *ngIf="( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible) )  &&  (filter.selectedColumn?.visible || filter.column?.value.visible) )  "
-          [ngSwitch]="getFilterType(filter)" >
-              <div *ngSwitchCase="'date'">
-                  <eda-date-picker
-                      [autoClear]="true"
-                      [inject]="datePickerConfigs[filter.id]"
-                      (onRemove)="removeGlobalFilter(filter, true)"
-                      (onDatesChanges)="processPickerEvent($event, filter)">
+            <!-- SDA CUSTOM --> <ng-container
+            *ngIf="( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible)   &&  (filter.selectedColumn?.visible || filter.column?.value.visible)) )"
+            [ngSwitch]="getFilterType(filter)" >
+                <div *ngSwitchCase="'date'">
+                    <eda-date-picker
+                        [autoClear]="true"
+                        [inject]="datePickerConfigs[filter.id]"
+                        (onRemove)="removeGlobalFilter(filter, true)"
+                        (onDatesChanges)="processPickerEvent($event, filter)">
 
-                      <ng-container footer>
-                          <button id="dashFilterConf"
-                              pButton pRipple type="button"
-                              icon="pi pi-cog"
-                              (click)="onShowGlobalFilter(false, filter)"
-                              class="p-button-rounded p-button-outlined filters-size">
-                          </button>
-                      </ng-container>
-                  </eda-date-picker>
-              </div>
-              <div *ngSwitchDefault>
-                  <!-- {{ filter | json }} -->
-                  <p-multiSelect *ngIf="( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible) )  &&  (filter.selectedColumn?.visible || filter.column?.value.visible) )"
-                      [options]="filter.data"
-                      [(ngModel)]="filter.selectedItems"
-                      [maxSelectedLabels]="3"
-                      [virtualScroll]="true"
-                      [defaultLabel]="getFilterLabel(filter)"
-                      [disabled]="disableGlobalFilter(filter)"
-                      itemSize="30"
-                      display="chip"
-                      class="customMultiselect filters-size"
-                      [style]="{'max-width': '250px', 'min-width':'200px', 'font-family':'var(--eda-filters-font-family)'}"
-                      [Show]="dropdownFiltersSize(filter)"
-                      (onChange)="setGlobalFilterItems(filter)">
+                        <ng-container footer>
+                            <button id="dashFilterConf"
+                                pButton pRipple type="button"
+                                icon="pi pi-cog"
+                                (click)="onShowGlobalFilter(false, filter)"
+                                class="p-button-rounded p-button-outlined filters-size">
+                            </button>
+                        </ng-container>
+                    </eda-date-picker>
+                </div>
+                <div *ngSwitchDefault>
 
-                      <p-footer>
-                          <button *ngIf="dashboard.canIedit()" id="dashFilterConf"
-                              pButton pRipple type="button"
-                              icon="pi pi-cog"
-                              (click)="onShowGlobalFilter(false, filter)"
-                              class="p-button-rounded p-button-outlined filters-size">
-                          </button>
-                      </p-footer>
-                  </p-multiSelect>
-              </div>
-          </ng-container>
-      </div>
-  </div>
+                    <!-- SDA CUSTOM --> <p-multiSelect *ngIf="filter.data && ( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible)   &&  (filter.selectedColumn?.visible || filter.column?.value.visible)) )"
+                        [options]="filter.data"
+                        [(ngModel)]="filter.selectedItems"
+                        [maxSelectedLabels]="3"
+                        [virtualScroll]="true"
+                        [defaultLabel]="getFilterLabel(filter)"
+                        [disabled]="disableGlobalFilter(filter)"
+                        itemSize="30"
+                        display="chip"
+                        class="customMultiselect filters-size"
+                        [style]="{'max-width': '250px', 'min-width':'200px', 'font-family':'var(--eda-filters-font-family)'}"
+                        [Show]="dropdownFiltersSize(filter)"
+                        (onChange)="setGlobalFilterItems(filter)">
+
+                        <p-footer>
+                            <button *ngIf="dashboard.canIedit()" id="dashFilterConf"
+                                pButton pRipple type="button"
+                                icon="pi pi-cog"
+                                (click)="onShowGlobalFilter(false, filter)"
+                                class="p-button-rounded p-button-outlined filters-size">
+                            </button>
+                        </p-footer>
+                    </p-multiSelect>
+                </div>
+            </ng-container>
+        </div>
+    </div>
 </div>
 
 <!-- ============================================================== -->
@@ -79,9 +82,9 @@
 <dashboard-filter-dialog *ngIf="filterController" [controller]="filterController"></dashboard-filter-dialog>
 
 <app-global-filter-dialog *ngIf="globalFilter"
-  [(globalFilter)]="globalFilter"
-  [globalFilterList]="globalFilters"
-  [panels]="dashboard.panels"
-  [dataSource]="dashboard.dataSource"
-  (close)="onCloseGlobalFilter($event)">
+    [(globalFilter)]="globalFilter"
+    [globalFilterList]="globalFilters"
+    [panels]="dashboard.panels"
+    [dataSource]="dashboard.dataSource"
+    (close)="onCloseGlobalFilter($event)">
 </app-global-filter-dialog>

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.html
@@ -21,18 +21,18 @@
           <!-- SDA CUSTOM --> <span *ngIf="( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible)   &&  (filter.selectedColumn?.visible || filter.column?.value?.visible)) )" class="filter-name filters-size">
                 {{getFilterLabel(filter)}}:
             </span>
-
-
-            <!-- SDA CUSTOM --> <ng-container
+        
+        
+            <!-- SDA CUSTOM --> <ng-container 
             *ngIf="( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible)   &&  (filter.selectedColumn?.visible || filter.column?.value.visible)) )"
             [ngSwitch]="getFilterType(filter)" >
                 <div *ngSwitchCase="'date'">
-                    <eda-date-picker
+                    <eda-date-picker 
                         [autoClear]="true"
                         [inject]="datePickerConfigs[filter.id]"
                         (onRemove)="removeGlobalFilter(filter, true)"
                         (onDatesChanges)="processPickerEvent($event, filter)">
-      
+        
                         <ng-container footer>
                             <button id="dashFilterConf"
                                 pButton pRipple type="button"
@@ -58,7 +58,7 @@
                         [style]="{'max-width': '250px', 'min-width':'200px', 'font-family':'var(--eda-filters-font-family)'}"
                         [Show]="dropdownFiltersSize(filter)"
                         (onChange)="setGlobalFilterItems(filter)">
-    
+        
                         <p-footer>
                             <button *ngIf="dashboard.canIedit()" id="dashFilterConf"
                                 pButton pRipple type="button"

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.html
@@ -4,7 +4,6 @@
 <div [ngClass]="{'noShow': hideFilters }" >
     <!--   panel mode es per quan vull mostrat nomes un panell-->
     <div *ngIf="globalFilters.length > 0" class="d-flex align-items-end" style="margin: 0.5em; gap: 10px; flex-wrap: wrap;" >
-
         <button
             *ngIf="isAdmin || isDashboardCreator || filterButtonVisibility.public"
             id="dashFilterBtn"
@@ -16,12 +15,11 @@
             class="p-button-raised p-button-outlined filters-size">
         </button>
 
-
+   
         <div *ngFor="let filter of globalFilters" class="filter-set d-flex align-items-center">
 
           <!-- SDA CUSTOM --> <span *ngIf="( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible)   &&  (filter.selectedColumn?.visible || filter.column?.value?.visible)) )" class="filter-name filters-size">
                 {{getFilterLabel(filter)}}:
-
             </span>
 
 
@@ -34,7 +32,7 @@
                         [inject]="datePickerConfigs[filter.id]"
                         (onRemove)="removeGlobalFilter(filter, true)"
                         (onDatesChanges)="processPickerEvent($event, filter)">
-
+      
                         <ng-container footer>
                             <button id="dashFilterConf"
                                 pButton pRipple type="button"
@@ -60,7 +58,7 @@
                         [style]="{'max-width': '250px', 'min-width':'200px', 'font-family':'var(--eda-filters-font-family)'}"
                         [Show]="dropdownFiltersSize(filter)"
                         (onChange)="setGlobalFilterItems(filter)">
-
+    
                         <p-footer>
                             <button *ngIf="dashboard.canIedit()" id="dashFilterConf"
                                 pButton pRipple type="button"

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.html
@@ -17,12 +17,13 @@
 
     
         <div *ngFor="let filter of globalFilters" class="filter-set d-flex align-items-center">
-
+          <!-- SDA CUSTOM <span *ngIf="( isAdmin || isDashboardCreator || ['public', 'readOnly'].includes(filter.visible) )  &&  filter.selectedColumn.visible " class="filter-name filters-size"> --> 
           <!-- SDA CUSTOM --> <span *ngIf="( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible)   &&  (filter.selectedColumn?.visible || filter.column?.value?.visible)) )" class="filter-name filters-size">
                 {{getFilterLabel(filter)}}:
             </span>
             
-            
+            <!-- SDA CUSTOM  <ng-container -->
+            <!-- SDA CUSTOM *ngIf="( isAdmin || isDashboardCreator ||   ['public', 'readOnly'].includes(filter.visible) ) &&  filter.selectedColumn.visible  " --> 
             <!-- SDA CUSTOM --> <ng-container 
             *ngIf="( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible)   &&  (filter.selectedColumn?.visible || filter.column?.value.visible)) )"
             [ngSwitch]="getFilterType(filter)" >
@@ -45,6 +46,7 @@
                 </div>
                 <div *ngSwitchDefault>
 
+                    <!-- SDA CUSTOM <p-multiSelect *ngIf="filter.data && ( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible)   &&  (filter.selectedColumn?.visible || filter.column?.value.visible)) )" -->
                     <!-- SDA CUSTOM --> <p-multiSelect *ngIf="filter.data && ( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible)   &&  (filter.selectedColumn?.visible || filter.column?.value.visible)) )"
                         [options]="filter.data"
                         [(ngModel)]="filter.selectedItems"

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.html
@@ -15,14 +15,14 @@
             class="p-button-raised p-button-outlined filters-size">
         </button>
 
-   
+    
         <div *ngFor="let filter of globalFilters" class="filter-set d-flex align-items-center">
 
           <!-- SDA CUSTOM --> <span *ngIf="( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible)   &&  (filter.selectedColumn?.visible || filter.column?.value?.visible)) )" class="filter-name filters-size">
                 {{getFilterLabel(filter)}}:
             </span>
-        
-        
+            
+            
             <!-- SDA CUSTOM --> <ng-container 
             *ngIf="( isAdmin || isDashboardCreator || (['public', 'readOnly'].includes(filter.visible)   &&  (filter.selectedColumn?.visible || filter.column?.value.visible)) )"
             [ngSwitch]="getFilterType(filter)" >


### PR DESCRIPTION
- resolve #310 

### Problema identificado

Se ha detectado que la estructura de los filtros en modo EDA es distinta a la utilizada en modo árbol (EDA2).

- En EDA, la estructura de filtros utiliza los atributos table y column.
- En EDA2, los filtros se estructuran con selectedTable y selectedColumn.

Esto provocaba que, si en un informe había filtros en modo EDA, el informe se quedaba en blanco debido a una inconsistencia en la verificación de la visibilidad de las columnas.

### Solución implementada

Se ha actualizado la función `checkFiltersVisibility` para incluir validaciones separadas según el modo en el que esté diseñado el filtro:

- Se verifica la visibilidad de selectedColumn y selectedTable para EDA2.
- Se valida column.value y table.value para el modo EDA.

Además en el archivo `global-filter.component.html` se han añadido excepciones específicas para los filtros en modo EDA.

Con esta implementación, los informes que contienen filtros en modo EDA ya no se quedarán en blanco y la visibilidad de las columnas se gestionará correctamente en ambos modos (EDA y EDA2).

### Cómo probarlo

1. Crear un informe en modo EDA.
2. Añadir un filtro.
3. Verificar que se puede guardar el informe correctamente.
4. Recargar el informe y comprobar que el filtro sigue presente y funcional.
