### PR TITLE
Incidencia - Filtros - Error con filtros de desplegables.  

### DIFF
--- a/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
@@ -1030,7 +1030,7 @@ export class MySqlBuilderService extends QueryBuilderService {
           if (filterObject.filter_type === 'not_like') { 
             filterObject.filter_type = 'not like'
             /** if i have the lovely code i use the code */
-            if( filterObject.filter_codes.length !== undefined  &&  filterObject.valueListSource !== undefined ){
+            if( filterObject.filter_codes?.length !== undefined  &&  filterObject.valueListSource !== undefined ){
                 return `${colname}  ${filterObject.filter_type} '%${filterObject.filter_codes[0].value1}%' `;
             }else{
                 return `${colname}  ${filterObject.filter_type} '%${filterObject.filter_elements[0].value1}%' `;


### PR DESCRIPTION
### Descripcion
Se ha comprobado que en determinadas situaciones que no se han podido aislar copletamente, la convivencia entre los filtros de listas desplegables que usaban el sistema antiguo (etiqueta) fallaban al intentar filtrar contra la columna code (en lugar de value).

Se ha encontrado el error a partir del log de la api y se ha corregido añadiendo el símbolo _?_ a la validación de la propiedad `filterObject.filter_codes?.length`, lo que aparentemente es una omisión en el código, ya que el mismo código se usa multiples veces en el mismo script de manera adecuada.

### Pruebas a realizar:
- Verificar el funcionamiento general de los filtros de panel.
- Por inspección de código.

