### PR TITLE
Improvement - API - Esconder menús de logs y acciones personalizadas

### DIFF
--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
@@ -139,7 +139,7 @@
                     <span i18n="@@newTag"> Nueva etiqueta </span>
                  </button>
             </div>
-            <input class="ml-2" *ngIf="addTag" type="text" pInputText [(ngModel)]="applyNewTag"> 
+            <input class="ml-2" *ngIf="addTag" type="text" pInputText [(ngModel)]="applyNewTag">
             <button pButton pRipple type="button" *ngIf="addTag" class="p-button-raised p-button-success ml-2" style="background-color: #4CAF50" (click)="setNewTag(applyNewTag)">
                 <span> Confirmar </span>
             </button>
@@ -208,7 +208,7 @@
             </p-inputSwitch>
         </div>
     </div>
-    
+
     <hr>
     <div *ngIf="display_v.edit_mode" class="right-sidebar-blocks-options block-options-bg pointer mt-1" (click)="editStyles()">
         <div>
@@ -238,12 +238,14 @@
         </div>
     </div>
 
-    <div  *ngIf="display_v.edit_mode && canIedit()" class="right-sidebar-blocks-options block-options-bg pointer mt-1" (click)="openUrlsConfig();">
+    <!-- SDA CUSTOM -->
+    <!-- <div  *ngIf="display_v.edit_mode && canIedit()" class="right-sidebar-blocks-options block-options-bg pointer mt-1" (click)="openUrlsConfig();">
         <div>
             <i class="fa fa-link"></i>
             <span i18n="@@opcionUrls" class="ml-2">ACCIÓN PERSONALIZADA</span>
         </div>
-    </div>
+    </div> -->
+    <!-- END SDA CUSTOM -->
 
 
 

--- a/eda/eda_app/src/app/shared/components/sidebar/sidebar.component.html
+++ b/eda/eda_app/src/app/shared/components/sidebar/sidebar.component.html
@@ -63,12 +63,15 @@
                             </a>
 
                         </li>
-                        <li *ngIf="userService.isDataSourceCreator||userService.isAdmin" class="user-profile">
+                        <!-- SDA CUSTOM -->
+                         <!--  -->
+                        <!-- <li *ngIf="userService.isDataSourceCreator||userService.isAdmin" class="user-profile">
                             <a routerLinkActive="active"  routerLink="/logs" (click)="ignoreNotSaved()">
                                 <i class="mdi mdi-clipboard-text"></i> <span i18n="@@logsManagement">Gestión de
                                     Logs</span>
                             </a>
-                        </li>
+                        </li> -->
+                        <!-- SDA CUSTOM -->
                         <li>
                             <a (click)="logout()" class="pointer" (click)="ignoreNotSaved()">
                                 <i class="mdi mdi-logout"></i> <span i18n="@@sidebarLogOut">Cerrar sesión</span>
@@ -81,7 +84,7 @@
 
                 <li class="user-profile">
                     <a class="has-arrow waves-effect waves-dark collapser" href="#"  (click)="checkNotSaved()" aria-expanded="false">
-                        
+
                         <i class="mdi mdi-view-dashboard"></i>
                         <span class="hide-menu ml-2" i18n="@@Dashboards_ms"> Informes </span>
                     </a>


### PR DESCRIPTION
Se esconden los menú _Gestión de Logs_ añadido en la versión 2.1.3 debido a su dificultad para configurarlo en el entorno de desarrollo de SinergiaDA y se esconde el menú _Acción personalizada_ del menu de edición de los informes, debido a que no se encuentra una aplicación práctica y generará un ruido innecesario.

Como probarlo:
Verificar que ambos menus no aparecen en la instancia.
