### PR TITLE
Enhancement - General - Habilitar usuarios de solo lectura de SinergiaCRM

### DIFF
--- a/eda/eda_api/lib/module/updateModel/service/usersAndGroupsToMongo.ts
+++ b/eda/eda_api/lib/module/updateModel/service/usersAndGroupsToMongo.ts
@@ -69,6 +69,7 @@ export class userAndGroupsToMongo {
     
     const edaROGroup = mongoGroups.find(g => g.name === 'EDA_RO');
     const edaROGroupId = edaROGroup ? edaROGroup._id : null;
+    const edaAdminGroupId = '135792467811111111111110';
 
     // Create/update users with their roles
     for (let i = 0; i < users.length; i++) {
@@ -80,7 +81,9 @@ export class userAndGroupsToMongo {
         })
         .filter(id => id !== null)
 
-      if (users[i].readonly == 1 && edaROGroupId) {
+      // Add EDA_RO role only if readonly=1 AND user is not an admin
+      const isAdmin = userRoles.some(roleId => roleId && roleId.toString() === edaAdminGroupId);
+      if (users[i].readonly == 1 && edaROGroupId && !isAdmin) {
         userRoles.push(edaROGroupId);
       }
   
@@ -115,13 +118,17 @@ export class userAndGroupsToMongo {
           { _id: { $in: userRoles } },
           { $addToSet: { users: existe._id } }
         )
-        if (users[i].readonly == 1 && edaROGroupId) {
+        
+        // Check if user is admin
+        const isExistingUserAdmin = userRoles.some(roleId => roleId && roleId.toString() === edaAdminGroupId);
+        
+        if (users[i].readonly == 1 && edaROGroupId && !isExistingUserAdmin) {
           await Group.updateOne(
             { _id: edaROGroupId },
             { $addToSet: { users: existe._id } }
           );
-        } else if (users[i].readonly == 0 && edaROGroupId) {
-          // Remove user from EDA_RO group
+        } else if ((users[i].readonly == 0 || isExistingUserAdmin) && edaROGroupId) {
+          // Remove user from EDA_RO group if readonly=0 OR if user is admin
           await Group.updateOne(
               { _id: edaROGroupId },
               { $pull: { users: existe._id } }
@@ -228,6 +235,8 @@ export class userAndGroupsToMongo {
     // Update user roles
     await mongoUsers.forEach(async (user) => {
       if( userExistsInCRM( user, crmUsers)) { 
+        const crmUser = crmUsers.find(cu => cu.email === user.email);
+        
         // Update CRM users, maintain non-SCRM_ roles
         const nonCRMRoles = user.role.filter(roleId => {
           const group = mongoGroups.find(g => g._id.toString() === roleId.toString() && !g.name.startsWith('SCRM_')  );
@@ -242,6 +251,22 @@ export class userAndGroupsToMongo {
           .map(group => group._id);
         
         user.role = [...new Set([...nonCRMRoles, ...crmRolesForUser])];
+        
+        // Ensure EDA_RO is correctly assigned based on readonly flag (but never for admins)
+        const edaROGroup = mongoGroups.find(g => g.name === 'EDA_RO');
+        const edaAdminGroupId = '135792467811111111111110';
+        if (edaROGroup && crmUser) {
+          const hasEDARORole = user.role.some(r => r.toString() === edaROGroup._id.toString());
+          const isUserAdmin = user.role.some(r => r.toString() === edaAdminGroupId);
+          
+          if (crmUser.readonly == 1 && !hasEDARORole && !isUserAdmin) {
+            // User should have EDA_RO role but doesn't (and is not admin)
+            user.role.push(edaROGroup._id);
+          } else if ((crmUser.readonly == 0 || isUserAdmin) && hasEDARORole) {
+            // User shouldn't have EDA_RO role but does (readonly=0 OR is admin)
+            user.role = user.role.filter(r => r.toString() !== edaROGroup._id.toString());
+          }
+        }
       }
     });
 
@@ -249,6 +274,22 @@ export class userAndGroupsToMongo {
     let admins = await mongoUsers.filter(i => i.role.includes('135792467811111111111110'));
     const edaAdminGroup = mongoGroups.find(i => i.name === 'EDA_ADMIN');
     edaAdminGroup.users = admins.map(admin => admin._id);
+
+    // Ensure EDA_RO group contains all readonly users from CRM (excluding admins)
+    const edaROGroup = mongoGroups.find(i => i.name === 'EDA_RO');
+    const edaAdminGroupId = '135792467811111111111110';
+    if (edaROGroup) {
+      const readonlyUserIds = mongoUsers
+        .filter(user => {
+          const crmUser = crmUsers.find(cu => cu.email === user.email);
+          const isAdmin = user.role.some(r => r.toString() === edaAdminGroupId);
+          // Include only if readonly=1 AND not admin
+          return crmUser && crmUser.readonly == 1 && !isAdmin;
+        })
+        .map(user => user._id);
+      
+      edaROGroup.users = readonlyUserIds;
+    }
 
     // Save changes to database
     await mongoGroups.forEach(async r => {

--- a/eda/eda_api/lib/module/updateModel/service/usersAndGroupsToMongo.ts
+++ b/eda/eda_api/lib/module/updateModel/service/usersAndGroupsToMongo.ts
@@ -67,6 +67,9 @@ export class userAndGroupsToMongo {
     // Update groups list
     mongoGroups = await Group.find()
     
+    const edaROGroup = mongoGroups.find(g => g.name === 'EDA_RO');
+    const edaROGroupId = edaROGroup ? edaROGroup._id : null;
+
     // Create/update users with their roles
     for (let i = 0; i < users.length; i++) {
       const userRoles = roles
@@ -76,6 +79,10 @@ export class userAndGroupsToMongo {
           return group ? group._id : null
         })
         .filter(id => id !== null)
+
+      if (users[i].readonly == 1 && edaROGroupId) {
+        userRoles.push(edaROGroupId);
+      }
   
       let existe = mongoUsers.find(e => e.email == users[i].email)
       if (!existe) {
@@ -108,6 +115,23 @@ export class userAndGroupsToMongo {
           { _id: { $in: userRoles } },
           { $addToSet: { users: existe._id } }
         )
+        if (users[i].readonly == 1 && edaROGroupId) {
+          await Group.updateOne(
+            { _id: edaROGroupId },
+            { $addToSet: { users: existe._id } }
+          );
+        } else if (users[i].readonly == 0 && edaROGroupId) {
+          // Remove user from EDA_RO group
+          await Group.updateOne(
+              { _id: edaROGroupId },
+              { $pull: { users: existe._id } }
+          );
+          // Also remove role from user
+          await User.updateOne(
+              { _id: existe._id },
+              { $pull: { role: edaROGroupId } }
+          );
+        }
       }
     }
   

--- a/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
+++ b/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
@@ -116,7 +116,7 @@ export class updateModel {
                 */
                 await connection
                   .query(`
-                      SELECT name as name, user_name as email, password as password, active as active 
+                      SELECT name as name, user_name as email, password as password, active as active, readonly 
                       FROM sda_def_users 
                       WHERE password IS NOT NULL`
                       )

--- a/eda/eda_app/src/app/module/pages/groups-management/group-detail/group-detail.component.html
+++ b/eda/eda_app/src/app/module/pages/groups-management/group-detail/group-detail.component.html
@@ -18,8 +18,7 @@
                             [targetStyle]="{width: '100%'}" [showSourceControls]="false" [showTargetControls]="false">
                             <ng-template let-user pTemplate="item">
                                 <div class="ui-helper-clearfix">
-                                    <img [src]="user.img | image" alt="user image"
-                                        style="display:inline-block;margin:2px 0 2px 2px" width="25" height="25">
+                                    <!--SDA CUSTOM --> <i class="fa fa-user fa-2x"></i>
                                     <span style="font-size:14px;float:right;margin:15px 5px 0 0">{{user.name}}</span>
                                 </div>
                             </ng-template>


### PR DESCRIPTION
## Descripción del Cambio
Se modifica UpdateModel para que gestiones los usuarios de solo lectura provenientes de SinergiaCRM, en función del valor de la columna _readonly_, de la vista _sda_def_users_. Este valor se establece en el perfil de usuario en SinergiaCRM y responde al desarrollo del PR https://github.com/SinergiaTIC/SinergiaCRM/pull/867. 
El funcionamiento establecido es que:
 1.  El usuario proveniente de SinergiaCRM pertenecerá o no al grupo EDA_RO, dependiendo del valor de la columna readonly. 
 2. Los usuarios administradores provenientes de SInergiaCRM en ningún caso pertenecerán a este grupo (independientemente de que tengan establecido este flag)
 3. Esta configuración se establece al ejecutar UpdateModel.

## Issue(s) resuelto(s)
- solves #216 

## Pruebas a realizar para validar el cambio
- En Sinergia CRM establecer la propiedad solo lectura de SinergiaDA a varios usuarios, reconstruir y ejecutar UpdateModel y verificar que se ha aplicado correctamente la pertenencia a no al grupo EDA_RO.
-  Desactivar y hacer otras modificaciones a los usuarios y verificar que el resultado es coherente.

