### PR TITLE
Hotfix - API - Corrección del tipo de grupo al actualizar el grupo

### DIFF
--- a/eda/eda_api/lib/module/admin/groups/group.controller.ts
+++ b/eda/eda_api/lib/module/admin/groups/group.controller.ts
@@ -187,7 +187,7 @@ export class GroupController {
 
         group.name = body.name
         group.users = body.users
-        group.role = 'EDA_USER_ROLE'
+        req.params.id === '135792467811111111111110' ? group.role = 'EDA_ADMIN_ROLE' : group.role = 'EDA_USER_ROLE';
 
         group.save(async (err, groupSaved: IGroup) => {
           if (err) {


### PR DESCRIPTION


## Descripción del Cambio
Cuando se actualiza un grupo se estaba cambiando a grupo de usuario forzado.

## Issue(s) resuelto(s)
<!-- Indicar el #<número> del/los issues resiueltos por este Pull Request -->
- solves #401 

## Pruebas a realizar para validar el cambio
Las descritas en el issue Actualizar un usuario del grupo admin y comprobar que sigue siendo admin


