### PR TITLE
Hotfix - Informes - Filtrado de etiquetas en la configuración del dashboard para eliminar entradas vacías

### DIFF
--- a/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.ts
+++ b/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.ts
@@ -270,7 +270,7 @@ export class HomeSdaComponent implements OnInit {
       config: {
         ...dashboard.config,
         tag: Array.isArray(dashboard.config.tag)
-          ? dashboard.config.tag.map(tag => tag.trim())
+          ? dashboard.config.tag.filter(t => t).map(tag => tag.trim())
           : dashboard.config.tag
           ? [dashboard.config.tag.trim()]
           : []


### PR DESCRIPTION
### Descripción
resolve #408
Se ha modificado el método `normalizeDashboard` en `HomeSdaComponent` para filtrar y sanear el array de etiquetas (`tags`) al cargar los informes. Esto evita que la aplicación falle al intentar procesar informes que fueron guardados con la opción "SIN ETIQUETA", los cuales persistían un valor `[null]` en la base de datos, rompiendo la visualización del listado general.

### Cómo reproducirlo
1. Tener un informe existente en la base de datos que tenga el campo tag con valor `[null]` (o guardar uno seleccionando la opción "SIN ETIQUETA" antes de aplicar este parche).
2. Acceder a la vista principal de informes (Home).
3. Verificar que la lista de informes se carga correctamente y no se produce un error en blanco o de consola, mostrando el informe afectado simplemente sin etiquetas.