### PR TITLE
Hotfix - - Corrección del espacio en la consulta de rangos en SDA

### DIFF
--- a/eda/eda_api/lib/services/query-builder/query-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/query-builder.service.ts
@@ -383,7 +383,7 @@ export abstract class QueryBuilderService {
 
                     let withRanges = "WITH ranges AS (\n";
 
-                    withRanges += `    SELECT ' < ${fieldsColumn.ranges[0]}' as \`range\`\n`;
+                    withRanges += `    SELECT '< ${fieldsColumn.ranges[0]}' as \`range\`\n`;
 
                     for (let i = 0; i < fieldsColumn.ranges.length - 1; i++) {
                         withRanges += `    UNION SELECT ' ${fieldsColumn.ranges[i]} - ${fieldsColumn.ranges[i + 1] - 1}'\n`;


### PR DESCRIPTION
- Solves #316
### Descripción:
Se ha corregido un error en la generación de la consulta SQL para los rangos en SDA. Anteriormente, la consulta generaba un espacio adicional delante del valor del primer tramo, lo que impedía que la unión con los resultados de la subconsulta coincidiera correctamente.
