### PR TITLE
Hotfix - Informes - Administradores deben tener acceso a todos los informes

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -371,6 +371,7 @@ export class EdaBlankPanelComponent implements OnInit {
     getEditMode() {
         const user = localStorage.getItem('user');
         const userName = JSON.parse(user).name;
+        if(JSON.parse(user).role.includes('135792467811111111111110') ) return true; // Admin role always can edit
         return (userName !== 'edaanonim' && !this.inject.isObserver);
     }
 

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -613,6 +613,9 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
         if(this.dashboard.datasSource.is_filtered) {
             this.display_v.edit_mode = false;
         }
+
+
+        if( (this.grups.filter(group => group.name === 'EDA_ADMIN' ).length > 0) )  this.display_v.edit_mode = true; // Admin always can edit
     }
 
     private setPanelSizes(panel) {
@@ -978,22 +981,33 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
                                 panel.savePanel();
                             });
 
-                            this.dashboardService.updateDashboard(r.dashboard._id, body).subscribe(
-                                () => {
-                                    this.dashboardService._notSaved.next(false);
-                                    this.display_v.rightSidebar = false;
-                                    this.alertService.addSuccess($localize`:@@dahsboardSaved:Informe guardado correctamente`);
-                                    this.router.navigate(['/dashboard/', r.dashboard._id]).then(() => {
-                                        window.location.reload();
-                                    });
 
-                                },
-                                err => {
-                                    this.dashboardService._notSaved.next(false);
-                                    this.display_v.rightSidebar = false;
-                                    this.alertService.addError(err);
-                                }
-                            );
+
+                            if(  this.checkPannels(body) === 'true'){
+                                this.dashboardService.updateDashboard(r.dashboard._id, body).subscribe(
+                                    () => {
+                                        this.dashboardService._notSaved.next(false);
+                                        this.display_v.rightSidebar = false;
+                                        this.alertService.addSuccess($localize`:@@dahsboardSaved:Informe guardado correctamente`);
+                                        this.router.navigate(['/dashboard/', r.dashboard._id]).then(() => {
+                                            window.location.reload();
+                                        });
+
+                                    },
+                                    err => {
+                                        this.dashboardService._notSaved.next(false);
+                                        this.display_v.rightSidebar = false;
+                                        this.alertService.addError(err);
+                                    }
+                                );
+                            }else{
+
+                               this.alertService.addError($localize`:@@errorSavingDashboardPannels:Error al guardar el informe. Error en el panel: ` + this.checkPannels(body) );
+ 
+                            }
+
+
+                            
                         },
                         err => this.alertService.addError(err)
                     );
@@ -1221,21 +1235,44 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
             this.edaPanels.forEach(panel => { panel.savePanel(); });
             body.config.panel = this.dashboard.panel;
 
-            this.dashboardService.updateDashboard(this.id, body).subscribe(
-                () => {
-                    this.display_v.rightSidebar = false;
-                    this.alertService.addSuccess($localize`:@@dahsboardSaved:Informe guardado correctamente`);
-                },
-                err => {
-                    this.display_v.rightSidebar = false;
-                    this.alertService.addError(err);
-                }
-            );
 
-            //not saved alert message
-            this.dashboardService._notSaved.next(false);
+            if( this.checkPannels(body) === 'true'){
+                this.dashboardService.updateDashboard(this.id, body).subscribe(
+                    () => {
+                        this.display_v.rightSidebar = false;
+                        this.alertService.addSuccess($localize`:@@dahsboardSaved:Informe guardado correctamente`);
+                    },
+                    err => {
+                        this.display_v.rightSidebar = false;
+                        this.alertService.addError(err);
+                    }
+                );
+                //not saved alert message
+                this.dashboardService._notSaved.next(false);
+            }else{
+                this.display_v.rightSidebar = false;
+                this.alertService.addError($localize`:@@errorSavingDashboardPannels:Error al guardar el informe. Error en el panel: ` + this.checkPannels(body) );
+            }
         }
     }
