### PR TITLE
Hotfix - Informes - Evitar borrar todos los campos del módulo principal

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -1568,8 +1568,8 @@ export class EdaBlankPanelComponent implements OnInit {
 
 /**SDA CUSTOM  */   public removeColumn = (c: Column, list?: string) => {
 /**SDA CUSTOM  */       // Conditions to check if we can delete the column
-/**SDA CUSTOM  */       const isNotRootColumn = c?.joins.length !== 0;
-/**SDA CUSTOM  */       const rootColumnElements = this.currentQuery.filter(col => col?.joins.length === 0).length;
+/**SDA CUSTOM  */       const isNotRootColumn = !!c?.joins?.length;
+/**SDA CUSTOM  */       const rootColumnElements = this.currentQuery.filter(col => !col?.joins?.length).length;
 /**SDA CUSTOM  */       const currentQueryLength = this.currentQuery.length;
 /**SDA CUSTOM  */
 /**SDA CUSTOM  */       // We just proceed if it is not the last column of the root table

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -1566,29 +1566,29 @@ export class EdaBlankPanelComponent implements OnInit {
 
     public loadColumns = (table: any) => PanelInteractionUtils.loadColumns(this, table);
 
-    public removeColumn = (c: Column, list?: string) => {
-        // Conditions to check if we can delete the column
-        const isNotRootColumn = c?.joins.length !== 0;
-        const rootColumnElements = this.currentQuery.filter(col => col?.joins.length === 0).length;
-        const currentQueryLength = this.currentQuery.length;
-
-        // We just proceed if it is not the last column of the root table
-        if (isNotRootColumn || rootColumnElements > 1 || currentQueryLength === 1) {
-            // We check if when deleting a field it has a filter at selectedFilters
-            if (this.selectedFilters.some((sf: any) => sf.filter_column === c.column_name)) {
-                if (this.sortedFilters.length !== 0) {
-                    this.alertService.addWarning($localize`:@@filterSettingsReboot:La configuración de filtros se ha reiniciado`);
-                }
-                this.sortedFilters = []; // resets the values ​​because one or more filters were deleted
-            }
-            PanelInteractionUtils.removeColumn(this, c, list);
-        }
-        else {
-            // We stop the event propagation to not open the attribute panel
-            event.stopPropagation();
-            this.alertService.addError($localize`:@@cannotRemoveLastColumn:No se puede eliminar todas las columnas de la tabla raíz sin eliminar las columnas dependientes.`);
-        }
-    }
+/**SDA CUSTOM  */   public removeColumn = (c: Column, list?: string) => {
+/**SDA CUSTOM  */       // Conditions to check if we can delete the column
+/**SDA CUSTOM  */       const isNotRootColumn = c?.joins.length !== 0;
+/**SDA CUSTOM  */       const rootColumnElements = this.currentQuery.filter(col => col?.joins.length === 0).length;
+/**SDA CUSTOM  */       const currentQueryLength = this.currentQuery.length;
+/**SDA CUSTOM  */
+/**SDA CUSTOM  */       // We just proceed if it is not the last column of the root table
+/**SDA CUSTOM  */       if (isNotRootColumn || rootColumnElements > 1 || currentQueryLength === 1) {
+/**SDA CUSTOM  */           // We check if when deleting a field it has a filter at selectedFilters
+                            if (this.selectedFilters.some((sf: any) => sf.filter_column === c.column_name)) {
+                                if (this.sortedFilters.length !== 0) {
+                                    this.alertService.addWarning($localize`:@@filterSettingsReboot:La configuración de filtros se ha reiniciado`);
+                                }
+                                this.sortedFilters = []; // resets the values ​​because one or more filters were deleted
+                            }
+                            PanelInteractionUtils.removeColumn(this, c, list);
+                        }
+/**SDA CUSTOM  */       else {
+/**SDA CUSTOM  */       // We stop the event propagation to not open the attribute panel
+/**SDA CUSTOM  */           event.stopPropagation();
+/**SDA CUSTOM  */           this.alertService.addError($localize`:@@cannotRemoveLastColumn:No se puede eliminar todas las columnas de la tabla raíz sin eliminar las columnas dependientes.`);
+/**SDA CUSTOM  */       }
+                   }
 
     public getOptionDescription = (value: string): string => EbpUtils.getOptionDescription(value);
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -1586,7 +1586,7 @@ export class EdaBlankPanelComponent implements OnInit {
         else {
             // We stop the event propagation to not open the attribute panel
             event.stopPropagation();
-            this.alertService.addError($localize`:@@cannotRemoveLastColumn:No se puede eliminar la última columna de la tabla raíz, si esta no es la última de la consulta.`);
+            this.alertService.addError($localize`:@@cannotRemoveLastColumn:No se puede eliminar todas las columnas de la tabla raíz sin eliminar las columnas dependientes.`);
         }
     }
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -1566,15 +1566,28 @@ export class EdaBlankPanelComponent implements OnInit {
 
     public loadColumns = (table: any) => PanelInteractionUtils.loadColumns(this, table);
 
-    public removeColumn = (c: Column, list?: string, event?: Event) => {
+    public removeColumn = (c: Column, list?: string) => {
+        // Conditions to check if we can delete the column
+        const isNotRootColumn = c?.joins.length !== 0;
+        const rootColumnElements = this.currentQuery.filter(col => col?.joins.length === 0).length;
+        const currentQueryLength = this.currentQuery.length;
+
+        // We just proceed if it is not the last column of the root table
+        if (isNotRootColumn || rootColumnElements > 1 || currentQueryLength === 1) {
             // We check if when deleting a field it has a filter at selectedFilters
-        if(this.selectedFilters.some( (sf: any) => sf.filter_column === c.column_name )){
-            if(this.sortedFilters.length !==0) {
-                this.alertService.addWarning($localize`:@@filterSettingsReboot:La configuración de filtros se ha reiniciado`);
+            if (this.selectedFilters.some((sf: any) => sf.filter_column === c.column_name)) {
+                if (this.sortedFilters.length !== 0) {
+                    this.alertService.addWarning($localize`:@@filterSettingsReboot:La configuración de filtros se ha reiniciado`);
+                }
+                this.sortedFilters = []; // resets the values ​​because one or more filters were deleted
             }
-            this.sortedFilters = []; // resets the values ​​because one or more filters were deleted
-        }    
-        PanelInteractionUtils.removeColumn(this, c, list);
+            PanelInteractionUtils.removeColumn(this, c, list);
+        }
+        else {
+            // We stop the event propagation to not open the attribute panel
+            event.stopPropagation();
+            this.alertService.addError($localize`:@@cannotRemoveLastColumn:No se puede eliminar la última columna de la tabla raíz, si esta no es la última de la consulta.`);
+        }
     }
 
     public getOptionDescription = (value: string): string => EbpUtils.getOptionDescription(value);

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
@@ -714,7 +714,7 @@ export const PanelInteractionUtils = {
           // If only there is 1 column of rootTable, check if panel have any globalFilter linked it.
           if (ebp.currentQuery.map((query) => query.table_id == rootTable).length <= 1) {
             if (ebp.globalFilters.some((filter) => filter.filter_table === rootTable)) {
-              event.stopPropagation();
+/**SDA CUSTOM  */ event.stopPropagation();
               ebp.alertService.addError($localize`@@removeColumnGlobalFilter:No se puede eliminar la columna porque hay vinculado un Filtro`);
               throw '[Error]: Can not remove this column cause there is a GlobalFilter linked.'
             }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
@@ -714,6 +714,7 @@ export const PanelInteractionUtils = {
           // If only there is 1 column of rootTable, check if panel have any globalFilter linked it.
           if (ebp.currentQuery.map((query) => query.table_id == rootTable).length <= 1) {
             if (ebp.globalFilters.some((filter) => filter.filter_table === rootTable)) {
+              event.stopPropagation();
               ebp.alertService.addError($localize`@@removeColumnGlobalFilter:No se puede eliminar la columna porque hay vinculado un Filtro`);
               throw '[Error]: Can not remove this column cause there is a GlobalFilter linked.'
             }

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4434,6 +4434,10 @@ Un cop configurada podreu invocar-la des del botó sempre que calgui.</target>
         <source>La configuración de filtros del panel involucrado se ha reiniciado</source>
         <target>La configuració de filtres del panell s'ha restablert</target>
       </trans-unit>
+      <trans-unit id="cannotRemoveLastColumn">
+        <source>No se puede eliminar la última columna de la tabla raíz, si esta no es la última de la consulta.</source>
+        <target>No es pot eliminar la darrera columna de la taula arrel, si aquesta no és la darrera de la consulta.</target>
+      </trans-unit>
       <trans-unit id="withoutFilters">
         <source>Aún no has configurado filtros. Usa el panel de filtros o los filtros globales</source>
         <target>Encara no heu configurat cap filtre. Feu servir el panell de filtres o els filtres globals.</target>

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4436,7 +4436,7 @@ Un cop configurada podreu invocar-la des del botó sempre que calgui.</target>
       </trans-unit>
       <trans-unit id="cannotRemoveLastColumn">
         <source>No se puede eliminar la última columna de la tabla raíz, si esta no es la última de la consulta.</source>
-        <target>No es pot eliminar la darrera columna de la taula arrel, si aquesta no és la darrera de la consulta.</target>
+        <target>La columna no es pot eliminar. Mentre el panell tingui columnes de taules relacionades cal que conservi almenys una columna de la taula principal.</target>
       </trans-unit>
       <trans-unit id="withoutFilters">
         <source>Aún no has configurado filtros. Usa el panel de filtros o los filtros globales</source>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4617,7 +4617,7 @@ Once configured you can invoke it whenever you want from the button.</target>
       </trans-unit>
       <trans-unit id="cannotRemoveLastColumn">
         <source>No se puede eliminar la última columna de la tabla raíz, si esta no es la última de la consulta.</source>
-        <target>You cannot delete the last column of the root table if it is not the last column in the query.</target>
+        <target>The column cannot be deleted. As long as the panel has columns from related tables, it must retain at least one column from the main table.</target>
       </trans-unit>
       <trans-unit id="withoutFilters">
         <source>Aún no has configurado filtros. Usa el panel de filtros o los filtros globales</source>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4615,6 +4615,10 @@ Once configured you can invoke it whenever you want from the button.</target>
         <source>La configuración de filtros del panel involucrado se ha reiniciado</source>
         <target>Panel filter settings have been reset</target>
       </trans-unit>
+      <trans-unit id="cannotRemoveLastColumn">
+        <source>No se puede eliminar la última columna de la tabla raíz, si esta no es la última de la consulta.</source>
+        <target>You cannot delete the last column of the root table if it is not the last column in the query.</target>
+      </trans-unit>
       <trans-unit id="withoutFilters">
         <source>Aún no has configurado filtros. Usa el panel de filtros o los filtros globales</source>
         <target>You haven't set up any filter. Use the filter panel or global filters.</target>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4411,7 +4411,7 @@
       </trans-unit>
       <trans-unit id="cannotRemoveLastColumn">
         <source>No se puede eliminar la última columna de la tabla raíz, si esta no es la última de la consulta.</source>
-        <target>No se puede eliminar la última columna del módulo principal, si esta no es la última que queda en el panel.</target>
+        <target>La columna no se puede eliminar. En tanto el panel contenga columnas de tablas relacionadas deberá conservar al menos una columna de la tabla principal.</target>
       </trans-unit>
       <trans-unit id="withoutFilters">
         <source>Aún no has configurado filtros. Usa el panel de filtros o los filtros globales</source>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4409,6 +4409,10 @@
         <source>La configuración de filtros del panel involucrado se ha reiniciado</source>
         <target>La configuración de filtros del panel se ha restablecido</target>
       </trans-unit>
+      <trans-unit id="cannotRemoveLastColumn">
+        <source>No se puede eliminar la última columna de la tabla raíz, si esta no es la última de la consulta.</source>
+        <target>No se puede eliminar la última columna de la tabla raíz, si esta no es la última de la consulta.</target>
+      </trans-unit>
       <trans-unit id="withoutFilters">
         <source>Aún no has configurado filtros. Usa el panel de filtros o los filtros globales</source>
         <target>Aún no se ha configurado ningún filtro. Use el panel de filtros o los filtros globales.</target>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4411,7 +4411,7 @@
       </trans-unit>
       <trans-unit id="cannotRemoveLastColumn">
         <source>No se puede eliminar la última columna de la tabla raíz, si esta no es la última de la consulta.</source>
-        <target>No se puede eliminar la última columna de la tabla raíz, si esta no es la última de la consulta.</target>
+        <target>No se puede eliminar la última columna del módulo principal, si esta no es la última que queda en el panel.</target>
       </trans-unit>
       <trans-unit id="withoutFilters">
         <source>Aún no has configurado filtros. Usa el panel de filtros o los filtros globales</source>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -4410,6 +4410,10 @@
         <source>La configuración de filtros del panel involucrado se ha reiniciado</source>
         <target>Restablecéronse a configuración do filtro para o panel implicado</target>
       </trans-unit>
+      <trans-unit id="cannotRemoveLastColumn">
+        <source>No se puede eliminar la última columna de la tabla raíz, si esta no es la última de la consulta.</source>
+        <target>No se puede eliminar la última columna de la tabla raíz, si esta no es la última de la consulta.</target>
+      </trans-unit>
       <trans-unit id="withoutFilters">
         <source>Aún no has configurado filtros. Usa el panel de filtros o los filtros globales</source>
         <target>Aínda non configuraches os filtros. Usar o panel de filtros ou os filtros globais</target>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -4412,7 +4412,7 @@
       </trans-unit>
       <trans-unit id="cannotRemoveLastColumn">
         <source>No se puede eliminar la última columna de la tabla raíz, si esta no es la última de la consulta.</source>
-        <target>No se puede eliminar la última columna de la tabla raíz, si esta no es la última de la consulta.</target>
+        <target>La columna no se puede eliminar. En tanto el panel contenga columnas de tablas relacionadas deberá conservar al menos una columna de la tabla principal.</target>
       </trans-unit>
       <trans-unit id="withoutFilters">
         <source>Aún no has configurado filtros. Usa el panel de filtros o los filtros globales</source>


### PR DESCRIPTION
## Descripción del Cambio
Al eliminar un campo de la consulta se comprueba si  queda algún campo cd la tabla principal. Si se intenta borrar el último campo de la tabla principal surge un error. 

## Issue(s) resuelto(s)
- solves #268

## Pruebas a realizar para validar el cambio
Abrir cualquier informe e intentar borrar los campos de la consulta. Te dejará borrar todos los que quieras excepto si intentas borrar el último campo de la tabla principal quedando campos de otras tablas

## Información Adicional
Hay que tener en cuenta también que hay otra validación que no te deja borrar el último campo de la tabla principal si hay filtros del informe vinculados a este. Se ha añadido una función para mejorar el comportamiento en este caso también.
