### PR TITLE
Hotfix - APP - Error grave al ordenar columnas en tablas

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.component.html
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.component.html
@@ -1,5 +1,5 @@
 <div class="eda-table">
-    <p-table #table [columns]="inject.cols" [value]="inject.value" [paginator]="true" [rows]="inject.rows" [rowsPerPageOptions]="[5, 10, 25, 50, 100]" paginatorDropdownAppendTo="body" (onPage)="inject.onPage($event)" (sortFunction)="customSort($event, inject.cols)" [customSort]="true" (onSort)="inject.onSort($event)" [sortField]="inject.sortedColumn ? inject.sortedColumn.field : null"
+    <p-table #table [columns]="inject.cols" [value]="inject.value" [paginator]="true" [rows]="inject.rows" [rowsPerPageOptions]="[5, 10, 25, 50, 100]" paginatorDropdownAppendTo="body" (onPage)="inject.onPage($event)" (sortFunction)="customSort($event, inject.cols)" [customSort]="true" [sortField]="inject.sortedColumn ? inject.sortedColumn.field : null"
         [sortOrder]="inject.sortedColumn ? inject.sortedColumn.order : null" [autoLayout]="inject.autolayout">
 
         <!-- Search -->
@@ -19,7 +19,7 @@
             </tr>
 
             <tr *ngFor="let serie of inject.series">
-                <th *ngFor="let label of serie.labels" [attr.rowspan]="label.rowspan" [attr.colspan]="label.colspan"
+                <th *ngFor="let label of serie.labels" [attr.rowspan]="label.rowspan" [pSortableColumn]="label.column" [attr.colspan]="label.colspan"
                 (click)="inject.onHeaderClick(label)" [pTooltip]="getTooltip(label)" style="text-align:center">
                     {{label.title}}
                     <p-sortIcon *ngIf="label.sortable"></p-sortIcon>

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.component.ts
@@ -366,8 +366,11 @@ export class EdaTableComponent implements OnInit {
                     const match1 = this.extractNumberRange(value1)
                     const match2 = this.extractNumberRange(value2)
                     result = (match1 < match2) ? -1 : (match1 > match2) ? 1 : 0;
-                } else
-                    result = value1.localeCompare(value2);
+                } else if (actualCol.type === "EdaColumnPercentage"){
+                    const match1 =  parseFloat(value1.replace('%', '') )
+                    const match2 =  parseFloat(value2.replace('%', '') )
+                    result = (match1 < match2) ? -1 : (match1 > match2) ? 1 : 0;
+                }else    result = value1.localeCompare(value2);
             }
             else
                 result = (value1 < value2) ? -1 : (value1 > value2) ? 1 : 0;


### PR DESCRIPTION

## Descripción del Cambio
Al hacer la integración se duplicó la función de ordenación por eso no funcionaba bien.
Por el camino hemos visto que la ordenación se hacía en formato texto para las columnas de porcentaje. Se ha incluido una función que convierte los texto en valores para obtener el resultado espeado.

## Issue(s) resuelto(s)
- solves #393

## Pruebas a realizar para validar el cambio
Las descritas en el issue. Hacer una tabla y ordenarla. 