+
+ 
+    /**
+     * @description  Check if all pannels have data to be saved. If they are not correct return the name of the pannel
+     * @param dashboard  get the dashboard to check the pannels content
+     * @returns  the text true if everithing is fine or the name of the pannel with worng configuration
+     */
+    private checkPannels(dashboard): string {
+            let correct = 'true';
+            dashboard.config.panel.forEach(p => {
+                if(  p.content && p.content?.query?.query.fields.length < 1  ) { 
+                    console.log('NO SE PUEDEN GAURDAR PANELES SIN DATOS');
+                    correct = p.title;
+                }
+            })
+            return correct;
+    }
+
 
     public getMailingAlertsEnabled(): boolean {
 

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4462,6 +4462,10 @@ Un cop configurat podràs invocar-lo sempre que vulguis des del botó.</target>
         <source>Una tabla árbol se puede configurar de dos formas. Mediante campos que se van anidando por medio de agrupaciones o mediante la definición de dos columnas numéricas que definan una relación padre-hijo. Si las dos primeras columnas son numéricas, se asumirá que describen una relación padre hijo.</source>
         <target>Una taula arbre es pot configurar de dues maneres. Mitjançant camps que es van niant per mitjà d'agrupacions o mitjançant la definició de dues columnes numèriques que defineixin una relació pare-fill. Si les dues primeres columnes són numèriques, cal assumir que descriuen una relació pare fill.</target>
       </trans-unit>
+      <trans-unit id="errorSavingDashboardPannels">
+        <source>Error al guardar el informe. Error en el panel: </source>
+        <target>Error en desar l'informe. Error al panell:</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4464,7 +4464,7 @@ Un cop configurat podràs invocar-lo sempre que vulguis des del botó.</target>
       </trans-unit>
       <trans-unit id="errorSavingDashboardPannels">
         <source>Error al guardar el informe. Error en el panel: </source>
-        <target>Error en desar l'informe. Error al panell:</target>
+        <target>S'ha produït un error al desar l'informe. L'error és al panell </target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4645,7 +4645,7 @@ Once configured you can invoke it whenever you want from the button.</target>
       </trans-unit>
       <trans-unit id="errorSavingDashboardPannels">
         <source>Error al guardar el informe. Error en el panel: </source>
-        <target>Error saving report. Error in pannel:</target>
+        <target>An error occurred while saving the report. The error is in the pannel </target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4643,6 +4643,10 @@ Once configured you can invoke it whenever you want from the button.</target>
         <source>Una tabla árbol se puede configurar de dos formas. Mediante campos que se van anidando por medio de agrupaciones o mediante la definición de dos columnas numéricas que definan una relación padre-hijo. Si las dos primeras columnas son numéricas, se asumirá que describen una relación padre hijo.</source>
         <target>A tree table can be configured in two ways: by nesting fields using groupings, or by defining two numeric columns that define a parent-child relationship. If the first two columns are numeric, they will be assumed to describe a parent-child relationship.</target>
       </trans-unit>
-        </body>
+      <trans-unit id="errorSavingDashboardPannels">
+        <source>Error al guardar el informe. Error en el panel: </source>
+        <target>Error saving report. Error in pannel:</target>
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4437,6 +4437,10 @@
         <source>Una tabla árbol se puede configurar de dos formas. Mediante campos que se van anidando por medio de agrupaciones o mediante la definición de dos columnas numéricas que definan una relación padre-hijo. Si las dos primeras columnas son numéricas, se asumirá que describen una relación padre hijo.</source>
         <target>Una tabla árbol se puede configurar de dos formas. Mediante campos que se van anidando por medio de agrupaciones o mediante la definición de dos columnas numéricas que definan una relación padre-hijo. Si las dos primeras columnas son numéricas, se asumirá que describen una relación padre hijo.</target>
       </trans-unit>
+      <trans-unit id="errorSavingDashboardPannels">
+        <source>Error al guardar el informe. Error en el panel: </source>
+        <target>Error al guardar el informe. Error en el panel: </target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4439,7 +4439,7 @@
       </trans-unit>
       <trans-unit id="errorSavingDashboardPannels">
         <source>Error al guardar el informe. Error en el panel: </source>
-        <target>Error al guardar el informe. Error en el panel: </target>
+        <target>Se ha producido un error al guardar el informe. El error está en el panel </target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -4438,6 +4438,10 @@
         <source>Una tabla árbol se puede configurar de dos formas. Mediante campos que se van anidando por medio de agrupaciones o mediante la definición de dos columnas numéricas que definan una relación padre-hijo. Si las dos primeras columnas son numéricas, se asumirá que describen una relación padre hijo.</source>
         <target>Unha táboa de árbore pódese configurar de dúas maneiras: aniñando campos mediante agrupacións ou definindo dúas columnas numéricas que definan unha relación pai-fillo. Se as dúas primeiras columnas son numéricas, asumirase que describen unha relación pai-fillo.</target>
       </trans-unit>
+      <trans-unit id="errorSavingDashboardPannels">
+        <source>Error al guardar el informe. Error en el panel: </source>
+        <target>Produciuse un erro ao gardar o informe. Erro no panel: </target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
## Descripción del Cambio
Si  un usuario ejecuta la secuenca: Crea un panel, configura una consulta y luego cancela el panel. La configuración del panel se queda en un estado inconsistente. Lo que provoca que el informe falle una vez guardado. 

Se ha añadido una comprobación en el momento de guardar el informe para que. Si hay un panel mal configurado  no se pueda guardar el informe.  Esto proporciona un filtro de seguridad para que este error no se propague y no se den situaciones en las que se guarde el informe con una configuración inconsistente. 

Además. Se ha revisado la configuración del informe para que el usuario admin siempre tenga control total sobre el mismo. 

Se debería resolver el problema de base.  Que la secuencia concreta no genere un estado inconsistente. Pero eso supondrá un desarrollo un poco más concienzudo que habrá que evaluar porque tiene un mayor alcance y repercusión. 



## Issue(s) resuelto(s)
- solves #383

## Pruebas a realizar para validar el cambio
En un informe nuevo o existente. Se debe:
1. Crear un nuevo panel.
2. Generar una consulta. 
3. Ejecutar la consulta
4. Volver al modo de edición del panel.
5. Borrar todos los campos.
6. Clicar en cancelar. 
Esto genera el error.  A partir de este momento: No se debería poder guardar el informe hasta que el panel no esté correctamente configurado o eliminado.
En caso de que suceda en un informe con el error ya existente. El comportamiento será el mismo. Sólo que SE DEBERÁ BORRAR el panel que produce el error. Este caso se ha desestimado puesto que los informes existentes ya han sido borrados.


