### PR TITLE
Hotfix- General - Asegurar funcionamiento correcto de la cache

### DIFF
--- a/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
+++ b/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
@@ -237,7 +237,7 @@ export class updateModel {
   * @returns cache_config_SDA checked if the result is not acceptable cache is disabled.
   */
   static assertCacheConfig(cache_config_SDA:any) {
-    if( cache_config_SDA.find( (v: any) => v.key === 'sda_config_cache_enabled').value  === "1") {
+    if( cache_config_SDA?.find( (v: any) => v.key === 'sda_config_cache_enabled')?.value  === "1") {
       if (  ! [ 'days', 'hours'].includes ( cache_config_SDA.find( (v: any) => v.key === 'sda_config_cache_units').value  )  ){
           // no correct units. Cache = false.
           console.log('Error in cache configuration units : ' + cache_config_SDA.find( (v: any) => v.key === 'sda_config_cache_units').value  );
@@ -267,7 +267,7 @@ export class updateModel {
         }
     }else{
       console.log('Cache disabled : ' + cache_config_SDA['sda_config_cache_enabled']  );
-      cache_config_SDA.find( (v: any) => v.key === 'sda_config_cache_enabled').value  = '0' ;
+      // cache_config_SDA.find( (v: any) => v.key === 'sda_config_cache_enabled').value  = '0' ;
     }
   return cache_config_SDA;
   }


### PR DESCRIPTION

## Descripción del Cambio
Se ha añadido una validación en updateModel para evitar errores cuando no está definida la configuración de caché en SinergiaCRM.

Si no se incluyen las siguientes líneas en el archivo de configuración, la función updateModel produce un error al intentar acceder a claves no definidas en el array.



```
$sugar_config['stic_sinergiada']['config']['cache_enabled'] = 0;
$sugar_config['stic_sinergiada']['config']['cache_units'] = 'days';
$sugar_config['stic_sinergiada']['config']['cache_quantity'] = 2;
$sugar_config['stic_sinergiada']['config']['cache_hours'] = '04';
$sugar_config['stic_sinergiada']['config']['cache_minutes'] = '33';

```

Con este cambio, se comprueba si dichas claves están definidas y, en caso contrario, se asume que la caché está deshabilitada, evitando así el error.

