### PR TITLE
Hotfix - Filtros - Evitar error al agregar filtros de informe y en consultas SQL

### DIFF
--- a/eda/eda_api/lib/services/query-builder/query-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/query-builder.service.ts
@@ -829,17 +829,22 @@ export abstract class QueryBuilderService {
      */
 
     // not needed to filter relations. They are stored in a different array
-    public findRelationsRecursive(tables, table, vMap) {
-        vMap.set(table.table_name, table);
-        table.relations
-            .forEach(rel => {
-                const newTable = tables.find(t => t.table_name === rel.target_table);
-                if (!vMap.has(newTable.table_name)) {
-                    this.findRelationsRecursive(tables, newTable, vMap);
-                }
-            });
-        return vMap;
-    }
+        public findRelationsRecursive(tables, table, vMap) {
+
+/* SDA CUSTOM */ // SDA CUSTOM - Added safety check for table and relations to avoid TypeError
+/* SDA CUSTOM */         if (!table) return vMap;
+/* SDA CUSTOM */         vMap.set(table.table_name, table);
+/* SDA CUSTOM */         if (table.relations) {
+/* SDA CUSTOM */             table.relations
+/* SDA CUSTOM */                .forEach(rel => {
+/* SDA CUSTOM */                     const newTable = tables.find(t => t.table_name === rel.target_table);
+/* SDA CUSTOM */                     if (newTable && !vMap.has(newTable.table_name)) {
+/* SDA CUSTOM */                         this.findRelationsRecursive(tables, newTable, vMap);
+/* SDA CUSTOM */                        }
+/* SDA CUSTOM */                    });
+/* SDA CUSTOM */                }
+/* SDA CUSTOM */        return vMap;
+/* SDA CUSTOM */    }
 
     public findJoinColumns(tableA: string, tableB: string) {
 

--- a/eda/eda_api/lib/services/query-builder/query-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/query-builder.service.ts
@@ -830,8 +830,8 @@ export abstract class QueryBuilderService {
 
     // not needed to filter relations. They are stored in a different array
         public findRelationsRecursive(tables, table, vMap) {
-
-/* SDA CUSTOM */ // SDA CUSTOM - Added safety check for table and relations to avoid TypeError
+// SDA CUSTOM - Added safety check for table and relations to avoid TypeError
+/* SDA CUSTOM */ 
 /* SDA CUSTOM */         if (!table) return vMap;
 /* SDA CUSTOM */         vMap.set(table.table_name, table);
 /* SDA CUSTOM */         if (table.relations) {
@@ -845,6 +845,7 @@ export abstract class QueryBuilderService {
 /* SDA CUSTOM */                }
 /* SDA CUSTOM */        return vMap;
 /* SDA CUSTOM */    }
+// END SDA CUSTOM
 
     public findJoinColumns(tableA: string, tableB: string) {
 

--- a/eda/eda_app/src/app/services/api/global-filters.service.ts
+++ b/eda/eda_app/src/app/services/api/global-filters.service.ts
@@ -298,7 +298,7 @@ export class GlobalFiltersService {
                 /** Checks if the current child_node is included before.
                  * This prevents duplicated paths.*/
                 if ((!rootTree.includes(relation.target_table) || relation.autorelation) && !childrenId.includes(child_id)) {
-                    // Label to show on the treeComponent 
+                    // Label to show on the treeComponent
                     let childLabel = relation.display_name?.default
                         ? `${relation.display_name.default}`
                         : ` ${relation.source_column[0]} - ${relation.target_table} `;
@@ -336,7 +336,7 @@ export class GlobalFiltersService {
                             (source.relations || []).some((rel: any) => rel.target_table != table_id);
                     });
 
-                    // If it's expandable, we add properties to expand the node. 
+                    // If it's expandable, we add properties to expand the node.
                     if (isexpandible && !relation.autorelation) {
                         childNode.expandedIcon = "pi pi-folder-open";
                         childNode.collapsedIcon = "pi pi-folder";
@@ -471,7 +471,7 @@ export class GlobalFiltersService {
     /**
      * Returns the selected values (labels) for a global filter, formatted according to the column type.
      * If the filter is of type 'date' and only one value is selected, adjusts the range to cover the entire year or month.
-     * 
+     *
      * @param globalFilter Object containing the global filter information and the selected items.
      * @returns An array of objects with the selected values, structured depending on whether it is a date filter or not.
      */

--- a/eda/eda_app/src/app/services/api/global-filters.service.ts
+++ b/eda/eda_app/src/app/services/api/global-filters.service.ts
@@ -97,9 +97,12 @@ export class GlobalFiltersService {
         const tableRelations = table.relations.filter((rel: any) => rel.visible);
 
         for (const rel of tableRelations) {
-            let newTable = modelTables.find((t: any) => t.table_name === rel.target_table || t.table_name === `${rel.target_table}.${rel.target_column[0]}`);
+            const newTable = modelTables.find((t: any) =>
+                t.table_name === rel.target_table ||
+                t.table_name === `${rel.target_table}.${rel.target_column[0]}`
+            );
 
-            if (newTable.table_name && !vMap.has(newTable.table_name)) {
+            if (newTable?.table_name && !vMap.has(newTable.table_name)) {
                 this.findRelations(modelTables, newTable, vMap);
             }
         }

--- a/eda/eda_app/src/app/services/api/global-filters.service.ts
+++ b/eda/eda_app/src/app/services/api/global-filters.service.ts
@@ -97,12 +97,9 @@ export class GlobalFiltersService {
         const tableRelations = table.relations.filter((rel: any) => rel.visible);
 
         for (const rel of tableRelations) {
-            const newTable = modelTables.find((t: any) =>
-                t.table_name === rel.target_table ||
-                t.table_name === `${rel.target_table}.${rel.target_column[0]}`
-            );
+        /*SDA CUSTOM*/    const newTable = modelTables.find((t: any) => t.table_name === rel.target_table || t.table_name === `${rel.target_table}.${rel.target_column[0]}`);
 
-            if (newTable?.table_name && !vMap.has(newTable.table_name)) {
+        /*SDA CUSTOM*/    if (newTable?.table_name && !vMap.has(newTable.table_name)) {
                 this.findRelations(modelTables, newTable, vMap);
             }
         }


### PR DESCRIPTION
## Descripción
Se ha visto que hay un error programático que no previene determinados casos de valores nulos en la función `findRelations` al añadir filtros de informe, que provoca que la ventana de filtros quede en blanco.
<img width="663" height="227" alt="image" src="https://github.com/user-attachments/assets/668df20e-ebdf-4f39-8cd9-b6a8009b47f5" />

Se ha corregido la función en el Pull Request https://github.com/SinergiaTIC/SinergiaDA/pull/424 y tras instalarlo en la instancia en que se había detectado el errors se ha comprobado  que el problema queda corregido.

Adicionalmente se ha corregido también la función `findRelationsRecursive` en el fichero _eda/eda_api/lib/services/query-builder/query-builder.service.ts_ debido a que estaba también generando errores de typo, ya que no se comprobabá la existencia de algunas variables antes de iterar sobre ellas  o utilizarlas


###Pruebas a realizar:
- Por inspección de código.
- Verificar que la adición de filtros de informe funciona con normalidad.
- verificar que no hay errores de querying dtaabase en los paneles SQL