### PR TITLE
Enhancement - Informes - Cambiar la etiqueta del campo sin necesidad de duplicarlo y añadir botón cancelar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ eda/eda_api/config/base_datamodel.json
 eda/eda_api/metadata.json
 .vscode
 eda/eda_app/src/locale/prod_messages*xlf
+.agent/rules.md
+.cursorrules

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html
@@ -4,15 +4,15 @@
 
         <!-- SDA CUSTOM Nombre de la columna -->
         <div class="col-12 mt-2" *ngIf="selectedColumn">
-        
+
             <div class="d-flex align-items-center flex-wrap" style="gap: 15px;">
-        
+
                 <h4 style="margin: 0; white-space: nowrap;">
          <span i18n="@@nombreColumnaH4">Etiqueta para el campo</span> [{{tableLabel}} -
                     {{sourceFieldName}}]:
-                   
+
                 </h4>
-                
+
                 <div style="flex-grow: 1; min-width: 250px; max-width: 500px;">
                     <input id="columnName" type="text" pInputText
                         [(ngModel)]="selectedColumn.display_name.default"
@@ -21,7 +21,7 @@
                 </div>
             </div>
             <hr>
-           
+
         </div>
         <!-- END SDA CUSTOM -->
 
@@ -74,7 +74,8 @@
 
             <div class="grid mt-2">
 
-                <div [ngClass]="{
+                <div
+                    [ngClass]="{
                         'md:col-4': (!display.between && !display.calendar ) || (!!display.calendar ),
                         'md:col-8': !(!display.between && !display.calendar) || (!!display.calendar)
                     }">
@@ -99,7 +100,7 @@
 
                         <ng-container *ngIf="!!display.calendar && !filter.switch">
 
-                            <div>
+                            <div >
 
                                 <!-- <label i18n="@@fechaLabel" class="p-float-label" for="datepicker">
                                     Fecha
@@ -153,15 +154,14 @@
                 </ng-container>
 
 
-                <ng-container
-                    *ngIf="filterSelected!=undefined && selectedColumn.column_type ==='numeric'  && !display.switchButton && (aggregationSelected.display_name !== 'No')">
+                <ng-container *ngIf="filterSelected!=undefined && selectedColumn.column_type ==='numeric'  && !display.switchButton && (aggregationSelected.display_name !== 'No')">
 
                     <div class="col-12 md:col-4">
 
                         <span class="p-float-label">
-                            <p-dropdown id="types" [options]="filterBeforeAfter.elements"
-                                [(ngModel)]="filterBeforeAfterSelected" optionLabel="label" [autoDisplayFirst]="true"
-                                [style]="{'width': '100%'}" (onChange)="whereHavingSwitch(filterBeforeAfterSelected)">
+                            <p-dropdown id="types" [options]="filterBeforeAfter.elements" [(ngModel)]="filterBeforeAfterSelected" optionLabel="label"
+                                [autoDisplayFirst]="true" [style]="{'width': '100%'}"
+                                (onChange)="whereHavingSwitch(filterBeforeAfterSelected)">
                             </p-dropdown>
 
                             <!-- <label i18n="@@tiposFiltrosLabel" for="types">
@@ -257,8 +257,8 @@
                                     </label> -->
 
                                     <p-multiSelect [options]="dropDownFields" [(ngModel)]="filterValue.value1"
-                                        [virtualScroll]="true" [itemSize]="34" [filter]="false"
-                                        [style]="{width: '100%'}" [panelStyle]="{minWidth:'100%'}"
+                                        [virtualScroll]="true" [itemSize]="34" [filter]="false" [style]="{width: '100%'}"
+                                        [panelStyle]="{minWidth:'100%'}"
                                         (onChange)="handleValidForm({value1: filterValue.value1})"
                                         defaultLabel="Selecciona Valor 1" [selectionLimit]="limitSelectionFields"
                                         id="float-input1">
@@ -277,8 +277,8 @@
                                     </label> -->
 
                                     <p-multiSelect [options]="dropDownFields" [(ngModel)]="filterValue.value2"
-                                        [virtualScroll]="true" [itemSize]="34" [filter]="false"
-                                        [style]="{width: '100%'}" [panelStyle]="{minWidth:'100%'}"
+                                        [virtualScroll]="true" [itemSize]="34" [filter]="false" [style]="{width: '100%'}"
+                                        [panelStyle]="{minWidth:'100%'}"
                                         (onChange)="handleValidForm({value2: filterValue.value2})"
                                         defaultLabel="Selecciona Valor 2" [selectionLimit]="limitSelectionFields"
                                         id="float-input2">
@@ -342,22 +342,22 @@
                             <h4 i18n="@@dateFormatH4"> Formato </h4>
 
                             <hr>
-                            <!--SDA CUSTOM-->
-                            <div *ngIf="selectedColumn.computed_column == 'computed'" class="p-message p-message-info"
-                                style="margin-bottom: 1em; padding: 0.5em;">
-                                <!--SDA CUSTOM--> <i class="pi pi-exclamation-triangle"
-                                    style="margin-right: 0.5em;"></i>
-                                <!--SDA CUSTOM--> <span i18n="@@noFormatsAvailable"> Esta es una columna calculada y no
-                                    tiene opciones de formato disponibles</span>
-                                <!--SDA CUSTOM-->
-                            </div>
-                            <!--SDA CUSTOM-->
-                            <div *ngIf="selectedColumn.computed_column != 'computed'">
+                           <!--SDA CUSTOM--> <div *ngIf="selectedColumn.computed_column == 'computed'" class="p-message p-message-info" style="margin-bottom: 1em; padding: 0.5em;">
+                           <!--SDA CUSTOM-->     <i class="pi pi-exclamation-triangle" style="margin-right: 0.5em;"></i>
+                           <!--SDA CUSTOM-->     <span i18n="@@noFormatsAvailable"> Esta es una columna calculada y no tiene opciones de formato disponibles</span>
+                           <!--SDA CUSTOM--> </div>
+                           <!--SDA CUSTOM--> <div *ngIf="selectedColumn.computed_column != 'computed'">
 
 
-                                <p-dropdown [(ngModel)]="formatDate" [options]="formatDates"
-                                    [optionLabel]="'display_name'" [autoDisplayFirst]="false" [showClear]="true"
-                                    [style]="{'min-width': '100%'}" (onChange)="addFormatDate(format)" class="w-100"
+                                <p-dropdown
+                                    [(ngModel)]="formatDate"
+                                    [options]="formatDates"
+                                    [optionLabel]="'display_name'"
+                                    [autoDisplayFirst]="false"
+                                    [showClear]="true"
+                                    [style]="{'min-width': '100%'}"
+                                    (onChange)="addFormatDate(format)"
+                                    class="w-100"
                                     appendTo="body">
                                 </p-dropdown>
 
@@ -370,15 +370,12 @@
 
 
 
-                                <div style="margin-top: 1.5em; margin-left: 1em;" [pTooltip]="cumulativeSumTooltip"
-                                    tooltipPosition="left">
+                                <div  style="margin-top: 1.5em; margin-left: 1em;" [pTooltip]="cumulativeSumTooltip" tooltipPosition="left">
                                     <h6 i18n="@@cumulativeSum">Suma acumulativa</h6>
                                     <p-inputSwitch id="cumulativeSum" [(ngModel)]="cumulativeSum"
-                                        (onChange)="handleCumulativeSum()"
-                                        [disabled]="!cumulativeSumAllowed()"></p-inputSwitch>
+                                  (onChange)="handleCumulativeSum()" [disabled]="!cumulativeSumAllowed()"></p-inputSwitch >
                                 </div>
-                                <!-- SDA CUSTOM -->
-                            </div>
+                        <!--SDA CUSTOM-->      </div>
                         </ng-container>
 
                         <ng-container *ngIf="selectedColumn.aggregation_type.length===7">
@@ -386,21 +383,14 @@
                             <h4 i18n="@@dateFormatH4"> Formato </h4>
 
                             <hr>
-                            <!--SDA CUSTOM-->
-                            <div *ngIf="selectedColumn.computed_column == 'computed'" class="p-message p-message-info"
-                                style="margin-bottom: 1em; padding: 0.5em;">
-                                <!--SDA CUSTOM--> <i class="pi pi-exclamation-triangle"
-                                    style="margin-right: 0.5em;"></i>
-                                <!--SDA CUSTOM--> <span i18n="@@noFormatsAvailable"> Esta es una columna calculada y no
-                                    tiene opciones de formato disponibles</span>
-                                <!--SDA CUSTOM-->
-                            </div>
-                            <!--SDA CUSTOM-->
-                            <div *ngIf="selectedColumn.computed_column != 'computed'" style="margin: 10px 0;">
+                           <!--SDA CUSTOM--><div *ngIf="selectedColumn.computed_column == 'computed'" class="p-message p-message-info" style="margin-bottom: 1em; padding: 0.5em;">
+                           <!--SDA CUSTOM-->    <i class="pi pi-exclamation-triangle" style="margin-right: 0.5em;"></i>
+                           <!--SDA CUSTOM-->    <span i18n="@@noFormatsAvailable"> Esta es una columna calculada y no tiene opciones de formato disponibles</span>
+                           <!--SDA CUSTOM--></div>
+                           <!--SDA CUSTOM--><div *ngIf="selectedColumn.computed_column != 'computed'" style="margin: 10px 0;">
 
                                 <div>
-                                    <h5 i18n="@@rangesExpresionH5"
-                                        style="margin-top: 5px; font-size: 1.2rem; display: inline;">Rangos: </h5>
+                                    <h5 i18n="@@rangesExpresionH5" style="margin-top: 5px; font-size: 1.2rem; display: inline;">Rangos: </h5>
                                     <span *ngIf="availableRange">
                                         <i class="pi pi-info-circle"
                                             style="cursor: pointer; margin-top: -5px; font-size: 1.2rem;"
@@ -420,31 +410,33 @@
 
                                 <div *ngIf="availableRange">
 
-                                    <input type="text" style="font-size: 1rem; margin-bottom: 10px;"
-                                        [(ngModel)]="rangeString" [disabled]="showRange"
+                                <input
+                                type="text"
+                                style="font-size: 1rem; margin-bottom: 10px;"
+                                [(ngModel)]="rangeString"
+                                [disabled]="showRange"
                                         (input)="validateInput($event)">
 
-                                    <p-button (onClick)="addRange(rangeString)" label="Añadir Rango"
+                                <p-button
+                                    (onClick)="addRange(rangeString)"
+                                    label="Añadir Rango"
                                         [disabled]="((!rangeString || rangeString.length === 0)) || showRange"
-                                        i18n-label="@@addRange">
+                                    i18n-label="@@addRange"
+                                    >
                                     </p-button>
 
                                     <div *ngIf="showRange" class="col-12 foot-card" style="margin-top: 5px;">
 
-                                        <p-scrollPanel [style]="{width: '100%', height: '160px'}"
-                                            styleClass="custombar1">
+                                    <p-scrollPanel [style]="{width: '100%', height: '160px'}" styleClass="custombar1">
 
                                             <ng-container *ngIf="showRange">
 
                                                 <b i18n="@@rangeDescriptionB" class="mr-2 pull-left">
                                                     • Rango:
                                                 </b>
-                                                <i class="pull-right ui-dropdown-clear-icon pi pi-times pointer md-3"
-                                                    (click)="removeRange()"></i>
+                                              <i class="pull-right ui-dropdown-clear-icon pi pi-times pointer md-3"(click)="removeRange()"></i>
 
-                                                <div *ngIf="showRange" class="d-flex align-items-center"
-                                                    [innerHTML]="selectedRange"
-                                                    style="font-size: 1rem; padding: 10px 40px 5px 30px;"></div>
+                                              <div *ngIf="showRange" class="d-flex align-items-center" [innerHTML]="selectedRange" style="font-size: 1rem; padding: 10px 40px 5px 30px;"></div>
 
                                             </ng-container>
 
@@ -454,8 +446,7 @@
 
                                 </div>
 
-                                <!-- SDA CUSTOM -->
-                            </div>
+                          <!--SDA CUSTOM--> </div>
                         </ng-container>
 
                     </ng-container>
@@ -477,10 +468,7 @@
                                     <b class="mr-2" style="margin: 2px;">
                                         * {{ selectedColumn.display_name.default }} is
                                         {{ filtre.filter_type }}
-                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"
-                                        tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage :
-                                            havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>:
-                                            {{getAggregationText(filtre)}} &nbsp;</b></span>
+                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"  tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage : havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>: {{getAggregationText(filtre)}}  &nbsp;</b></span>
 
                                     <i class="ui-dropdown-clear-icon pi pi-times pointer"
                                         (click)="removeFilter(filtre)"></i>
@@ -491,10 +479,7 @@
                                         * {{ selectedColumn.display_name.default }}
                                         {{ filtre.filter_type }}
                                         "{{ filtre.filter_elements[0].value1 }}"
-                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"
-                                        tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage :
-                                            havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>:
-                                            {{getAggregationText(filtre)}} &nbsp;</b></span>
+                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"  tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage : havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>: {{getAggregationText(filtre)}} &nbsp;</b></span>
 
                                     <i class="ui-dropdown-clear-icon pi pi-times pointer"
                                         (click)="removeFilter(filtre)"></i>
@@ -506,13 +491,9 @@
                                         {{ getFilterText(filtre) }}
                                         "{{ filtre.filter_elements[0].value1}}" - "{{ filtre.filter_elements[1].value2
                                         }}"
-                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"
-                                        tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage :
-                                            havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>:
-                                            {{getAggregationText(filtre)}} &nbsp;</b></span>
+                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"  tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage : havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>: {{getAggregationText(filtre)}} &nbsp;</b></span>
 
-                                    <i class="ui-dropdown-clear-icon pi pi-times pointer"
-                                        (click)="removeFilter(filtre)"></i>
+                                    <i class="ui-dropdown-clear-icon pi pi-times pointer" (click)="removeFilter(filtre)"></i>
                                 </p>
 
                             </ng-container>
@@ -530,8 +511,7 @@
         <!-- Duplicar columna -->
         <div class="col-12" style="position: absolute; bottom: 0; right:1.9rem" class="text-right">
             <button type="button" pButton (click)="duplicateColumn()" icon="fa fa-check"
-                class="p-button p-button-raised ml-2" i18n-label="@@duplicateColumnButton" label="Duplicar columna"
-                id="eda_column_dialog_confirmar">
+                class="p-button p-button-raised ml-2" i18n-label="@@duplicateColumnButton" label="Duplicar columna" id="eda_column_dialog_confirmar">
             </button>
         </div>
 
@@ -541,11 +521,11 @@
         <!-- por defecto está habilitado.  Si el botón "añadir filtro" está habilitado este se desactiva.-->
         <div class="ui-dialog-buttonpane ui-widget-content ui-helper-clearfix text-right">
             <button type="button" pButton (click)="closeDialog()" class="p-button-raised p-button-success"
-                i18n-label="@@guardarButton" icon="fa fa-check" label="Confirmar" id="eda_column_dialog_confirmar"
-                [disabled]="!display.filterButton">
+                i18n-label="@@guardarButton" icon="fa fa-check" label="Confirmar"
+                id="eda_column_dialog_confirmar" [disabled]="!display.filterButton">
             </button>
 
-<!-- SDA CUSTOM -->
+<!-- SDA CUSTOM CANCEL BUTTON-->
              <button type="button" pButton (click)="cancelDialog()" class="p-button-raised p-button-danger"
                 i18n-label="@@cancelButton" icon="fa fa-times" label="Cancelar" id="eda_column_dialog_cancel">
             </button>
@@ -556,17 +536,15 @@
 
 </eda-dialog>
 
-<eda-dialog2 *ngIf="display.duplicateColumn" [display]="display.duplicateColumn" header="Duplicar columna" width="60vw"
-    height="auto" (close)="onCancelDuplicateColumn()" (apply)="saveDuplicatedColumn()">
+<eda-dialog2 *ngIf="display.duplicateColumn" [display]="display.duplicateColumn" header="Duplicar columna" width="60vw" height= "auto" (close)="onCancelDuplicateColumn()" (apply)="saveDuplicatedColumn()">
     <div content>
         <!-- Duplicar columna -->
         <div class="col-12">
             <span>
-                <label i18n="@@duplicatedColumnNameLabel" for="duplicatedColumnName"
-                    style="font-size: 18px;margin-right: 1.5rem;">
+                <label i18n="@@duplicatedColumnNameLabel" for="duplicatedColumnName" style="font-size: 18px;margin-right: 1.5rem;">
                     Nombre columna duplicada
                 </label>
-                <input pInputText id="duplicatedColumnName" [(ngModel)]="duplicatedColumnName" type="text" />
+                <input pInputText id="duplicatedColumnName" [(ngModel)]="duplicatedColumnName" type="text"  />
             </span>
         </div>
     </div>

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html
@@ -527,7 +527,7 @@
 
 <!-- SDA CUSTOM CANCEL BUTTON-->
              <button type="button" pButton (click)="cancelDialog()" class="p-button-raised p-button-danger"
-                i18n-label="@@cancelButton" icon="fa fa-times" label="Cancelar" id="eda_column_dialog_cancel">
+                i18n-label="@@DeleteGroupCancel" icon="fa fa-times" label="Cancelar" id="eda_column_dialog_cancel">
             </button>
 <!-- END SDA CUSTOM -->
         </div>

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html
@@ -2,6 +2,21 @@
 
     <div body class="grid mb-0 pb-0">
 
+        <!-- Nombre de la columna -->
+        <div class="col-12 mt-2" *ngIf="selectedColumn">
+            <div class="d-flex align-items-center flex-wrap" style="gap: 15px;">
+                <h4 style="margin: 0; white-space: nowrap;">
+                    <span i18n="@@nombreColumnaH4">Etiqueta para el campo</span> [{{tableLabel}} - {{sourceFieldName}}]:
+                </h4>
+                <div style="flex-grow: 1; min-width: 250px; max-width: 500px;">
+                    <input id="columnName" type="text" pInputText [(ngModel)]="selectedColumn.display_name.default"
+                        (blur)="renameColumn(selectedColumn.display_name.default)"
+                        (keydown.enter)="renameColumn(selectedColumn.display_name.default)" style="width: 100%;">
+                </div>
+            </div>
+            <hr>
+        </div>
+
         <!-- Agregaciones -->
         <div class="col-12 lg:col-2">
 
@@ -10,7 +25,7 @@
             </h4>
             <hr>
 
-            <div class="aggregation-list" >
+            <div class="aggregation-list">
                 <div class="aggregation-box" *ngFor="let aggregation of aggregationsTypes"
                     (click)="allowedAggregations && addAggregation(aggregation)"
                     [ngStyle]="{'cursor': !allowedAggregations ? 'not-allowed' : 'pointer'}"
@@ -51,8 +66,7 @@
 
             <div class="grid mt-2">
 
-                <div
-                    [ngClass]="{
+                <div [ngClass]="{
                         'md:col-4': (!display.between && !display.calendar ) || (!!display.calendar ),
                         'md:col-8': !(!display.between && !display.calendar) || (!!display.calendar)
                     }">
@@ -77,7 +91,7 @@
 
                         <ng-container *ngIf="!!display.calendar && !filter.switch">
 
-                            <div >
+                            <div>
 
                                 <!-- <label i18n="@@fechaLabel" class="p-float-label" for="datepicker">
                                     Fecha
@@ -131,14 +145,15 @@
                 </ng-container>
 
 
-                <ng-container *ngIf="filterSelected!=undefined && selectedColumn.column_type ==='numeric'  && !display.switchButton && (aggregationSelected.display_name !== 'No')">
+                <ng-container
+                    *ngIf="filterSelected!=undefined && selectedColumn.column_type ==='numeric'  && !display.switchButton && (aggregationSelected.display_name !== 'No')">
 
                     <div class="col-12 md:col-4">
 
                         <span class="p-float-label">
-                            <p-dropdown id="types" [options]="filterBeforeAfter.elements" [(ngModel)]="filterBeforeAfterSelected" optionLabel="label"
-                                [autoDisplayFirst]="true" [style]="{'width': '100%'}"
-                                (onChange)="whereHavingSwitch(filterBeforeAfterSelected)">
+                            <p-dropdown id="types" [options]="filterBeforeAfter.elements"
+                                [(ngModel)]="filterBeforeAfterSelected" optionLabel="label" [autoDisplayFirst]="true"
+                                [style]="{'width': '100%'}" (onChange)="whereHavingSwitch(filterBeforeAfterSelected)">
                             </p-dropdown>
 
                             <!-- <label i18n="@@tiposFiltrosLabel" for="types">
@@ -234,8 +249,8 @@
                                     </label> -->
 
                                     <p-multiSelect [options]="dropDownFields" [(ngModel)]="filterValue.value1"
-                                        [virtualScroll]="true" [itemSize]="34" [filter]="false" [style]="{width: '100%'}"
-                                        [panelStyle]="{minWidth:'100%'}"
+                                        [virtualScroll]="true" [itemSize]="34" [filter]="false"
+                                        [style]="{width: '100%'}" [panelStyle]="{minWidth:'100%'}"
                                         (onChange)="handleValidForm({value1: filterValue.value1})"
                                         defaultLabel="Selecciona Valor 1" [selectionLimit]="limitSelectionFields"
                                         id="float-input1">
@@ -254,8 +269,8 @@
                                     </label> -->
 
                                     <p-multiSelect [options]="dropDownFields" [(ngModel)]="filterValue.value2"
-                                        [virtualScroll]="true" [itemSize]="34" [filter]="false" [style]="{width: '100%'}"
-                                        [panelStyle]="{minWidth:'100%'}"
+                                        [virtualScroll]="true" [itemSize]="34" [filter]="false"
+                                        [style]="{width: '100%'}" [panelStyle]="{minWidth:'100%'}"
                                         (onChange)="handleValidForm({value2: filterValue.value2})"
                                         defaultLabel="Selecciona Valor 2" [selectionLimit]="limitSelectionFields"
                                         id="float-input2">
@@ -319,22 +334,22 @@
                             <h4 i18n="@@dateFormatH4"> Formato </h4>
 
                             <hr>
-                           <!--SDA CUSTOM--> <div *ngIf="selectedColumn.computed_column == 'computed'" class="p-message p-message-info" style="margin-bottom: 1em; padding: 0.5em;">
-                           <!--SDA CUSTOM-->     <i class="pi pi-exclamation-triangle" style="margin-right: 0.5em;"></i>
-                           <!--SDA CUSTOM-->     <span i18n="@@noFormatsAvailable"> Esta es una columna calculada y no tiene opciones de formato disponibles</span>
-                           <!--SDA CUSTOM--> </div>
-                           <!--SDA CUSTOM--> <div *ngIf="selectedColumn.computed_column != 'computed'">
+                            <!--SDA CUSTOM-->
+                            <div *ngIf="selectedColumn.computed_column == 'computed'" class="p-message p-message-info"
+                                style="margin-bottom: 1em; padding: 0.5em;">
+                                <!--SDA CUSTOM--> <i class="pi pi-exclamation-triangle"
+                                    style="margin-right: 0.5em;"></i>
+                                <!--SDA CUSTOM--> <span i18n="@@noFormatsAvailable"> Esta es una columna calculada y no
+                                    tiene opciones de formato disponibles</span>
+                                <!--SDA CUSTOM-->
+                            </div>
+                            <!--SDA CUSTOM-->
+                            <div *ngIf="selectedColumn.computed_column != 'computed'">
 
 
-                                <p-dropdown
-                                    [(ngModel)]="formatDate"
-                                    [options]="formatDates"
-                                    [optionLabel]="'display_name'"
-                                    [autoDisplayFirst]="false"
-                                    [showClear]="true"
-                                    [style]="{'min-width': '100%'}"
-                                    (onChange)="addFormatDate(format)"
-                                    class="w-100"
+                                <p-dropdown [(ngModel)]="formatDate" [options]="formatDates"
+                                    [optionLabel]="'display_name'" [autoDisplayFirst]="false" [showClear]="true"
+                                    [style]="{'min-width': '100%'}" (onChange)="addFormatDate(format)" class="w-100"
                                     appendTo="body">
                                 </p-dropdown>
 
@@ -347,12 +362,15 @@
 
 
 
-                                <div  style="margin-top: 1.5em; margin-left: 1em;" [pTooltip]="cumulativeSumTooltip" tooltipPosition="left">
-                                  <h6 i18n="@@cumulativeSum">Suma acumulativa</h6>
-                                  <p-inputSwitch id="cumulativeSum" [(ngModel)]="cumulativeSum"
-                                  (onChange)="handleCumulativeSum()" [disabled]="!cumulativeSumAllowed()"></p-inputSwitch >
+                                <div style="margin-top: 1.5em; margin-left: 1em;" [pTooltip]="cumulativeSumTooltip"
+                                    tooltipPosition="left">
+                                    <h6 i18n="@@cumulativeSum">Suma acumulativa</h6>
+                                    <p-inputSwitch id="cumulativeSum" [(ngModel)]="cumulativeSum"
+                                        (onChange)="handleCumulativeSum()"
+                                        [disabled]="!cumulativeSumAllowed()"></p-inputSwitch>
                                 </div>
-                        <!--SDA CUSTOM-->      </div>
+                                <!--SDA CUSTOM-->
+                            </div>
                         </ng-container>
 
                         <ng-container *ngIf="selectedColumn.aggregation_type.length===7">
@@ -360,70 +378,76 @@
                             <h4 i18n="@@dateFormatH4"> Formato </h4>
 
                             <hr>
-                           <!--SDA CUSTOM--><div *ngIf="selectedColumn.computed_column == 'computed'" class="p-message p-message-info" style="margin-bottom: 1em; padding: 0.5em;">
-                           <!--SDA CUSTOM-->    <i class="pi pi-exclamation-triangle" style="margin-right: 0.5em;"></i>
-                           <!--SDA CUSTOM-->    <span i18n="@@noFormatsAvailable"> Esta es una columna calculada y no tiene opciones de formato disponibles</span>
-                           <!--SDA CUSTOM--></div>
-                           <!--SDA CUSTOM--><div *ngIf="selectedColumn.computed_column != 'computed'" style="margin: 10px 0;">
+                            <!--SDA CUSTOM-->
+                            <div *ngIf="selectedColumn.computed_column == 'computed'" class="p-message p-message-info"
+                                style="margin-bottom: 1em; padding: 0.5em;">
+                                <!--SDA CUSTOM--> <i class="pi pi-exclamation-triangle"
+                                    style="margin-right: 0.5em;"></i>
+                                <!--SDA CUSTOM--> <span i18n="@@noFormatsAvailable"> Esta es una columna calculada y no
+                                    tiene opciones de formato disponibles</span>
+                                <!--SDA CUSTOM-->
+                            </div>
+                            <!--SDA CUSTOM-->
+                            <div *ngIf="selectedColumn.computed_column != 'computed'" style="margin: 10px 0;">
 
-                                 <div>
-                                    <h5 i18n="@@rangesExpresionH5" style="margin-top: 5px; font-size: 1.2rem; display: inline;">Rangos: </h5>
-                                     <span *ngIf="availableRange">
+                                <div>
+                                    <h5 i18n="@@rangesExpresionH5"
+                                        style="margin-top: 5px; font-size: 1.2rem; display: inline;">Rangos: </h5>
+                                    <span *ngIf="availableRange">
                                         <i class="pi pi-info-circle"
-                                           style="cursor: pointer; margin-top: -5px; font-size: 1.2rem;"
-                                           [pTooltip]="ptooltipViewTextRanges">
+                                            style="cursor: pointer; margin-top: -5px; font-size: 1.2rem;"
+                                            [pTooltip]="ptooltipViewTextRanges">
                                         </i>
-                                     </span>
-                                     <span *ngIf="!availableRange">
+                                    </span>
+                                    <span *ngIf="!availableRange">
                                         <i class="pi pi-info-circle"
-                                           style="cursor: pointer; margin-top: -5px; font-size: 1.2rem;"
-                                           [pTooltip]="ptooltipNotAvailableRanges">
+                                            style="cursor: pointer; margin-top: -5px; font-size: 1.2rem;"
+                                            [pTooltip]="ptooltipNotAvailableRanges">
                                         </i>
-                                     </span>
-                                 </div>
+                                    </span>
+                                </div>
 
 
 
 
-                            <div *ngIf="availableRange">
+                                <div *ngIf="availableRange">
 
-                                <input
-                                type="text"
-                                style="font-size: 1rem; margin-bottom: 10px;"
-                                [(ngModel)]="rangeString"
-                                [disabled]="showRange"
-                                (input)="validateInput($event)">
+                                    <input type="text" style="font-size: 1rem; margin-bottom: 10px;"
+                                        [(ngModel)]="rangeString" [disabled]="showRange"
+                                        (input)="validateInput($event)">
 
-                                <p-button
-                                    (onClick)="addRange(rangeString)"
-                                    label="Añadir Rango"
-                                    [disabled]="((!rangeString || rangeString.length === 0)) || showRange"
-                                    i18n-label="@@addRange"
-                                    >
-                                </p-button>
+                                    <p-button (onClick)="addRange(rangeString)" label="Añadir Rango"
+                                        [disabled]="((!rangeString || rangeString.length === 0)) || showRange"
+                                        i18n-label="@@addRange">
+                                    </p-button>
 
-                                <div *ngIf="showRange" class="col-12 foot-card" style="margin-top: 5px;">
+                                    <div *ngIf="showRange" class="col-12 foot-card" style="margin-top: 5px;">
 
-                                    <p-scrollPanel [style]="{width: '100%', height: '160px'}" styleClass="custombar1">
+                                        <p-scrollPanel [style]="{width: '100%', height: '160px'}"
+                                            styleClass="custombar1">
 
-                                        <ng-container *ngIf="showRange">
+                                            <ng-container *ngIf="showRange">
 
-                                            <b i18n="@@rangeDescriptionB" class="mr-2 pull-left">
-                                                • Rango:
-                                              </b>
-                                              <i class="pull-right ui-dropdown-clear-icon pi pi-times pointer md-3"(click)="removeRange()"></i>
+                                                <b i18n="@@rangeDescriptionB" class="mr-2 pull-left">
+                                                    • Rango:
+                                                </b>
+                                                <i class="pull-right ui-dropdown-clear-icon pi pi-times pointer md-3"
+                                                    (click)="removeRange()"></i>
 
-                                              <div *ngIf="showRange" class="d-flex align-items-center" [innerHTML]="selectedRange" style="font-size: 1rem; padding: 10px 40px 5px 30px;"></div>
+                                                <div *ngIf="showRange" class="d-flex align-items-center"
+                                                    [innerHTML]="selectedRange"
+                                                    style="font-size: 1rem; padding: 10px 40px 5px 30px;"></div>
 
-                                        </ng-container>
+                                            </ng-container>
 
-                                    </p-scrollPanel>
+                                        </p-scrollPanel>
+
+                                    </div>
 
                                 </div>
 
+                                <!--SDA CUSTOM-->
                             </div>
-
-                          <!--SDA CUSTOM--> </div>
                         </ng-container>
 
                     </ng-container>
@@ -445,7 +469,10 @@
                                     <b class="mr-2" style="margin: 2px;">
                                         * {{ selectedColumn.display_name.default }} is
                                         {{ filtre.filter_type }}
-                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"  tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage : havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>: {{getAggregationText(filtre)}}  &nbsp;</b></span>
+                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"
+                                        tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage :
+                                            havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>:
+                                            {{getAggregationText(filtre)}} &nbsp;</b></span>
 
                                     <i class="ui-dropdown-clear-icon pi pi-times pointer"
                                         (click)="removeFilter(filtre)"></i>
@@ -456,7 +483,10 @@
                                         * {{ selectedColumn.display_name.default }}
                                         {{ filtre.filter_type }}
                                         "{{ filtre.filter_elements[0].value1 }}"
-                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"  tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage : havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>: {{getAggregationText(filtre)}} &nbsp;</b></span>
+                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"
+                                        tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage :
+                                            havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>:
+                                            {{getAggregationText(filtre)}} &nbsp;</b></span>
 
                                     <i class="ui-dropdown-clear-icon pi pi-times pointer"
                                         (click)="removeFilter(filtre)"></i>
@@ -468,9 +498,13 @@
                                         {{ getFilterText(filtre) }}
                                         "{{ filtre.filter_elements[0].value1}}" - "{{ filtre.filter_elements[1].value2
                                         }}"
-                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"  tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage : havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>: {{getAggregationText(filtre)}} &nbsp;</b></span>
+                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"
+                                        tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage :
+                                            havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>:
+                                            {{getAggregationText(filtre)}} &nbsp;</b></span>
 
-                                    <i class="ui-dropdown-clear-icon pi pi-times pointer" (click)="removeFilter(filtre)"></i>
+                                    <i class="ui-dropdown-clear-icon pi pi-times pointer"
+                                        (click)="removeFilter(filtre)"></i>
                                 </p>
 
                             </ng-container>
@@ -488,7 +522,8 @@
         <!-- Duplicar columna -->
         <div class="col-12" style="position: absolute; bottom: 0; right:1.9rem" class="text-right">
             <button type="button" pButton (click)="duplicateColumn()" icon="fa fa-check"
-                class="p-button p-button-raised ml-2" i18n-label="@@duplicateColumnButton" label="Duplicar columna" id="eda_column_dialog_confirmar">
+                class="p-button p-button-raised ml-2" i18n-label="@@duplicateColumnButton" label="Duplicar columna"
+                id="eda_column_dialog_confirmar">
             </button>
         </div>
 
@@ -498,8 +533,8 @@
         <!-- por defecto está habilitado.  Si el botón "añadir filtro" está habilitado este se desactiva.-->
         <div class="ui-dialog-buttonpane ui-widget-content ui-helper-clearfix text-right">
             <button type="button" pButton (click)="closeDialog()" class="p-button-raised p-button-success"
-                i18n-label="@@guardarButton" icon="fa fa-check" label="Confirmar"
-                id="eda_column_dialog_confirmar" [disabled]="!display.filterButton">
+                i18n-label="@@guardarButton" icon="fa fa-check" label="Confirmar" id="eda_column_dialog_confirmar"
+                [disabled]="!display.filterButton">
             </button>
         </div>
 
@@ -507,15 +542,17 @@
 
 </eda-dialog>
 
-<eda-dialog2 *ngIf="display.duplicateColumn" [display]="display.duplicateColumn" header="Duplicar columna" width="60vw" height= "auto" (close)="onCancelDuplicateColumn()" (apply)="saveDuplicatedColumn()">
+<eda-dialog2 *ngIf="display.duplicateColumn" [display]="display.duplicateColumn" header="Duplicar columna" width="60vw"
+    height="auto" (close)="onCancelDuplicateColumn()" (apply)="saveDuplicatedColumn()">
     <div content>
         <!-- Duplicar columna -->
         <div class="col-12">
             <span>
-                <label i18n="@@duplicatedColumnNameLabel" for="duplicatedColumnName" style="font-size: 18px;margin-right: 1.5rem;">
+                <label i18n="@@duplicatedColumnNameLabel" for="duplicatedColumnName"
+                    style="font-size: 18px;margin-right: 1.5rem;">
                     Nombre columna duplicada
                 </label>
-                <input pInputText id="duplicatedColumnName" [(ngModel)]="duplicatedColumnName" type="text"  />
+                <input pInputText id="duplicatedColumnName" [(ngModel)]="duplicatedColumnName" type="text" />
             </span>
         </div>
     </div>

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html
@@ -2,7 +2,7 @@
 
     <div body class="grid mb-0 pb-0">
 
-        <!-- SDA CUSTOM Nombre de la columna -->
+        <!-- SDA CUSTOM Column name -->
         <div class="col-12 mt-2" *ngIf="selectedColumn">
 
             <div class="d-flex align-items-center flex-wrap" style="gap: 15px;">
@@ -371,8 +371,8 @@
 
 
                                 <div  style="margin-top: 1.5em; margin-left: 1em;" [pTooltip]="cumulativeSumTooltip" tooltipPosition="left">
-                                    <h6 i18n="@@cumulativeSum">Suma acumulativa</h6>
-                                    <p-inputSwitch id="cumulativeSum" [(ngModel)]="cumulativeSum"
+                                  <h6 i18n="@@cumulativeSum">Suma acumulativa</h6>
+                                  <p-inputSwitch id="cumulativeSum" [(ngModel)]="cumulativeSum"
                                   (onChange)="handleCumulativeSum()" [disabled]="!cumulativeSumAllowed()"></p-inputSwitch >
                                 </div>
                         <!--SDA CUSTOM-->      </div>
@@ -389,62 +389,62 @@
                            <!--SDA CUSTOM--></div>
                            <!--SDA CUSTOM--><div *ngIf="selectedColumn.computed_column != 'computed'" style="margin: 10px 0;">
 
-                                <div>
+                                 <div>
                                     <h5 i18n="@@rangesExpresionH5" style="margin-top: 5px; font-size: 1.2rem; display: inline;">Rangos: </h5>
-                                    <span *ngIf="availableRange">
+                                     <span *ngIf="availableRange">
                                         <i class="pi pi-info-circle"
-                                            style="cursor: pointer; margin-top: -5px; font-size: 1.2rem;"
-                                            [pTooltip]="ptooltipViewTextRanges">
+                                           style="cursor: pointer; margin-top: -5px; font-size: 1.2rem;"
+                                           [pTooltip]="ptooltipViewTextRanges">
                                         </i>
-                                    </span>
-                                    <span *ngIf="!availableRange">
+                                     </span>
+                                     <span *ngIf="!availableRange">
                                         <i class="pi pi-info-circle"
-                                            style="cursor: pointer; margin-top: -5px; font-size: 1.2rem;"
-                                            [pTooltip]="ptooltipNotAvailableRanges">
+                                           style="cursor: pointer; margin-top: -5px; font-size: 1.2rem;"
+                                           [pTooltip]="ptooltipNotAvailableRanges">
                                         </i>
-                                    </span>
-                                </div>
+                                     </span>
+                                 </div>
 
 
 
 
-                                <div *ngIf="availableRange">
+                            <div *ngIf="availableRange">
 
                                 <input
                                 type="text"
                                 style="font-size: 1rem; margin-bottom: 10px;"
                                 [(ngModel)]="rangeString"
                                 [disabled]="showRange"
-                                        (input)="validateInput($event)">
+                                (input)="validateInput($event)">
 
                                 <p-button
                                     (onClick)="addRange(rangeString)"
                                     label="Añadir Rango"
-                                        [disabled]="((!rangeString || rangeString.length === 0)) || showRange"
+                                    [disabled]="((!rangeString || rangeString.length === 0)) || showRange"
                                     i18n-label="@@addRange"
                                     >
-                                    </p-button>
+                                </p-button>
 
-                                    <div *ngIf="showRange" class="col-12 foot-card" style="margin-top: 5px;">
+                                <div *ngIf="showRange" class="col-12 foot-card" style="margin-top: 5px;">
 
                                     <p-scrollPanel [style]="{width: '100%', height: '160px'}" styleClass="custombar1">
 
-                                            <ng-container *ngIf="showRange">
+                                        <ng-container *ngIf="showRange">
 
-                                                <b i18n="@@rangeDescriptionB" class="mr-2 pull-left">
-                                                    • Rango:
-                                                </b>
+                                            <b i18n="@@rangeDescriptionB" class="mr-2 pull-left">
+                                                • Rango:
+                                              </b>
                                               <i class="pull-right ui-dropdown-clear-icon pi pi-times pointer md-3"(click)="removeRange()"></i>
 
                                               <div *ngIf="showRange" class="d-flex align-items-center" [innerHTML]="selectedRange" style="font-size: 1rem; padding: 10px 40px 5px 30px;"></div>
 
-                                            </ng-container>
+                                        </ng-container>
 
-                                        </p-scrollPanel>
-
-                                    </div>
+                                    </p-scrollPanel>
 
                                 </div>
+
+                            </div>
 
                           <!--SDA CUSTOM--> </div>
                         </ng-container>

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html
@@ -2,18 +2,28 @@
 
     <div body class="grid mb-0 pb-0">
 
-<!-- SDA CUSTOM-->      <!-- Nombre de la columna -->
-<!-- SDA CUSTOM-->      <div class="col-12 mt-2" *ngIf="selectedColumn">
-<!-- SDA CUSTOM-->          <div class="d-flex align-items-center flex-wrap" style="gap: 15px;">
-<!-- SDA CUSTOM-->              <h4 style="margin: 0; white-space: nowrap;">
-<!-- SDA CUSTOM-->                  <span i18n="@@nombreColumnaH4">Etiqueta para el campo</span> [{{tableLabel}} - {{sourceFieldName}}]:
-<!-- SDA CUSTOM-->              </h4>
-<!-- SDA CUSTOM-->              <div style="flex-grow: 1; min-width: 250px; max-width: 500px;">
-<!-- SDA CUSTOM-->                  <input id="columnName" type="text" pInputText [(ngModel)]="selectedColumn.display_name.default" (blur)="renameColumn(selectedColumn.display_name.default)" (keydown.enter)="renameColumn(selectedColumn.display_name.default)" style="width: 100%;">
-<!-- SDA CUSTOM-->              </div>
-<!-- SDA CUSTOM-->          </div>
-<!-- SDA CUSTOM-->          <hr>
-<!-- SDA CUSTOM-->      </div>
+        <!-- SDA CUSTOM Nombre de la columna -->
+        <div class="col-12 mt-2" *ngIf="selectedColumn">
+        
+            <div class="d-flex align-items-center flex-wrap" style="gap: 15px;">
+        
+                <h4 style="margin: 0; white-space: nowrap;">
+         <span i18n="@@nombreColumnaH4">Etiqueta para el campo</span> [{{tableLabel}} -
+                    {{sourceFieldName}}]:
+                   
+                </h4>
+                
+                <div style="flex-grow: 1; min-width: 250px; max-width: 500px;">
+                    <input id="columnName" type="text" pInputText
+                        [(ngModel)]="selectedColumn.display_name.default"
+                        (blur)="renameColumn(selectedColumn.display_name.default)"
+                        (keydown.enter)="renameColumn(selectedColumn.display_name.default)" style="width: 100%;">
+                </div>
+            </div>
+            <hr>
+           
+        </div>
+        <!-- END SDA CUSTOM -->
 
         <!-- Agregaciones -->
         <div class="col-12 lg:col-2">
@@ -64,8 +74,7 @@
 
             <div class="grid mt-2">
 
-                <div
-                    [ngClass]="{
+                <div [ngClass]="{
                         'md:col-4': (!display.between && !display.calendar ) || (!!display.calendar ),
                         'md:col-8': !(!display.between && !display.calendar) || (!!display.calendar)
                     }">
@@ -90,7 +99,7 @@
 
                         <ng-container *ngIf="!!display.calendar && !filter.switch">
 
-                            <div >
+                            <div>
 
                                 <!-- <label i18n="@@fechaLabel" class="p-float-label" for="datepicker">
                                     Fecha
@@ -144,14 +153,15 @@
                 </ng-container>
 
 
-                <ng-container *ngIf="filterSelected!=undefined && selectedColumn.column_type ==='numeric'  && !display.switchButton && (aggregationSelected.display_name !== 'No')">
+                <ng-container
+                    *ngIf="filterSelected!=undefined && selectedColumn.column_type ==='numeric'  && !display.switchButton && (aggregationSelected.display_name !== 'No')">
 
                     <div class="col-12 md:col-4">
 
                         <span class="p-float-label">
-                            <p-dropdown id="types" [options]="filterBeforeAfter.elements" [(ngModel)]="filterBeforeAfterSelected" optionLabel="label"
-                                [autoDisplayFirst]="true" [style]="{'width': '100%'}"
-                                (onChange)="whereHavingSwitch(filterBeforeAfterSelected)">
+                            <p-dropdown id="types" [options]="filterBeforeAfter.elements"
+                                [(ngModel)]="filterBeforeAfterSelected" optionLabel="label" [autoDisplayFirst]="true"
+                                [style]="{'width': '100%'}" (onChange)="whereHavingSwitch(filterBeforeAfterSelected)">
                             </p-dropdown>
 
                             <!-- <label i18n="@@tiposFiltrosLabel" for="types">
@@ -247,8 +257,8 @@
                                     </label> -->
 
                                     <p-multiSelect [options]="dropDownFields" [(ngModel)]="filterValue.value1"
-                                        [virtualScroll]="true" [itemSize]="34" [filter]="false" [style]="{width: '100%'}"
-                                        [panelStyle]="{minWidth:'100%'}"
+                                        [virtualScroll]="true" [itemSize]="34" [filter]="false"
+                                        [style]="{width: '100%'}" [panelStyle]="{minWidth:'100%'}"
                                         (onChange)="handleValidForm({value1: filterValue.value1})"
                                         defaultLabel="Selecciona Valor 1" [selectionLimit]="limitSelectionFields"
                                         id="float-input1">
@@ -267,8 +277,8 @@
                                     </label> -->
 
                                     <p-multiSelect [options]="dropDownFields" [(ngModel)]="filterValue.value2"
-                                        [virtualScroll]="true" [itemSize]="34" [filter]="false" [style]="{width: '100%'}"
-                                        [panelStyle]="{minWidth:'100%'}"
+                                        [virtualScroll]="true" [itemSize]="34" [filter]="false"
+                                        [style]="{width: '100%'}" [panelStyle]="{minWidth:'100%'}"
                                         (onChange)="handleValidForm({value2: filterValue.value2})"
                                         defaultLabel="Selecciona Valor 2" [selectionLimit]="limitSelectionFields"
                                         id="float-input2">
@@ -332,22 +342,22 @@
                             <h4 i18n="@@dateFormatH4"> Formato </h4>
 
                             <hr>
-                           <!--SDA CUSTOM--> <div *ngIf="selectedColumn.computed_column == 'computed'" class="p-message p-message-info" style="margin-bottom: 1em; padding: 0.5em;">
-                           <!--SDA CUSTOM-->     <i class="pi pi-exclamation-triangle" style="margin-right: 0.5em;"></i>
-                           <!--SDA CUSTOM-->     <span i18n="@@noFormatsAvailable"> Esta es una columna calculada y no tiene opciones de formato disponibles</span>
-                           <!--SDA CUSTOM--> </div>
-                           <!--SDA CUSTOM--> <div *ngIf="selectedColumn.computed_column != 'computed'">
+                            <!--SDA CUSTOM-->
+                            <div *ngIf="selectedColumn.computed_column == 'computed'" class="p-message p-message-info"
+                                style="margin-bottom: 1em; padding: 0.5em;">
+                                <!--SDA CUSTOM--> <i class="pi pi-exclamation-triangle"
+                                    style="margin-right: 0.5em;"></i>
+                                <!--SDA CUSTOM--> <span i18n="@@noFormatsAvailable"> Esta es una columna calculada y no
+                                    tiene opciones de formato disponibles</span>
+                                <!--SDA CUSTOM-->
+                            </div>
+                            <!--SDA CUSTOM-->
+                            <div *ngIf="selectedColumn.computed_column != 'computed'">
 
 
-                                <p-dropdown
-                                    [(ngModel)]="formatDate"
-                                    [options]="formatDates"
-                                    [optionLabel]="'display_name'"
-                                    [autoDisplayFirst]="false"
-                                    [showClear]="true"
-                                    [style]="{'min-width': '100%'}"
-                                    (onChange)="addFormatDate(format)"
-                                    class="w-100"
+                                <p-dropdown [(ngModel)]="formatDate" [options]="formatDates"
+                                    [optionLabel]="'display_name'" [autoDisplayFirst]="false" [showClear]="true"
+                                    [style]="{'min-width': '100%'}" (onChange)="addFormatDate(format)" class="w-100"
                                     appendTo="body">
                                 </p-dropdown>
 
@@ -360,12 +370,15 @@
 
 
 
-                                <div  style="margin-top: 1.5em; margin-left: 1em;" [pTooltip]="cumulativeSumTooltip" tooltipPosition="left">
-                                  <h6 i18n="@@cumulativeSum">Suma acumulativa</h6>
-                                  <p-inputSwitch id="cumulativeSum" [(ngModel)]="cumulativeSum"
-                                  (onChange)="handleCumulativeSum()" [disabled]="!cumulativeSumAllowed()"></p-inputSwitch >
+                                <div style="margin-top: 1.5em; margin-left: 1em;" [pTooltip]="cumulativeSumTooltip"
+                                    tooltipPosition="left">
+                                    <h6 i18n="@@cumulativeSum">Suma acumulativa</h6>
+                                    <p-inputSwitch id="cumulativeSum" [(ngModel)]="cumulativeSum"
+                                        (onChange)="handleCumulativeSum()"
+                                        [disabled]="!cumulativeSumAllowed()"></p-inputSwitch>
                                 </div>
-                        <!--SDA CUSTOM-->      </div>
+                                <!-- SDA CUSTOM -->
+                            </div>
                         </ng-container>
 
                         <ng-container *ngIf="selectedColumn.aggregation_type.length===7">
@@ -373,70 +386,76 @@
                             <h4 i18n="@@dateFormatH4"> Formato </h4>
 
                             <hr>
-                           <!--SDA CUSTOM--><div *ngIf="selectedColumn.computed_column == 'computed'" class="p-message p-message-info" style="margin-bottom: 1em; padding: 0.5em;">
-                           <!--SDA CUSTOM-->    <i class="pi pi-exclamation-triangle" style="margin-right: 0.5em;"></i>
-                           <!--SDA CUSTOM-->    <span i18n="@@noFormatsAvailable"> Esta es una columna calculada y no tiene opciones de formato disponibles</span>
-                           <!--SDA CUSTOM--></div>
-                           <!--SDA CUSTOM--><div *ngIf="selectedColumn.computed_column != 'computed'" style="margin: 10px 0;">
+                            <!--SDA CUSTOM-->
+                            <div *ngIf="selectedColumn.computed_column == 'computed'" class="p-message p-message-info"
+                                style="margin-bottom: 1em; padding: 0.5em;">
+                                <!--SDA CUSTOM--> <i class="pi pi-exclamation-triangle"
+                                    style="margin-right: 0.5em;"></i>
+                                <!--SDA CUSTOM--> <span i18n="@@noFormatsAvailable"> Esta es una columna calculada y no
+                                    tiene opciones de formato disponibles</span>
+                                <!--SDA CUSTOM-->
+                            </div>
+                            <!--SDA CUSTOM-->
+                            <div *ngIf="selectedColumn.computed_column != 'computed'" style="margin: 10px 0;">
 
-                                 <div>
-                                    <h5 i18n="@@rangesExpresionH5" style="margin-top: 5px; font-size: 1.2rem; display: inline;">Rangos: </h5>
-                                     <span *ngIf="availableRange">
+                                <div>
+                                    <h5 i18n="@@rangesExpresionH5"
+                                        style="margin-top: 5px; font-size: 1.2rem; display: inline;">Rangos: </h5>
+                                    <span *ngIf="availableRange">
                                         <i class="pi pi-info-circle"
-                                           style="cursor: pointer; margin-top: -5px; font-size: 1.2rem;"
-                                           [pTooltip]="ptooltipViewTextRanges">
+                                            style="cursor: pointer; margin-top: -5px; font-size: 1.2rem;"
+                                            [pTooltip]="ptooltipViewTextRanges">
                                         </i>
-                                     </span>
-                                     <span *ngIf="!availableRange">
+                                    </span>
+                                    <span *ngIf="!availableRange">
                                         <i class="pi pi-info-circle"
-                                           style="cursor: pointer; margin-top: -5px; font-size: 1.2rem;"
-                                           [pTooltip]="ptooltipNotAvailableRanges">
+                                            style="cursor: pointer; margin-top: -5px; font-size: 1.2rem;"
+                                            [pTooltip]="ptooltipNotAvailableRanges">
                                         </i>
-                                     </span>
-                                 </div>
+                                    </span>
+                                </div>
 
 
 
 
-                            <div *ngIf="availableRange">
+                                <div *ngIf="availableRange">
 
-                                <input
-                                type="text"
-                                style="font-size: 1rem; margin-bottom: 10px;"
-                                [(ngModel)]="rangeString"
-                                [disabled]="showRange"
-                                (input)="validateInput($event)">
+                                    <input type="text" style="font-size: 1rem; margin-bottom: 10px;"
+                                        [(ngModel)]="rangeString" [disabled]="showRange"
+                                        (input)="validateInput($event)">
 
-                                <p-button
-                                    (onClick)="addRange(rangeString)"
-                                    label="Añadir Rango"
-                                    [disabled]="((!rangeString || rangeString.length === 0)) || showRange"
-                                    i18n-label="@@addRange"
-                                    >
-                                </p-button>
+                                    <p-button (onClick)="addRange(rangeString)" label="Añadir Rango"
+                                        [disabled]="((!rangeString || rangeString.length === 0)) || showRange"
+                                        i18n-label="@@addRange">
+                                    </p-button>
 
-                                <div *ngIf="showRange" class="col-12 foot-card" style="margin-top: 5px;">
+                                    <div *ngIf="showRange" class="col-12 foot-card" style="margin-top: 5px;">
 
-                                    <p-scrollPanel [style]="{width: '100%', height: '160px'}" styleClass="custombar1">
+                                        <p-scrollPanel [style]="{width: '100%', height: '160px'}"
+                                            styleClass="custombar1">
 
-                                        <ng-container *ngIf="showRange">
+                                            <ng-container *ngIf="showRange">
 
-                                            <b i18n="@@rangeDescriptionB" class="mr-2 pull-left">
-                                                • Rango:
-                                              </b>
-                                              <i class="pull-right ui-dropdown-clear-icon pi pi-times pointer md-3"(click)="removeRange()"></i>
+                                                <b i18n="@@rangeDescriptionB" class="mr-2 pull-left">
+                                                    • Rango:
+                                                </b>
+                                                <i class="pull-right ui-dropdown-clear-icon pi pi-times pointer md-3"
+                                                    (click)="removeRange()"></i>
 
-                                              <div *ngIf="showRange" class="d-flex align-items-center" [innerHTML]="selectedRange" style="font-size: 1rem; padding: 10px 40px 5px 30px;"></div>
+                                                <div *ngIf="showRange" class="d-flex align-items-center"
+                                                    [innerHTML]="selectedRange"
+                                                    style="font-size: 1rem; padding: 10px 40px 5px 30px;"></div>
 
-                                        </ng-container>
+                                            </ng-container>
 
-                                    </p-scrollPanel>
+                                        </p-scrollPanel>
+
+                                    </div>
 
                                 </div>
 
+                                <!-- SDA CUSTOM -->
                             </div>
-
-                          <!--SDA CUSTOM--> </div>
                         </ng-container>
 
                     </ng-container>
@@ -458,7 +477,10 @@
                                     <b class="mr-2" style="margin: 2px;">
                                         * {{ selectedColumn.display_name.default }} is
                                         {{ filtre.filter_type }}
-                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"  tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage : havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>: {{getAggregationText(filtre)}}  &nbsp;</b></span>
+                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"
+                                        tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage :
+                                            havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>:
+                                            {{getAggregationText(filtre)}} &nbsp;</b></span>
 
                                     <i class="ui-dropdown-clear-icon pi pi-times pointer"
                                         (click)="removeFilter(filtre)"></i>
@@ -469,7 +491,10 @@
                                         * {{ selectedColumn.display_name.default }}
                                         {{ filtre.filter_type }}
                                         "{{ filtre.filter_elements[0].value1 }}"
-                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"  tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage : havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>: {{getAggregationText(filtre)}} &nbsp;</b></span>
+                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"
+                                        tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage :
+                                            havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>:
+                                            {{getAggregationText(filtre)}} &nbsp;</b></span>
 
                                     <i class="ui-dropdown-clear-icon pi pi-times pointer"
                                         (click)="removeFilter(filtre)"></i>
@@ -481,9 +506,13 @@
                                         {{ getFilterText(filtre) }}
                                         "{{ filtre.filter_elements[0].value1}}" - "{{ filtre.filter_elements[1].value2
                                         }}"
-                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"  tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage : havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>: {{getAggregationText(filtre)}} &nbsp;</b></span>
+                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"
+                                        tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage :
+                                            havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>:
+                                            {{getAggregationText(filtre)}} &nbsp;</b></span>
 
-                                    <i class="ui-dropdown-clear-icon pi pi-times pointer" (click)="removeFilter(filtre)"></i>
+                                    <i class="ui-dropdown-clear-icon pi pi-times pointer"
+                                        (click)="removeFilter(filtre)"></i>
                                 </p>
 
                             </ng-container>
@@ -501,7 +530,8 @@
         <!-- Duplicar columna -->
         <div class="col-12" style="position: absolute; bottom: 0; right:1.9rem" class="text-right">
             <button type="button" pButton (click)="duplicateColumn()" icon="fa fa-check"
-                class="p-button p-button-raised ml-2" i18n-label="@@duplicateColumnButton" label="Duplicar columna" id="eda_column_dialog_confirmar">
+                class="p-button p-button-raised ml-2" i18n-label="@@duplicateColumnButton" label="Duplicar columna"
+                id="eda_column_dialog_confirmar">
             </button>
         </div>
 
@@ -511,24 +541,32 @@
         <!-- por defecto está habilitado.  Si el botón "añadir filtro" está habilitado este se desactiva.-->
         <div class="ui-dialog-buttonpane ui-widget-content ui-helper-clearfix text-right">
             <button type="button" pButton (click)="closeDialog()" class="p-button-raised p-button-success"
-                i18n-label="@@guardarButton" icon="fa fa-check" label="Confirmar"
-                id="eda_column_dialog_confirmar" [disabled]="!display.filterButton">
+                i18n-label="@@guardarButton" icon="fa fa-check" label="Confirmar" id="eda_column_dialog_confirmar"
+                [disabled]="!display.filterButton">
             </button>
+
+<!-- SDA CUSTOM -->
+             <button type="button" pButton (click)="cancelDialog()" class="p-button-raised p-button-danger"
+                i18n-label="@@cancelButton" icon="fa fa-times" label="Cancelar" id="eda_column_dialog_cancel">
+            </button>
+<!-- END SDA CUSTOM -->
         </div>
 
     </div>
 
 </eda-dialog>
 
-<eda-dialog2 *ngIf="display.duplicateColumn" [display]="display.duplicateColumn" header="Duplicar columna" width="60vw" height= "auto" (close)="onCancelDuplicateColumn()" (apply)="saveDuplicatedColumn()">
+<eda-dialog2 *ngIf="display.duplicateColumn" [display]="display.duplicateColumn" header="Duplicar columna" width="60vw"
+    height="auto" (close)="onCancelDuplicateColumn()" (apply)="saveDuplicatedColumn()">
     <div content>
         <!-- Duplicar columna -->
         <div class="col-12">
             <span>
-                <label i18n="@@duplicatedColumnNameLabel" for="duplicatedColumnName" style="font-size: 18px;margin-right: 1.5rem;">
+                <label i18n="@@duplicatedColumnNameLabel" for="duplicatedColumnName"
+                    style="font-size: 18px;margin-right: 1.5rem;">
                     Nombre columna duplicada
                 </label>
-                <input pInputText id="duplicatedColumnName" [(ngModel)]="duplicatedColumnName" type="text"  />
+                <input pInputText id="duplicatedColumnName" [(ngModel)]="duplicatedColumnName" type="text" />
             </span>
         </div>
     </div>

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html
@@ -2,20 +2,18 @@
 
     <div body class="grid mb-0 pb-0">
 
-        <!-- Nombre de la columna -->
-        <div class="col-12 mt-2" *ngIf="selectedColumn">
-            <div class="d-flex align-items-center flex-wrap" style="gap: 15px;">
-                <h4 style="margin: 0; white-space: nowrap;">
-                    <span i18n="@@nombreColumnaH4">Etiqueta para el campo</span> [{{tableLabel}} - {{sourceFieldName}}]:
-                </h4>
-                <div style="flex-grow: 1; min-width: 250px; max-width: 500px;">
-                    <input id="columnName" type="text" pInputText [(ngModel)]="selectedColumn.display_name.default"
-                        (blur)="renameColumn(selectedColumn.display_name.default)"
-                        (keydown.enter)="renameColumn(selectedColumn.display_name.default)" style="width: 100%;">
-                </div>
-            </div>
-            <hr>
-        </div>
+<!-- SDA CUSTOM-->      <!-- Nombre de la columna -->
+<!-- SDA CUSTOM-->      <div class="col-12 mt-2" *ngIf="selectedColumn">
+<!-- SDA CUSTOM-->          <div class="d-flex align-items-center flex-wrap" style="gap: 15px;">
+<!-- SDA CUSTOM-->              <h4 style="margin: 0; white-space: nowrap;">
+<!-- SDA CUSTOM-->                  <span i18n="@@nombreColumnaH4">Etiqueta para el campo</span> [{{tableLabel}} - {{sourceFieldName}}]:
+<!-- SDA CUSTOM-->              </h4>
+<!-- SDA CUSTOM-->              <div style="flex-grow: 1; min-width: 250px; max-width: 500px;">
+<!-- SDA CUSTOM-->                  <input id="columnName" type="text" pInputText [(ngModel)]="selectedColumn.display_name.default" (blur)="renameColumn(selectedColumn.display_name.default)" (keydown.enter)="renameColumn(selectedColumn.display_name.default)" style="width: 100%;">
+<!-- SDA CUSTOM-->              </div>
+<!-- SDA CUSTOM-->          </div>
+<!-- SDA CUSTOM-->          <hr>
+<!-- SDA CUSTOM-->      </div>
 
         <!-- Agregaciones -->
         <div class="col-12 lg:col-2">
@@ -25,7 +23,7 @@
             </h4>
             <hr>
 
-            <div class="aggregation-list">
+            <div class="aggregation-list" >
                 <div class="aggregation-box" *ngFor="let aggregation of aggregationsTypes"
                     (click)="allowedAggregations && addAggregation(aggregation)"
                     [ngStyle]="{'cursor': !allowedAggregations ? 'not-allowed' : 'pointer'}"
@@ -66,7 +64,8 @@
 
             <div class="grid mt-2">
 
-                <div [ngClass]="{
+                <div
+                    [ngClass]="{
                         'md:col-4': (!display.between && !display.calendar ) || (!!display.calendar ),
                         'md:col-8': !(!display.between && !display.calendar) || (!!display.calendar)
                     }">
@@ -91,7 +90,7 @@
 
                         <ng-container *ngIf="!!display.calendar && !filter.switch">
 
-                            <div>
+                            <div >
 
                                 <!-- <label i18n="@@fechaLabel" class="p-float-label" for="datepicker">
                                     Fecha
@@ -145,15 +144,14 @@
                 </ng-container>
 
 
-                <ng-container
-                    *ngIf="filterSelected!=undefined && selectedColumn.column_type ==='numeric'  && !display.switchButton && (aggregationSelected.display_name !== 'No')">
+                <ng-container *ngIf="filterSelected!=undefined && selectedColumn.column_type ==='numeric'  && !display.switchButton && (aggregationSelected.display_name !== 'No')">
 
                     <div class="col-12 md:col-4">
 
                         <span class="p-float-label">
-                            <p-dropdown id="types" [options]="filterBeforeAfter.elements"
-                                [(ngModel)]="filterBeforeAfterSelected" optionLabel="label" [autoDisplayFirst]="true"
-                                [style]="{'width': '100%'}" (onChange)="whereHavingSwitch(filterBeforeAfterSelected)">
+                            <p-dropdown id="types" [options]="filterBeforeAfter.elements" [(ngModel)]="filterBeforeAfterSelected" optionLabel="label"
+                                [autoDisplayFirst]="true" [style]="{'width': '100%'}"
+                                (onChange)="whereHavingSwitch(filterBeforeAfterSelected)">
                             </p-dropdown>
 
                             <!-- <label i18n="@@tiposFiltrosLabel" for="types">
@@ -249,8 +247,8 @@
                                     </label> -->
 
                                     <p-multiSelect [options]="dropDownFields" [(ngModel)]="filterValue.value1"
-                                        [virtualScroll]="true" [itemSize]="34" [filter]="false"
-                                        [style]="{width: '100%'}" [panelStyle]="{minWidth:'100%'}"
+                                        [virtualScroll]="true" [itemSize]="34" [filter]="false" [style]="{width: '100%'}"
+                                        [panelStyle]="{minWidth:'100%'}"
                                         (onChange)="handleValidForm({value1: filterValue.value1})"
                                         defaultLabel="Selecciona Valor 1" [selectionLimit]="limitSelectionFields"
                                         id="float-input1">
@@ -269,8 +267,8 @@
                                     </label> -->
 
                                     <p-multiSelect [options]="dropDownFields" [(ngModel)]="filterValue.value2"
-                                        [virtualScroll]="true" [itemSize]="34" [filter]="false"
-                                        [style]="{width: '100%'}" [panelStyle]="{minWidth:'100%'}"
+                                        [virtualScroll]="true" [itemSize]="34" [filter]="false" [style]="{width: '100%'}"
+                                        [panelStyle]="{minWidth:'100%'}"
                                         (onChange)="handleValidForm({value2: filterValue.value2})"
                                         defaultLabel="Selecciona Valor 2" [selectionLimit]="limitSelectionFields"
                                         id="float-input2">
@@ -334,22 +332,22 @@
                             <h4 i18n="@@dateFormatH4"> Formato </h4>
 
                             <hr>
-                            <!--SDA CUSTOM-->
-                            <div *ngIf="selectedColumn.computed_column == 'computed'" class="p-message p-message-info"
-                                style="margin-bottom: 1em; padding: 0.5em;">
-                                <!--SDA CUSTOM--> <i class="pi pi-exclamation-triangle"
-                                    style="margin-right: 0.5em;"></i>
-                                <!--SDA CUSTOM--> <span i18n="@@noFormatsAvailable"> Esta es una columna calculada y no
-                                    tiene opciones de formato disponibles</span>
-                                <!--SDA CUSTOM-->
-                            </div>
-                            <!--SDA CUSTOM-->
-                            <div *ngIf="selectedColumn.computed_column != 'computed'">
+                           <!--SDA CUSTOM--> <div *ngIf="selectedColumn.computed_column == 'computed'" class="p-message p-message-info" style="margin-bottom: 1em; padding: 0.5em;">
+                           <!--SDA CUSTOM-->     <i class="pi pi-exclamation-triangle" style="margin-right: 0.5em;"></i>
+                           <!--SDA CUSTOM-->     <span i18n="@@noFormatsAvailable"> Esta es una columna calculada y no tiene opciones de formato disponibles</span>
+                           <!--SDA CUSTOM--> </div>
+                           <!--SDA CUSTOM--> <div *ngIf="selectedColumn.computed_column != 'computed'">
 
 
-                                <p-dropdown [(ngModel)]="formatDate" [options]="formatDates"
-                                    [optionLabel]="'display_name'" [autoDisplayFirst]="false" [showClear]="true"
-                                    [style]="{'min-width': '100%'}" (onChange)="addFormatDate(format)" class="w-100"
+                                <p-dropdown
+                                    [(ngModel)]="formatDate"
+                                    [options]="formatDates"
+                                    [optionLabel]="'display_name'"
+                                    [autoDisplayFirst]="false"
+                                    [showClear]="true"
+                                    [style]="{'min-width': '100%'}"
+                                    (onChange)="addFormatDate(format)"
+                                    class="w-100"
                                     appendTo="body">
                                 </p-dropdown>
 
@@ -362,15 +360,12 @@
 
 
 
-                                <div style="margin-top: 1.5em; margin-left: 1em;" [pTooltip]="cumulativeSumTooltip"
-                                    tooltipPosition="left">
-                                    <h6 i18n="@@cumulativeSum">Suma acumulativa</h6>
-                                    <p-inputSwitch id="cumulativeSum" [(ngModel)]="cumulativeSum"
-                                        (onChange)="handleCumulativeSum()"
-                                        [disabled]="!cumulativeSumAllowed()"></p-inputSwitch>
+                                <div  style="margin-top: 1.5em; margin-left: 1em;" [pTooltip]="cumulativeSumTooltip" tooltipPosition="left">
+                                  <h6 i18n="@@cumulativeSum">Suma acumulativa</h6>
+                                  <p-inputSwitch id="cumulativeSum" [(ngModel)]="cumulativeSum"
+                                  (onChange)="handleCumulativeSum()" [disabled]="!cumulativeSumAllowed()"></p-inputSwitch >
                                 </div>
-                                <!--SDA CUSTOM-->
-                            </div>
+                        <!--SDA CUSTOM-->      </div>
                         </ng-container>
 
                         <ng-container *ngIf="selectedColumn.aggregation_type.length===7">
@@ -378,76 +373,70 @@
                             <h4 i18n="@@dateFormatH4"> Formato </h4>
 
                             <hr>
-                            <!--SDA CUSTOM-->
-                            <div *ngIf="selectedColumn.computed_column == 'computed'" class="p-message p-message-info"
-                                style="margin-bottom: 1em; padding: 0.5em;">
-                                <!--SDA CUSTOM--> <i class="pi pi-exclamation-triangle"
-                                    style="margin-right: 0.5em;"></i>
-                                <!--SDA CUSTOM--> <span i18n="@@noFormatsAvailable"> Esta es una columna calculada y no
-                                    tiene opciones de formato disponibles</span>
-                                <!--SDA CUSTOM-->
-                            </div>
-                            <!--SDA CUSTOM-->
-                            <div *ngIf="selectedColumn.computed_column != 'computed'" style="margin: 10px 0;">
+                           <!--SDA CUSTOM--><div *ngIf="selectedColumn.computed_column == 'computed'" class="p-message p-message-info" style="margin-bottom: 1em; padding: 0.5em;">
+                           <!--SDA CUSTOM-->    <i class="pi pi-exclamation-triangle" style="margin-right: 0.5em;"></i>
+                           <!--SDA CUSTOM-->    <span i18n="@@noFormatsAvailable"> Esta es una columna calculada y no tiene opciones de formato disponibles</span>
+                           <!--SDA CUSTOM--></div>
+                           <!--SDA CUSTOM--><div *ngIf="selectedColumn.computed_column != 'computed'" style="margin: 10px 0;">
 
-                                <div>
-                                    <h5 i18n="@@rangesExpresionH5"
-                                        style="margin-top: 5px; font-size: 1.2rem; display: inline;">Rangos: </h5>
-                                    <span *ngIf="availableRange">
+                                 <div>
+                                    <h5 i18n="@@rangesExpresionH5" style="margin-top: 5px; font-size: 1.2rem; display: inline;">Rangos: </h5>
+                                     <span *ngIf="availableRange">
                                         <i class="pi pi-info-circle"
-                                            style="cursor: pointer; margin-top: -5px; font-size: 1.2rem;"
-                                            [pTooltip]="ptooltipViewTextRanges">
+                                           style="cursor: pointer; margin-top: -5px; font-size: 1.2rem;"
+                                           [pTooltip]="ptooltipViewTextRanges">
                                         </i>
-                                    </span>
-                                    <span *ngIf="!availableRange">
+                                     </span>
+                                     <span *ngIf="!availableRange">
                                         <i class="pi pi-info-circle"
-                                            style="cursor: pointer; margin-top: -5px; font-size: 1.2rem;"
-                                            [pTooltip]="ptooltipNotAvailableRanges">
+                                           style="cursor: pointer; margin-top: -5px; font-size: 1.2rem;"
+                                           [pTooltip]="ptooltipNotAvailableRanges">
                                         </i>
-                                    </span>
-                                </div>
+                                     </span>
+                                 </div>
 
 
 
 
-                                <div *ngIf="availableRange">
+                            <div *ngIf="availableRange">
 
-                                    <input type="text" style="font-size: 1rem; margin-bottom: 10px;"
-                                        [(ngModel)]="rangeString" [disabled]="showRange"
-                                        (input)="validateInput($event)">
+                                <input
+                                type="text"
+                                style="font-size: 1rem; margin-bottom: 10px;"
+                                [(ngModel)]="rangeString"
+                                [disabled]="showRange"
+                                (input)="validateInput($event)">
 
-                                    <p-button (onClick)="addRange(rangeString)" label="Añadir Rango"
-                                        [disabled]="((!rangeString || rangeString.length === 0)) || showRange"
-                                        i18n-label="@@addRange">
-                                    </p-button>
+                                <p-button
+                                    (onClick)="addRange(rangeString)"
+                                    label="Añadir Rango"
+                                    [disabled]="((!rangeString || rangeString.length === 0)) || showRange"
+                                    i18n-label="@@addRange"
+                                    >
+                                </p-button>
 
-                                    <div *ngIf="showRange" class="col-12 foot-card" style="margin-top: 5px;">
+                                <div *ngIf="showRange" class="col-12 foot-card" style="margin-top: 5px;">
 
-                                        <p-scrollPanel [style]="{width: '100%', height: '160px'}"
-                                            styleClass="custombar1">
+                                    <p-scrollPanel [style]="{width: '100%', height: '160px'}" styleClass="custombar1">
 
-                                            <ng-container *ngIf="showRange">
+                                        <ng-container *ngIf="showRange">
 
-                                                <b i18n="@@rangeDescriptionB" class="mr-2 pull-left">
-                                                    • Rango:
-                                                </b>
-                                                <i class="pull-right ui-dropdown-clear-icon pi pi-times pointer md-3"
-                                                    (click)="removeRange()"></i>
+                                            <b i18n="@@rangeDescriptionB" class="mr-2 pull-left">
+                                                • Rango:
+                                              </b>
+                                              <i class="pull-right ui-dropdown-clear-icon pi pi-times pointer md-3"(click)="removeRange()"></i>
 
-                                                <div *ngIf="showRange" class="d-flex align-items-center"
-                                                    [innerHTML]="selectedRange"
-                                                    style="font-size: 1rem; padding: 10px 40px 5px 30px;"></div>
+                                              <div *ngIf="showRange" class="d-flex align-items-center" [innerHTML]="selectedRange" style="font-size: 1rem; padding: 10px 40px 5px 30px;"></div>
 
-                                            </ng-container>
+                                        </ng-container>
 
-                                        </p-scrollPanel>
-
-                                    </div>
+                                    </p-scrollPanel>
 
                                 </div>
 
-                                <!--SDA CUSTOM-->
                             </div>
+
+                          <!--SDA CUSTOM--> </div>
                         </ng-container>
 
                     </ng-container>
@@ -469,10 +458,7 @@
                                     <b class="mr-2" style="margin: 2px;">
                                         * {{ selectedColumn.display_name.default }} is
                                         {{ filtre.filter_type }}
-                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"
-                                        tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage :
-                                            havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>:
-                                            {{getAggregationText(filtre)}} &nbsp;</b></span>
+                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"  tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage : havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>: {{getAggregationText(filtre)}}  &nbsp;</b></span>
 
                                     <i class="ui-dropdown-clear-icon pi pi-times pointer"
                                         (click)="removeFilter(filtre)"></i>
@@ -483,10 +469,7 @@
                                         * {{ selectedColumn.display_name.default }}
                                         {{ filtre.filter_type }}
                                         "{{ filtre.filter_elements[0].value1 }}"
-                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"
-                                        tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage :
-                                            havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>:
-                                            {{getAggregationText(filtre)}} &nbsp;</b></span>
+                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"  tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage : havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>: {{getAggregationText(filtre)}} &nbsp;</b></span>
 
                                     <i class="ui-dropdown-clear-icon pi pi-times pointer"
                                         (click)="removeFilter(filtre)"></i>
@@ -498,13 +481,9 @@
                                         {{ getFilterText(filtre) }}
                                         "{{ filtre.filter_elements[0].value1}}" - "{{ filtre.filter_elements[1].value2
                                         }}"
-                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"
-                                        tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage :
-                                            havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>:
-                                            {{getAggregationText(filtre)}} &nbsp;</b></span>
+                                    </b> <span [pTooltip]="filtre.filterBeforeGrouping ? whereMessage : havingMessage"  tooltipPosition="left"><b>[ {{filtre.filterBeforeGrouping ? whereMessage : havingMessage}} ] - <span i18n="@@AggregationText">Agregación</span>: {{getAggregationText(filtre)}} &nbsp;</b></span>
 
-                                    <i class="ui-dropdown-clear-icon pi pi-times pointer"
-                                        (click)="removeFilter(filtre)"></i>
+                                    <i class="ui-dropdown-clear-icon pi pi-times pointer" (click)="removeFilter(filtre)"></i>
                                 </p>
 
                             </ng-container>
@@ -522,8 +501,7 @@
         <!-- Duplicar columna -->
         <div class="col-12" style="position: absolute; bottom: 0; right:1.9rem" class="text-right">
             <button type="button" pButton (click)="duplicateColumn()" icon="fa fa-check"
-                class="p-button p-button-raised ml-2" i18n-label="@@duplicateColumnButton" label="Duplicar columna"
-                id="eda_column_dialog_confirmar">
+                class="p-button p-button-raised ml-2" i18n-label="@@duplicateColumnButton" label="Duplicar columna" id="eda_column_dialog_confirmar">
             </button>
         </div>
 
@@ -533,8 +511,8 @@
         <!-- por defecto está habilitado.  Si el botón "añadir filtro" está habilitado este se desactiva.-->
         <div class="ui-dialog-buttonpane ui-widget-content ui-helper-clearfix text-right">
             <button type="button" pButton (click)="closeDialog()" class="p-button-raised p-button-success"
-                i18n-label="@@guardarButton" icon="fa fa-check" label="Confirmar" id="eda_column_dialog_confirmar"
-                [disabled]="!display.filterButton">
+                i18n-label="@@guardarButton" icon="fa fa-check" label="Confirmar"
+                id="eda_column_dialog_confirmar" [disabled]="!display.filterButton">
             </button>
         </div>
 
@@ -542,17 +520,15 @@
 
 </eda-dialog>
 
-<eda-dialog2 *ngIf="display.duplicateColumn" [display]="display.duplicateColumn" header="Duplicar columna" width="60vw"
-    height="auto" (close)="onCancelDuplicateColumn()" (apply)="saveDuplicatedColumn()">
+<eda-dialog2 *ngIf="display.duplicateColumn" [display]="display.duplicateColumn" header="Duplicar columna" width="60vw" height= "auto" (close)="onCancelDuplicateColumn()" (apply)="saveDuplicatedColumn()">
     <div content>
         <!-- Duplicar columna -->
         <div class="col-12">
             <span>
-                <label i18n="@@duplicatedColumnNameLabel" for="duplicatedColumnName"
-                    style="font-size: 18px;margin-right: 1.5rem;">
+                <label i18n="@@duplicatedColumnNameLabel" for="duplicatedColumnName" style="font-size: 18px;margin-right: 1.5rem;">
                     Nombre columna duplicada
                 </label>
-                <input pInputText id="duplicatedColumnName" [(ngModel)]="duplicatedColumnName" type="text" />
+                <input pInputText id="duplicatedColumnName" [(ngModel)]="duplicatedColumnName" type="text"  />
             </span>
         </div>
     </div>

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
@@ -30,6 +30,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     public selectedColumn: Column;
     public duplicatedColumnName: string;
 /* SDA CUSTOM */    public originalName: string;
+/* SDA CUSTOM */    public backupName: string;
 /* SDA CUSTOM */    public sourceFieldName: string;
 /* SDA CUSTOM */    public tableLabel: string;
 
@@ -116,14 +117,15 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
     onShow(): void {
         this.selectedColumn = this.controller.params.selectedColumn;
-/*SDA CUSTOM*/        this.originalName = this.selectedColumn.display_name.default;
+/* SDA CUSTOM */        this.originalName = this.selectedColumn.display_name.default;
+/* SDA CUSTOM */        this.backupName = this.selectedColumn.display_name.default;
 
-/*SDA CUSTOM*/        const table_id = this.selectedColumn.table_id.split('.')[0];
-/*SDA CUSTOM*/       const modelTable = this.controller.params.inject.dataSource.model.tables.find(t => t.table_name === table_id);
-/*SDA CUSTOM*/        const modelColumn = modelTable?.columns.find(c => c.column_name === this.selectedColumn.column_name);
-/*SDA CUSTOM*/        this.sourceFieldName = modelColumn?.display_name?.default || this.selectedColumn.column_name;
+/* SDA CUSTOM */        const table_id = this.selectedColumn.table_id.split('.')[0];
+/* SDA CUSTOM */        const modelTable = this.controller.params.inject.dataSource.model.tables.find(t => t.table_name === table_id);
+/* SDA CUSTOM */        const modelColumn = modelTable?.columns.find(c => c.column_name === this.selectedColumn.column_name);
+/* SDA CUSTOM */        this.sourceFieldName = modelColumn?.display_name?.default || this.selectedColumn.column_name;
 
-/*SDA CUSTOM*/        this.tableLabel = this.controller.params.table;
+/* SDA CUSTOM */        this.tableLabel = this.controller.params.table;
         const allowed = [];
         const title = this.selectedColumn.display_name.default;
         const col = $localize`:@@col:Atributo`, from = $localize`:@@table:de la entidad`;
@@ -147,13 +149,13 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         }
 
         // Buscando el valor inicial de agregacion de la columna seleccionada
-        for(let agg of this.selectedColumn.aggregation_type) {
-            if(agg.selected){
+        for (let agg of this.selectedColumn.aggregation_type) {
+            if (agg.selected) {
                 this.aggregationSelected = _.cloneDeep(agg);
             }
         }
-        if(this.controller.params.currentQuery.find( elemento => elemento.hasOwnProperty('ranges') &&  elemento.ranges.length!==0)) {
-            if(this.selectedColumn.hasOwnProperty('ranges') && this.selectedColumn.ranges.length!==0) {
+        if (this.controller.params.currentQuery.find(elemento => elemento.hasOwnProperty('ranges') && elemento.ranges.length !== 0)) {
+            if (this.selectedColumn.hasOwnProperty('ranges') && this.selectedColumn.ranges.length !== 0) {
                 this.availableRange = true;
             } else {
                 this.availableRange = false;
@@ -228,7 +230,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         };
 
         // Control of adding just filter in the where section
-        if(filter['filterBeforeGrouping']) {
+        if (filter['filterBeforeGrouping']) {
             this.updateSortedFiltersColumnDialog.emit(addToSortedFilters); // Emitting an event to the eda-blank-panel component
         }
 
@@ -258,7 +260,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
         this.aggregationsTypes.find((ag: any) => ag.value === type.value).selected = true;
 
-        for (let ag of this.aggregationsTypes) {
+        for (const ag of this.aggregationsTypes) {
             if (ag.selected === true && type.value !== ag.value) {
                 ag.selected = false;
             }
@@ -278,7 +280,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         this.aggregationSelected = _.cloneDeep(type);
 
         // En caso no tengamos agregación el selected Where/Having se establece en Where
-        if(this.aggregationSelected.value==='none') {
+        if (this.aggregationSelected.value === 'none') {
             this.whereHavingSwitch({
                 label: 'WHERE',
                 value: true,
@@ -286,7 +288,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         }
 
         // Changing to numeric type
-        if(this.aggregationsTypes.length === 3 && type.value !== 'none') {
+        if (this.aggregationsTypes.length === 3 && type.value !== 'none') {
             this.selectedColumn.column_type = 'numeric';
             const columnType = 'numeric';
             const allowed = [];
@@ -305,7 +307,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         }
 
         // Changing to text type
-        if(this.aggregationsTypes.length === 3 && type.value === 'none') {
+        if (this.aggregationsTypes.length === 3 && type.value === 'none') {
             this.selectedColumn.column_type = 'text';
             const columnType = 'text';
             const allowed = [];
@@ -410,7 +412,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             this.display.filterValue = !_.isEqual(this.selectedColumn.column_type, 'date') ? handler.value : false;
             this.display.calendar = _.isEqual(this.selectedColumn.column_type, 'date') ? handler.value : false;
             this.display.switchButton = _.isEqual(filter.value, 'not_null') || _.isEqual(filter.value, 'not_null_nor_empty') || _.isEqual(filter.value, 'null_or_empty'); // se usa para deshabilitar el boton que da las opciones en el selector.
-            this.display.filterButton = filter.value == 'not_null' || filter.value == 'not_null_nor_empty' || filter.value == 'null_or_empty' ? false : true ;
+            this.display.filterButton = filter.value == 'not_null' || filter.value == 'not_null_nor_empty' || filter.value == 'null_or_empty' ? false : true;
             this.limitSelectionFields = handler.limitFields === 1 ? 1 : 50;
             this.filter.switch = handler.switchBtn;
 
@@ -469,7 +471,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
                 }
 
                 return;
-            } else{
+            } else {
                 this.aggregationsTypes = JSON.parse(JSON.stringify(this.controller.params.selectedColumn.aggregation_type));
             }
 
@@ -549,13 +551,13 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         if (this.controller.params.panel.content) {
 
             const queryFromServer = this.controller.params.panel.content.query.query.fields;
-            const found = this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id  && c.display_name.default === column.display_name.default)?.ordenation_type;
+            const found = this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id && c.display_name.default === column.display_name.default)?.ordenation_type;
             if (found) {
                 this.ordenationTypes.forEach(o => {
                     o.value !== column.ordenation_type ? o.selected = false : o.selected = true;
                 });
 
-                this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id  && c.display_name.default === column.display_name.default).ordenation_type = column.ordenation_type;
+                this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id && c.display_name.default === column.display_name.default).ordenation_type = column.ordenation_type;
                 return;
             }
 
@@ -563,7 +565,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
                 column.ordenation_type = 'No';
             }
 
-            let ordenation = queryFromServer.filter(c => c.column_name === column.column_name && c.table_id === column.table_id  && c.display_name.default === column.display_name.default)[0];
+            let ordenation = queryFromServer.filter(c => c.column_name === column.column_name && c.table_id === column.table_id && c.display_name.default === column.display_name.default)[0];
             ordenation = ordenation ? ordenation.ordenation_type : column.ordenation_type;
             const d = this.ordenationTypes.find(ag => ag.selected === true && ordenation !== ag.value);
             if (!_.isNil(d)) {
@@ -587,7 +589,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             });
         }
 
-        addOrd = this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id  && c.display_name.default === column.display_name.default);
+        addOrd = this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id && c.display_name.default === column.display_name.default);
 
         if (addOrd) {
             addOrd.ordenation_type = this.ordenationTypes.filter(ord => ord.selected === true)[0].value;
@@ -709,11 +711,11 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
                 if (res.length > 1) {
                     for (const item of res[1]) {
-                        if (item[0] === '' || item[0] ) {
-                            if(column.valueListSource !== undefined) {
-                                this.dropDownFields.push({ label : item[0], value: item[0], id : item[1] });
+                        if (item[0] === '' || item[0]) {
+                            if (column.valueListSource !== undefined) {
+                                this.dropDownFields.push({ label: item[0], value: item[0], id: item[1] });
                             } else {
-                                this.dropDownFields.push({ label : item[0], value: item[0], id : item[0] });
+                                this.dropDownFields.push({ label: item[0], value: item[0], id: item[0] });
                             }
                         }
                     }
@@ -730,7 +732,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     }
 
     getAggregationText(value: any) {
-        if(!value.aggregation_type){
+        if (!value.aggregation_type) {
             return 'none'; // if there isn`t aggregation, none is added
         } else {
             const label = aggTypes.filter(agg => {
@@ -741,7 +743,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     }
 
     getFilterText(value) {
-        if(value.filter_type === 'between') return this.textBetween;
+        if (value.filter_type === 'between') return this.textBetween;
         return value.filter_type;
     }
 
@@ -752,9 +754,9 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
                 event.dates[1] = event.dates[0];
             }
 
-            let stringRange = [event.dates[0], event.dates[1]]
+            const stringRange = [event.dates[0], event.dates[1]]
                 .map(date => {
-                    let [{ value: mo }, , { value: da }, , { value: ye }] = dtf.formatToParts(date);
+                    const [{ value: mo }, , { value: da }, , { value: ye }] = dtf.formatToParts(date);
                     return `${ye}-${mo}-${da}`
                 });
 
@@ -765,23 +767,25 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         }
     }
 
-/*SDA COLUMN */    public renameColumn(newName: string) {
-/*SDA COLUMN */        if (_.isNil(newName) || _.isEmpty(newName)) return;
-
-/*SDA COLUMN */        const colInQuery = this.controller.params.currentQuery.find((c: any) =>
-/*SDA COLUMN */            this.selectedColumn.table_id === c.table_id &&
-/*SDA COLUMN */            this.selectedColumn.column_name === c.column_name &&
-/*SDA COLUMN */            this.originalName === c.display_name.default
-/*SDA COLUMN */        );
-
-/*SDA COLUMN */        if (colInQuery) {
-/*SDA COLUMN */            colInQuery.display_name.default = newName;
-/*SDA COLUMN */            this.originalName = newName;
-/*SDA COLUMN */        }
-
-/*SDA COLUMN */        const col = $localize`:@@col:Atributo`, from = $localize`:@@table:de la entidad`;
-/*SDA COLUMN */        this.dialog.title = `${col} ${newName} ${from} ${this.controller.params.table}`;
-/*SDA COLUMN */    }
+/* SDA CUSTOM */    public renameColumn(newName: string) {
+/* SDA CUSTOM */        if (_.isNil(newName) || _.isEmpty(newName)) return;
+/* SDA CUSTOM */
+/* SDA CUSTOM */        const colInQuery = this.controller.params.currentQuery.find((c: any) =>
+/* SDA CUSTOM */            this.selectedColumn.table_id === c.table_id &&
+/* SDA CUSTOM */            this.selectedColumn.column_name === c.column_name &&
+/* SDA CUSTOM */            this.originalName === c.display_name.default
+/* SDA CUSTOM */);
+/* SDA CUSTOM */
+/* SDA CUSTOM */        if (colInQuery) {
+/* SDA CUSTOM */            colInQuery.display_name.default = newName;
+/* SDA CUSTOM */            this.originalName = newName;
+            /* SDA CUSTOM */
+        }
+/* SDA CUSTOM */
+/* SDA CUSTOM */        const col = $localize`:@@col:Atributo`, from = $localize`:@@table:de la entidad`;
+/* SDA CUSTOM */        this.dialog.title = `${col} ${newName} ${from} ${this.controller.params.table}`;
+        /* SDA CUSTOM */
+    }
 
     public onCancelDuplicateColumn(): void {
         this.display.duplicateColumn = false;
@@ -798,10 +802,30 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         this.display.duplicateColumn = false;
         const newColumn = _.cloneDeep(this.selectedColumn);
         newColumn.display_name.default = this.duplicatedColumnName;
-        this.onClose(EdaDialogCloseEvent.NEW, { duplicated: true, column: newColumn});
+        this.onClose(EdaDialogCloseEvent.NEW, { duplicated: true, column: newColumn });
     }
 
     /* Close functions */
+/* SDA CUSTOM */    cancelDialog() {
+/* SDA CUSTOM */        const colInQuery = this.controller.params.currentQuery.find((c: any) =>
+/* SDA CUSTOM */            this.selectedColumn.table_id === c.table_id &&
+/* SDA CUSTOM */            this.selectedColumn.column_name === c.column_name &&
+/* SDA CUSTOM */            this.originalName === c.display_name.default
+/* SDA CUSTOM */);
+/* SDA CUSTOM */
+/* SDA CUSTOM */        if (colInQuery) {
+/* SDA CUSTOM */            colInQuery.display_name.default = this.backupName;
+/* SDA CUSTOM */            this.selectedColumn.display_name.default = this.backupName;
+            /* SDA CUSTOM */
+}
+/* SDA CUSTOM */
+/* SDA CUSTOM */        this.filter.switch = false;
+/* SDA CUSTOM */        this.filterSelected = undefined;
+/* SDA CUSTOM */        this.filterValue = {};
+/* SDA CUSTOM */        this.onClose(EdaDialogCloseEvent.NONE, []);
+        /* SDA CUSTOM */
+}
+
     closeDialog() {
         this.filter.switch = false;
         this.filterSelected = undefined;
@@ -815,7 +839,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
     whereHavingSwitch(selected) {
 
-        if(selected.value) {
+        if (selected.value) {
             this.filterBeforeAfter.filterBeforeGrouping = true;
             return true
         } else {
@@ -829,15 +853,15 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
         const regexNumber = /^[0-9]/;
 
-        if(regexNumber.test(rangeString[rangeString.length-1])){
+        if (regexNumber.test(rangeString[rangeString.length - 1])) {
 
             const ranges = rangeString.split(":")
                 .map(item => parseFloat(item.replace(",", ".")));
 
-            for (let i = 0; i < ranges.length-1; i++) {
+            for (let i = 0; i < ranges.length - 1; i++) {
                 // Verificar si el número actual es menor o igual al anterior
                 if (ranges[i] >= ranges[i + 1]) {
-                    this.ranges=[];
+                    this.ranges = [];
                     this.alertService.addError('El correcto orden de los límites del rango van de menor a mayor');
                     return;
                 }
@@ -866,8 +890,8 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     }
 
     removeRange() {
-        this.selectedRange='';
-        this.showRange=false;
+        this.selectedRange = '';
+        this.showRange = false;
         this.allowedAggregations = true;
         const addAggr = this.findColumn(this.selectedColumn, this.controller.params.currentQuery);
         addAggr.column_type = 'numeric';
@@ -895,9 +919,9 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
     verifyRange() {
 
-        if(this.selectedColumn.ranges !== undefined){
+        if (this.selectedColumn.ranges !== undefined) {
 
-            if(this.selectedColumn.ranges.length !==0){
+            if (this.selectedColumn.ranges.length !== 0) {
                 this.allowedAggregations = false;
                 this.showRange = true;
                 this.ranges = this.selectedColumn.ranges;
@@ -911,7 +935,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         const validCharacters = /[1234567890.,:-]*/g;
         inputElement.value = inputElement.value.match(validCharacters)?.join('') || '';
         // Si el input inicia con (. , :) no se habilitara el botón del rango ni se agregará el signo en el input. Se debe empezar con un número o con un signo (-) y un número para los negativos.
-        if(inputElement.value=== '.' || inputElement.value===',' || inputElement.value===':') inputElement.value = '';
+        if (inputElement.value === '.' || inputElement.value === ',' || inputElement.value === ':') inputElement.value = '';
         this.rangeString = inputElement.value; // Se actualiza ngModel
     }
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
@@ -130,7 +130,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         const title = this.selectedColumn.display_name.default;
         const col = $localize`:@@col:Atributo`, from = $localize`:@@table:de la entidad`;
         this.dialog.title = `${col} ${title} ${from} ${this.controller.params.table}`;
-
+        
         this.carregarValidacions();
         this.verifyRange();
 
@@ -153,7 +153,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             if(agg.selected){
                 this.aggregationSelected = _.cloneDeep(agg);
             }
-        }
+        }        
         if(this.controller.params.currentQuery.find( elemento => elemento.hasOwnProperty('ranges') &&  elemento.ranges.length!==0)) {
             if(this.selectedColumn.hasOwnProperty('ranges') && this.selectedColumn.ranges.length!==0) {
                 this.availableRange = true;
@@ -192,7 +192,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         const data = this.dropDownFields;
         const computed_column = this.selectedColumn.computed_column;
         const SQLexpression = this.selectedColumn.SQLexpression;
-
+        
 
         const filter = this.columnUtils.setFilter({
             obj: this.filterValue,
@@ -211,7 +211,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             SQLexpression
         });
 
-        this.filter.selecteds.push(filter);
+        this.filter.selecteds.push(filter);        
         this.carregarFilters();
 
         /* Reset Filter Form */
@@ -233,8 +233,8 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         if(filter['filterBeforeGrouping']) {
             this.updateSortedFiltersColumnDialog.emit(addToSortedFilters); // Emitting an event to the eda-blank-panel component
         }
-
-        this.dropDownFields = [];
+        
+       this.dropDownFields = [];
     }
 
     removeFilter(item: any) {
@@ -256,8 +256,8 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
     }
 
-    addAggregation(type: any) {
-
+    addAggregation(type: any) {    
+        
         this.aggregationsTypes.find((ag: any) => ag.value === type.value).selected = true;
 
         for (let ag of this.aggregationsTypes) {
@@ -304,7 +304,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             if (allowed.length > 0) {
                 this.filter.types = allowed;
             }
-        }
+        } 
 
         // Changing to text type
         if(this.aggregationsTypes.length === 3 && type.value === 'none') {
@@ -323,7 +323,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             if (allowed.length > 0) {
                 this.filter.types = allowed;
             }
-        }
+        } 
 
     }
 
@@ -357,7 +357,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             if (!this.formatDate.display_name) {
                 this.formatDate = foundFormat;
             }
-
+    
             this.formatDates.forEach(o => {
                 if (o.selected === true && this.formatDate.value !== o.value) {
                     o.selected = false;
@@ -453,19 +453,19 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             c.column_name === column.column_name &&
             c.display_name.default === column.display_name.default
         );
-
+        
         if (this.controller.params.panel.content) {
             const tmpAggTypes = [];
-
+            
             const selectedAggregation = matchingQuery
                 ? matchingQuery.aggregation_type.find((agg: any) => agg.selected === true)
                 : undefined;
 
             // Si ja s'ha carregat el panell i tenim dades a this.select
             if (selectedAggregation) {
-
+                
                 tmpAggTypes.push(...column.aggregation_type);
-
+                
                 if (matchingQuery) {
                     this.aggregationsTypes = JSON.parse(JSON.stringify(matchingQuery.aggregation_type));
                 }
@@ -496,7 +496,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     }
 
     public findColumn(column: Column, columns: any[]) {
-        const found = columns.find((c: any) =>
+        const found = columns.find((c: any) => 
             column.table_id === c.table_id &&
             column.column_name === c.column_name &&
             column.display_name.default === c.display_name.default
@@ -509,7 +509,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         const column = this.selectedColumn;
 
         let tmpDateFormat = '';
-
+    
         if (this.controller.params.panel.content) {
             const foundColumn = this.findColumn(column, this.controller.params.currentQuery);
             const foundFormat = foundColumn?.format;
@@ -534,7 +534,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
                 }
             }
         } else {
-            const foundColumn = this.findColumn(column, this.controller.params.currentQuery);
+            const foundColumn = this.findColumn(column, this.controller.params.currentQuery);            
             tmpDateFormat = foundColumn?.format || 'No';
 
             this.formatDate = { display_name: '', value: tmpDateFormat, selected: true };
@@ -603,30 +603,30 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         if (this.controller.params.panel.content) {
             const { currentQuery } = this.controller.params;
             const queryFromServer = this.controller.params.panel.content.query.query.fields;
-
+            
             const foundColumn = currentQuery.find(c =>
                 c.column_name === column.column_name &&
                 c.table_id === column.table_id &&
                 c.display_name.default === column.display_name.default
             );
-
+    
             if (foundColumn) {
                 const { ordenation_type } = column;
                 this.ordenationTypes.forEach(o => o.selected = o.value === ordenation_type);
                 foundColumn.ordenation_type = ordenation_type;
                 return;
             }
-
+    
             if (!column.ordenation_type) {
                 column.ordenation_type = 'No';
             }
-
+    
             const ordenation = queryFromServer.find(c =>
                 c.column_name === column.column_name &&
                 c.table_id === column.table_id &&
                 c.display_name.default === column.display_name.default
             )?.ordenation_type || column.ordenation_type;
-
+    
             const selectedOrd = this.ordenationTypes.find(ag => ag.selected);
             if (selectedOrd && selectedOrd.value !== ordenation) {
                 selectedOrd.selected = false;
@@ -642,13 +642,13 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
                 { display_name: 'No', value: 'No', selected: true }
             ];
         }
-
+    
         const addOrd = this.controller.params.currentQuery.find(c =>
             c.column_name === column.column_name &&
             c.table_id === column.table_id &&
             c.display_name.default === column.display_name.default
         );
-
+    
         if (addOrd) {
             const selectedOrder = this.ordenationTypes.find(ord => ord.selected);
             if (selectedOrder) {
@@ -656,9 +656,10 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             }
         }
     }
-
+    
 
     handleInputTypes() {
+
         const type = this.selectedColumn.column_type;
         this.inputType = this.columnUtils.handleInputTypes(type);
     }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
@@ -29,6 +29,9 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     public dialog: EdaDialog;
     public selectedColumn: Column;
     public duplicatedColumnName: string;
+    public originalName: string;
+    public sourceFieldName: string;
+    public tableLabel: string;
 
     public display = {
         calendar: false, // calendars inputs
@@ -60,7 +63,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     public cumulativeSumTooltip: string = $localize`:@@cumulativeSumTooltip:Si activas ésta función se calculará la suma acumulativa 
                                             para los campos numéricos que eligas. Sólo se puede activar si la fecha está agregada por mes, semana o dia.`
 
-    public filterBeforeAfter = {    
+    public filterBeforeAfter = {
         filterBeforeGrouping: true, // valor por defecto true ==> WHERE / valor false ==> HAVING
         elements: [
             { label: $localize`:@@whereMessageLabel:Aplicar el filtro sobre todos los registros`, value: true },
@@ -113,11 +116,19 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
     onShow(): void {
         this.selectedColumn = this.controller.params.selectedColumn;
+        this.originalName = this.selectedColumn.display_name.default;
+
+        const table_id = this.selectedColumn.table_id.split('.')[0];
+        const modelTable = this.controller.params.inject.dataSource.model.tables.find(t => t.table_name === table_id);
+        const modelColumn = modelTable?.columns.find(c => c.column_name === this.selectedColumn.column_name);
+        this.sourceFieldName = modelColumn?.display_name?.default || this.selectedColumn.column_name;
+
+        this.tableLabel = this.controller.params.table;
         const allowed = [];
         const title = this.selectedColumn.display_name.default;
         const col = $localize`:@@col:Atributo`, from = $localize`:@@table:de la entidad`;
         this.dialog.title = `${col} ${title} ${from} ${this.controller.params.table}`;
-        
+
         this.carregarValidacions();
         this.verifyRange();
 
@@ -136,13 +147,13 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         }
 
         // Buscando el valor inicial de agregacion de la columna seleccionada
-        for(let agg of this.selectedColumn.aggregation_type) {
-            if(agg.selected){
+        for (let agg of this.selectedColumn.aggregation_type) {
+            if (agg.selected) {
                 this.aggregationSelected = _.cloneDeep(agg);
             }
-        }        
-        if(this.controller.params.currentQuery.find( elemento => elemento.hasOwnProperty('ranges') &&  elemento.ranges.length!==0)) {
-            if(this.selectedColumn.hasOwnProperty('ranges') && this.selectedColumn.ranges.length!==0) {
+        }
+        if (this.controller.params.currentQuery.find(elemento => elemento.hasOwnProperty('ranges') && elemento.ranges.length !== 0)) {
+            if (this.selectedColumn.hasOwnProperty('ranges') && this.selectedColumn.ranges.length !== 0) {
                 this.availableRange = true;
             } else {
                 this.availableRange = false;
@@ -179,7 +190,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         const data = this.dropDownFields;
         const computed_column = this.selectedColumn.computed_column;
         const SQLexpression = this.selectedColumn.SQLexpression;
-        
+
 
         const filter = this.columnUtils.setFilter({
             obj: this.filterValue,
@@ -198,7 +209,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             SQLexpression
         });
 
-        this.filter.selecteds.push(filter);        
+        this.filter.selecteds.push(filter);
         this.carregarFilters();
 
         /* Reset Filter Form */
@@ -217,11 +228,11 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         };
 
         // Control of adding just filter in the where section
-        if(filter['filterBeforeGrouping']) {
+        if (filter['filterBeforeGrouping']) {
             this.updateSortedFiltersColumnDialog.emit(addToSortedFilters); // Emitting an event to the eda-blank-panel component
         }
-        
-       this.dropDownFields = [];
+
+        this.dropDownFields = [];
     }
 
     removeFilter(item: any) {
@@ -243,8 +254,8 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
     }
 
-    addAggregation(type: any) {    
-        
+    addAggregation(type: any) {
+
         this.aggregationsTypes.find((ag: any) => ag.value === type.value).selected = true;
 
         for (let ag of this.aggregationsTypes) {
@@ -267,7 +278,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         this.aggregationSelected = _.cloneDeep(type);
 
         // En caso no tengamos agregación el selected Where/Having se establece en Where
-        if(this.aggregationSelected.value==='none') {
+        if (this.aggregationSelected.value === 'none') {
             this.whereHavingSwitch({
                 label: 'WHERE',
                 value: true,
@@ -275,7 +286,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         }
 
         // Changing to numeric type
-        if(this.aggregationsTypes.length === 3 && type.value !== 'none') {
+        if (this.aggregationsTypes.length === 3 && type.value !== 'none') {
             this.selectedColumn.column_type = 'numeric';
             const columnType = 'numeric';
             const allowed = [];
@@ -291,10 +302,10 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             if (allowed.length > 0) {
                 this.filter.types = allowed;
             }
-        } 
+        }
 
         // Changing to text type
-        if(this.aggregationsTypes.length === 3 && type.value === 'none') {
+        if (this.aggregationsTypes.length === 3 && type.value === 'none') {
             this.selectedColumn.column_type = 'text';
             const columnType = 'text';
             const allowed = [];
@@ -310,7 +321,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             if (allowed.length > 0) {
                 this.filter.types = allowed;
             }
-        } 
+        }
 
     }
 
@@ -344,7 +355,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             if (!this.formatDate.display_name) {
                 this.formatDate = foundFormat;
             }
-    
+
             this.formatDates.forEach(o => {
                 if (o.selected === true && this.formatDate.value !== o.value) {
                     o.selected = false;
@@ -399,7 +410,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             this.display.filterValue = !_.isEqual(this.selectedColumn.column_type, 'date') ? handler.value : false;
             this.display.calendar = _.isEqual(this.selectedColumn.column_type, 'date') ? handler.value : false;
             this.display.switchButton = _.isEqual(filter.value, 'not_null') || _.isEqual(filter.value, 'not_null_nor_empty') || _.isEqual(filter.value, 'null_or_empty'); // se usa para deshabilitar el boton que da las opciones en el selector.
-            this.display.filterButton = filter.value == 'not_null' || filter.value == 'not_null_nor_empty' || filter.value == 'null_or_empty' ? false : true ;
+            this.display.filterButton = filter.value == 'not_null' || filter.value == 'not_null_nor_empty' || filter.value == 'null_or_empty' ? false : true;
             this.limitSelectionFields = handler.limitFields === 1 ? 1 : 50;
             this.filter.switch = handler.switchBtn;
 
@@ -440,25 +451,25 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             c.column_name === column.column_name &&
             c.display_name.default === column.display_name.default
         );
-        
+
         if (this.controller.params.panel.content) {
             const tmpAggTypes = [];
-            
+
             const selectedAggregation = matchingQuery
                 ? matchingQuery.aggregation_type.find((agg: any) => agg.selected === true)
                 : undefined;
 
             // Si ja s'ha carregat el panell i tenim dades a this.select
             if (selectedAggregation) {
-                
+
                 tmpAggTypes.push(...column.aggregation_type);
-                
+
                 if (matchingQuery) {
                     this.aggregationsTypes = JSON.parse(JSON.stringify(matchingQuery.aggregation_type));
                 }
 
                 return;
-            } else{
+            } else {
                 this.aggregationsTypes = JSON.parse(JSON.stringify(this.controller.params.selectedColumn.aggregation_type));
             }
 
@@ -483,7 +494,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     }
 
     public findColumn(column: Column, columns: any[]) {
-        const found = columns.find((c: any) => 
+        const found = columns.find((c: any) =>
             column.table_id === c.table_id &&
             column.column_name === c.column_name &&
             column.display_name.default === c.display_name.default
@@ -496,7 +507,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         const column = this.selectedColumn;
 
         let tmpDateFormat = '';
-    
+
         if (this.controller.params.panel.content) {
             const foundColumn = this.findColumn(column, this.controller.params.currentQuery);
             const foundFormat = foundColumn?.format;
@@ -521,7 +532,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
                 }
             }
         } else {
-            const foundColumn = this.findColumn(column, this.controller.params.currentQuery);            
+            const foundColumn = this.findColumn(column, this.controller.params.currentQuery);
             tmpDateFormat = foundColumn?.format || 'No';
 
             this.formatDate = { display_name: '', value: tmpDateFormat, selected: true };
@@ -538,13 +549,13 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         if (this.controller.params.panel.content) {
 
             const queryFromServer = this.controller.params.panel.content.query.query.fields;
-            const found = this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id  && c.display_name.default === column.display_name.default)?.ordenation_type;
+            const found = this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id && c.display_name.default === column.display_name.default)?.ordenation_type;
             if (found) {
                 this.ordenationTypes.forEach(o => {
                     o.value !== column.ordenation_type ? o.selected = false : o.selected = true;
                 });
 
-                this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id  && c.display_name.default === column.display_name.default).ordenation_type = column.ordenation_type;
+                this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id && c.display_name.default === column.display_name.default).ordenation_type = column.ordenation_type;
                 return;
             }
 
@@ -552,7 +563,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
                 column.ordenation_type = 'No';
             }
 
-            let ordenation = queryFromServer.filter(c => c.column_name === column.column_name && c.table_id === column.table_id  && c.display_name.default === column.display_name.default)[0];
+            let ordenation = queryFromServer.filter(c => c.column_name === column.column_name && c.table_id === column.table_id && c.display_name.default === column.display_name.default)[0];
             ordenation = ordenation ? ordenation.ordenation_type : column.ordenation_type;
             const d = this.ordenationTypes.find(ag => ag.selected === true && ordenation !== ag.value);
             if (!_.isNil(d)) {
@@ -576,7 +587,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             });
         }
 
-        addOrd = this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id  && c.display_name.default === column.display_name.default);
+        addOrd = this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id && c.display_name.default === column.display_name.default);
 
         if (addOrd) {
             addOrd.ordenation_type = this.ordenationTypes.filter(ord => ord.selected === true)[0].value;
@@ -590,30 +601,30 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         if (this.controller.params.panel.content) {
             const { currentQuery } = this.controller.params;
             const queryFromServer = this.controller.params.panel.content.query.query.fields;
-            
+
             const foundColumn = currentQuery.find(c =>
                 c.column_name === column.column_name &&
                 c.table_id === column.table_id &&
                 c.display_name.default === column.display_name.default
             );
-    
+
             if (foundColumn) {
                 const { ordenation_type } = column;
                 this.ordenationTypes.forEach(o => o.selected = o.value === ordenation_type);
                 foundColumn.ordenation_type = ordenation_type;
                 return;
             }
-    
+
             if (!column.ordenation_type) {
                 column.ordenation_type = 'No';
             }
-    
+
             const ordenation = queryFromServer.find(c =>
                 c.column_name === column.column_name &&
                 c.table_id === column.table_id &&
                 c.display_name.default === column.display_name.default
             )?.ordenation_type || column.ordenation_type;
-    
+
             const selectedOrd = this.ordenationTypes.find(ag => ag.selected);
             if (selectedOrd && selectedOrd.value !== ordenation) {
                 selectedOrd.selected = false;
@@ -629,13 +640,13 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
                 { display_name: 'No', value: 'No', selected: true }
             ];
         }
-    
+
         const addOrd = this.controller.params.currentQuery.find(c =>
             c.column_name === column.column_name &&
             c.table_id === column.table_id &&
             c.display_name.default === column.display_name.default
         );
-    
+
         if (addOrd) {
             const selectedOrder = this.ordenationTypes.find(ord => ord.selected);
             if (selectedOrder) {
@@ -643,7 +654,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             }
         }
     }
-    
+
 
     handleInputTypes() {
         const type = this.selectedColumn.column_type;
@@ -698,11 +709,11 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
                 if (res.length > 1) {
                     for (const item of res[1]) {
-                        if (item[0] === '' || item[0] ) {
-                            if(column.valueListSource !== undefined) {
-                                this.dropDownFields.push({ label : item[0], value: item[0], id : item[1] });
+                        if (item[0] === '' || item[0]) {
+                            if (column.valueListSource !== undefined) {
+                                this.dropDownFields.push({ label: item[0], value: item[0], id: item[1] });
                             } else {
-                                this.dropDownFields.push({ label : item[0], value: item[0], id : item[0] });
+                                this.dropDownFields.push({ label: item[0], value: item[0], id: item[0] });
                             }
                         }
                     }
@@ -719,7 +730,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     }
 
     getAggregationText(value: any) {
-        if(!value.aggregation_type){
+        if (!value.aggregation_type) {
             return 'none'; // if there isn`t aggregation, none is added
         } else {
             const label = aggTypes.filter(agg => {
@@ -730,7 +741,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     }
 
     getFilterText(value) {
-        if(value.filter_type === 'between') return this.textBetween;
+        if (value.filter_type === 'between') return this.textBetween;
         return value.filter_type;
     }
 
@@ -754,6 +765,24 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         }
     }
 
+    public renameColumn(newName: string) {
+        if (_.isNil(newName) || _.isEmpty(newName)) return;
+
+        const colInQuery = this.controller.params.currentQuery.find((c: any) =>
+            this.selectedColumn.table_id === c.table_id &&
+            this.selectedColumn.column_name === c.column_name &&
+            this.originalName === c.display_name.default
+        );
+
+        if (colInQuery) {
+            colInQuery.display_name.default = newName;
+            this.originalName = newName;
+        }
+
+        const col = $localize`:@@col:Atributo`, from = $localize`:@@table:de la entidad`;
+        this.dialog.title = `${col} ${newName} ${from} ${this.controller.params.table}`;
+    }
+
     public onCancelDuplicateColumn(): void {
         this.display.duplicateColumn = false;
     }
@@ -769,7 +798,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         this.display.duplicateColumn = false;
         const newColumn = _.cloneDeep(this.selectedColumn);
         newColumn.display_name.default = this.duplicatedColumnName;
-        this.onClose(EdaDialogCloseEvent.NEW, { duplicated: true, column: newColumn});
+        this.onClose(EdaDialogCloseEvent.NEW, { duplicated: true, column: newColumn });
     }
 
     /* Close functions */
@@ -786,7 +815,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
     whereHavingSwitch(selected) {
 
-        if(selected.value) {
+        if (selected.value) {
             this.filterBeforeAfter.filterBeforeGrouping = true;
             return true
         } else {
@@ -800,15 +829,15 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
         const regexNumber = /^[0-9]/;
 
-        if(regexNumber.test(rangeString[rangeString.length-1])){
+        if (regexNumber.test(rangeString[rangeString.length - 1])) {
 
             const ranges = rangeString.split(":")
-            .map(item => parseFloat(item.replace(",", ".")));
+                .map(item => parseFloat(item.replace(",", ".")));
 
-            for (let i = 0; i < ranges.length-1; i++) {
+            for (let i = 0; i < ranges.length - 1; i++) {
                 // Verificar si el número actual es menor o igual al anterior
                 if (ranges[i] >= ranges[i + 1]) {
-                    this.ranges=[];
+                    this.ranges = [];
                     this.alertService.addError('El correcto orden de los límites del rango van de menor a mayor');
                     return;
                 }
@@ -837,8 +866,8 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     }
 
     removeRange() {
-        this.selectedRange='';
-        this.showRange=false;
+        this.selectedRange = '';
+        this.showRange = false;
         this.allowedAggregations = true;
         const addAggr = this.findColumn(this.selectedColumn, this.controller.params.currentQuery);
         addAggr.column_type = 'numeric';
@@ -849,26 +878,26 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
     generarStringRango(rango: number[]): string {
         let resultado = "";
-    
+
         // Agregamos la primera condición
         resultado += `< ${rango[0]}<br>`;
-        
+
         // Creamos las condiciones intermedias
         for (let i = 0; i < rango.length - 1; i++) {
             resultado += `${rango[i]} - ${rango[i + 1] - 1}<br>`;
         }
-        
+
         // Agregamos la última condición
         resultado += `>= ${rango[rango.length - 1]}`;
-        
+
         return resultado;
     }
 
     verifyRange() {
 
-        if(this.selectedColumn.ranges !== undefined){
+        if (this.selectedColumn.ranges !== undefined) {
 
-            if(this.selectedColumn.ranges.length !==0){
+            if (this.selectedColumn.ranges.length !== 0) {
                 this.allowedAggregations = false;
                 this.showRange = true;
                 this.ranges = this.selectedColumn.ranges;
@@ -882,7 +911,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         const validCharacters = /[1234567890.,:-]*/g;
         inputElement.value = inputElement.value.match(validCharacters)?.join('') || '';
         // Si el input inicia con (. , :) no se habilitara el botón del rango ni se agregará el signo en el input. Se debe empezar con un número o con un signo (-) y un número para los negativos.
-        if(inputElement.value=== '.' || inputElement.value===',' || inputElement.value===':') inputElement.value = '';
+        if (inputElement.value === '.' || inputElement.value === ',' || inputElement.value === ':') inputElement.value = '';
         this.rangeString = inputElement.value; // Se actualiza ngModel
     }
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
@@ -766,7 +766,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             this.display.filterButton = false;
         }
     }
-
+                    // Function to rename the column in the query when the user changes the name in the dialog, also updates the title of the dialog
 /* SDA CUSTOM */    public renameColumn(newName: string) {
 /* SDA CUSTOM */        if (_.isNil(newName) || _.isEmpty(newName)) return;
 /* SDA CUSTOM */

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
@@ -149,13 +149,13 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         }
 
         // Buscando el valor inicial de agregacion de la columna seleccionada
-        for (let agg of this.selectedColumn.aggregation_type) {
-            if (agg.selected) {
+        for(let agg of this.selectedColumn.aggregation_type) {
+            if(agg.selected){
                 this.aggregationSelected = _.cloneDeep(agg);
             }
         }
-        if (this.controller.params.currentQuery.find(elemento => elemento.hasOwnProperty('ranges') && elemento.ranges.length !== 0)) {
-            if (this.selectedColumn.hasOwnProperty('ranges') && this.selectedColumn.ranges.length !== 0) {
+        if(this.controller.params.currentQuery.find( elemento => elemento.hasOwnProperty('ranges') &&  elemento.ranges.length!==0)) {
+            if(this.selectedColumn.hasOwnProperty('ranges') && this.selectedColumn.ranges.length!==0) {
                 this.availableRange = true;
             } else {
                 this.availableRange = false;
@@ -230,7 +230,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         };
 
         // Control of adding just filter in the where section
-        if (filter['filterBeforeGrouping']) {
+        if(filter['filterBeforeGrouping']) {
             this.updateSortedFiltersColumnDialog.emit(addToSortedFilters); // Emitting an event to the eda-blank-panel component
         }
 
@@ -260,7 +260,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
         this.aggregationsTypes.find((ag: any) => ag.value === type.value).selected = true;
 
-        for (const ag of this.aggregationsTypes) {
+        for (let ag of this.aggregationsTypes) {
             if (ag.selected === true && type.value !== ag.value) {
                 ag.selected = false;
             }
@@ -280,7 +280,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         this.aggregationSelected = _.cloneDeep(type);
 
         // En caso no tengamos agregación el selected Where/Having se establece en Where
-        if (this.aggregationSelected.value === 'none') {
+        if(this.aggregationSelected.value==='none') {
             this.whereHavingSwitch({
                 label: 'WHERE',
                 value: true,
@@ -288,7 +288,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         }
 
         // Changing to numeric type
-        if (this.aggregationsTypes.length === 3 && type.value !== 'none') {
+        if(this.aggregationsTypes.length === 3 && type.value !== 'none') {
             this.selectedColumn.column_type = 'numeric';
             const columnType = 'numeric';
             const allowed = [];
@@ -307,7 +307,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         }
 
         // Changing to text type
-        if (this.aggregationsTypes.length === 3 && type.value === 'none') {
+        if(this.aggregationsTypes.length === 3 && type.value === 'none') {
             this.selectedColumn.column_type = 'text';
             const columnType = 'text';
             const allowed = [];
@@ -412,7 +412,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             this.display.filterValue = !_.isEqual(this.selectedColumn.column_type, 'date') ? handler.value : false;
             this.display.calendar = _.isEqual(this.selectedColumn.column_type, 'date') ? handler.value : false;
             this.display.switchButton = _.isEqual(filter.value, 'not_null') || _.isEqual(filter.value, 'not_null_nor_empty') || _.isEqual(filter.value, 'null_or_empty'); // se usa para deshabilitar el boton que da las opciones en el selector.
-            this.display.filterButton = filter.value == 'not_null' || filter.value == 'not_null_nor_empty' || filter.value == 'null_or_empty' ? false : true;
+            this.display.filterButton = filter.value == 'not_null' || filter.value == 'not_null_nor_empty' || filter.value == 'null_or_empty' ? false : true ;
             this.limitSelectionFields = handler.limitFields === 1 ? 1 : 50;
             this.filter.switch = handler.switchBtn;
 
@@ -471,7 +471,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
                 }
 
                 return;
-            } else {
+            } else{
                 this.aggregationsTypes = JSON.parse(JSON.stringify(this.controller.params.selectedColumn.aggregation_type));
             }
 
@@ -551,13 +551,13 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         if (this.controller.params.panel.content) {
 
             const queryFromServer = this.controller.params.panel.content.query.query.fields;
-            const found = this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id && c.display_name.default === column.display_name.default)?.ordenation_type;
+            const found = this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id  && c.display_name.default === column.display_name.default)?.ordenation_type;
             if (found) {
                 this.ordenationTypes.forEach(o => {
                     o.value !== column.ordenation_type ? o.selected = false : o.selected = true;
                 });
 
-                this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id && c.display_name.default === column.display_name.default).ordenation_type = column.ordenation_type;
+                this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id  && c.display_name.default === column.display_name.default).ordenation_type = column.ordenation_type;
                 return;
             }
 
@@ -565,7 +565,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
                 column.ordenation_type = 'No';
             }
 
-            let ordenation = queryFromServer.filter(c => c.column_name === column.column_name && c.table_id === column.table_id && c.display_name.default === column.display_name.default)[0];
+            let ordenation = queryFromServer.filter(c => c.column_name === column.column_name && c.table_id === column.table_id  && c.display_name.default === column.display_name.default)[0];
             ordenation = ordenation ? ordenation.ordenation_type : column.ordenation_type;
             const d = this.ordenationTypes.find(ag => ag.selected === true && ordenation !== ag.value);
             if (!_.isNil(d)) {
@@ -589,7 +589,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             });
         }
 
-        addOrd = this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id && c.display_name.default === column.display_name.default);
+        addOrd = this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id  && c.display_name.default === column.display_name.default);
 
         if (addOrd) {
             addOrd.ordenation_type = this.ordenationTypes.filter(ord => ord.selected === true)[0].value;
@@ -711,11 +711,11 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
                 if (res.length > 1) {
                     for (const item of res[1]) {
-                        if (item[0] === '' || item[0]) {
-                            if (column.valueListSource !== undefined) {
-                                this.dropDownFields.push({ label: item[0], value: item[0], id: item[1] });
+                        if (item[0] === '' || item[0] ) {
+                            if(column.valueListSource !== undefined) {
+                                this.dropDownFields.push({ label : item[0], value: item[0], id : item[1] });
                             } else {
-                                this.dropDownFields.push({ label: item[0], value: item[0], id: item[0] });
+                                this.dropDownFields.push({ label : item[0], value: item[0], id : item[0] });
                             }
                         }
                     }
@@ -732,7 +732,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     }
 
     getAggregationText(value: any) {
-        if (!value.aggregation_type) {
+        if(!value.aggregation_type){
             return 'none'; // if there isn`t aggregation, none is added
         } else {
             const label = aggTypes.filter(agg => {
@@ -743,7 +743,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     }
 
     getFilterText(value) {
-        if (value.filter_type === 'between') return this.textBetween;
+        if(value.filter_type === 'between') return this.textBetween;
         return value.filter_type;
     }
 
@@ -754,9 +754,9 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
                 event.dates[1] = event.dates[0];
             }
 
-            const stringRange = [event.dates[0], event.dates[1]]
+            let stringRange = [event.dates[0], event.dates[1]]
                 .map(date => {
-                    const [{ value: mo }, , { value: da }, , { value: ye }] = dtf.formatToParts(date);
+                    let [{ value: mo }, , { value: da }, , { value: ye }] = dtf.formatToParts(date);
                     return `${ye}-${mo}-${da}`
                 });
 
@@ -774,18 +774,16 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 /* SDA CUSTOM */            this.selectedColumn.table_id === c.table_id &&
 /* SDA CUSTOM */            this.selectedColumn.column_name === c.column_name &&
 /* SDA CUSTOM */            this.originalName === c.display_name.default
-/* SDA CUSTOM */);
+/* SDA CUSTOM */        );
 /* SDA CUSTOM */
 /* SDA CUSTOM */        if (colInQuery) {
 /* SDA CUSTOM */            colInQuery.display_name.default = newName;
 /* SDA CUSTOM */            this.originalName = newName;
-            /* SDA CUSTOM */
-        }
+/* SDA CUSTOM */        }
 /* SDA CUSTOM */
 /* SDA CUSTOM */        const col = $localize`:@@col:Atributo`, from = $localize`:@@table:de la entidad`;
 /* SDA CUSTOM */        this.dialog.title = `${col} ${newName} ${from} ${this.controller.params.table}`;
-        /* SDA CUSTOM */
-    }
+/* SDA CUSTOM */      }
 
     public onCancelDuplicateColumn(): void {
         this.display.duplicateColumn = false;
@@ -802,7 +800,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         this.display.duplicateColumn = false;
         const newColumn = _.cloneDeep(this.selectedColumn);
         newColumn.display_name.default = this.duplicatedColumnName;
-        this.onClose(EdaDialogCloseEvent.NEW, { duplicated: true, column: newColumn });
+        this.onClose(EdaDialogCloseEvent.NEW, { duplicated: true, column: newColumn});
     }
 
     /* Close functions */
@@ -839,7 +837,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
     whereHavingSwitch(selected) {
 
-        if (selected.value) {
+        if(selected.value) {
             this.filterBeforeAfter.filterBeforeGrouping = true;
             return true
         } else {
@@ -853,15 +851,15 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
         const regexNumber = /^[0-9]/;
 
-        if (regexNumber.test(rangeString[rangeString.length - 1])) {
+        if(regexNumber.test(rangeString[rangeString.length-1])){
 
             const ranges = rangeString.split(":")
                 .map(item => parseFloat(item.replace(",", ".")));
 
-            for (let i = 0; i < ranges.length - 1; i++) {
+            for (let i = 0; i < ranges.length-1; i++) {
                 // Verificar si el número actual es menor o igual al anterior
                 if (ranges[i] >= ranges[i + 1]) {
-                    this.ranges = [];
+                    this.ranges=[];
                     this.alertService.addError('El correcto orden de los límites del rango van de menor a mayor');
                     return;
                 }
@@ -890,8 +888,8 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     }
 
     removeRange() {
-        this.selectedRange = '';
-        this.showRange = false;
+        this.selectedRange='';
+        this.showRange=false;
         this.allowedAggregations = true;
         const addAggr = this.findColumn(this.selectedColumn, this.controller.params.currentQuery);
         addAggr.column_type = 'numeric';
@@ -919,9 +917,9 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
     verifyRange() {
 
-        if (this.selectedColumn.ranges !== undefined) {
+        if(this.selectedColumn.ranges !== undefined){
 
-            if (this.selectedColumn.ranges.length !== 0) {
+            if(this.selectedColumn.ranges.length !==0){
                 this.allowedAggregations = false;
                 this.showRange = true;
                 this.ranges = this.selectedColumn.ranges;
@@ -935,7 +933,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         const validCharacters = /[1234567890.,:-]*/g;
         inputElement.value = inputElement.value.match(validCharacters)?.join('') || '';
         // Si el input inicia con (. , :) no se habilitara el botón del rango ni se agregará el signo en el input. Se debe empezar con un número o con un signo (-) y un número para los negativos.
-        if (inputElement.value === '.' || inputElement.value === ',' || inputElement.value === ':') inputElement.value = '';
+        if(inputElement.value=== '.' || inputElement.value===',' || inputElement.value===':') inputElement.value = '';
         this.rangeString = inputElement.value; // Se actualiza ngModel
     }
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
@@ -29,9 +29,9 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     public dialog: EdaDialog;
     public selectedColumn: Column;
     public duplicatedColumnName: string;
-    public originalName: string;
-    public sourceFieldName: string;
-    public tableLabel: string;
+/* SDA CUSTOM */    public originalName: string;
+/* SDA CUSTOM */    public sourceFieldName: string;
+/* SDA CUSTOM */    public tableLabel: string;
 
     public display = {
         calendar: false, // calendars inputs
@@ -60,7 +60,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     public dropDownFields: any[] = [];
     public limitSelectionFields: number;
     public cumulativeSum: boolean;
-    public cumulativeSumTooltip: string = $localize`:@@cumulativeSumTooltip:Si activas ésta función se calculará la suma acumulativa 
+    public cumulativeSumTooltip: string = $localize`:@@cumulativeSumTooltip:Si activas ésta función se calculará la suma acumulativa
                                             para los campos numéricos que eligas. Sólo se puede activar si la fecha está agregada por mes, semana o dia.`
 
     public filterBeforeAfter = {
@@ -116,14 +116,14 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
     onShow(): void {
         this.selectedColumn = this.controller.params.selectedColumn;
-        this.originalName = this.selectedColumn.display_name.default;
+/*SDA CUSTOM*/        this.originalName = this.selectedColumn.display_name.default;
 
-        const table_id = this.selectedColumn.table_id.split('.')[0];
-        const modelTable = this.controller.params.inject.dataSource.model.tables.find(t => t.table_name === table_id);
-        const modelColumn = modelTable?.columns.find(c => c.column_name === this.selectedColumn.column_name);
-        this.sourceFieldName = modelColumn?.display_name?.default || this.selectedColumn.column_name;
+/*SDA CUSTOM*/        const table_id = this.selectedColumn.table_id.split('.')[0];
+/*SDA CUSTOM*/       const modelTable = this.controller.params.inject.dataSource.model.tables.find(t => t.table_name === table_id);
+/*SDA CUSTOM*/        const modelColumn = modelTable?.columns.find(c => c.column_name === this.selectedColumn.column_name);
+/*SDA CUSTOM*/        this.sourceFieldName = modelColumn?.display_name?.default || this.selectedColumn.column_name;
 
-        this.tableLabel = this.controller.params.table;
+/*SDA CUSTOM*/        this.tableLabel = this.controller.params.table;
         const allowed = [];
         const title = this.selectedColumn.display_name.default;
         const col = $localize`:@@col:Atributo`, from = $localize`:@@table:de la entidad`;
@@ -147,13 +147,13 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         }
 
         // Buscando el valor inicial de agregacion de la columna seleccionada
-        for (let agg of this.selectedColumn.aggregation_type) {
-            if (agg.selected) {
+        for(let agg of this.selectedColumn.aggregation_type) {
+            if(agg.selected){
                 this.aggregationSelected = _.cloneDeep(agg);
             }
         }
-        if (this.controller.params.currentQuery.find(elemento => elemento.hasOwnProperty('ranges') && elemento.ranges.length !== 0)) {
-            if (this.selectedColumn.hasOwnProperty('ranges') && this.selectedColumn.ranges.length !== 0) {
+        if(this.controller.params.currentQuery.find( elemento => elemento.hasOwnProperty('ranges') &&  elemento.ranges.length!==0)) {
+            if(this.selectedColumn.hasOwnProperty('ranges') && this.selectedColumn.ranges.length!==0) {
                 this.availableRange = true;
             } else {
                 this.availableRange = false;
@@ -228,7 +228,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         };
 
         // Control of adding just filter in the where section
-        if (filter['filterBeforeGrouping']) {
+        if(filter['filterBeforeGrouping']) {
             this.updateSortedFiltersColumnDialog.emit(addToSortedFilters); // Emitting an event to the eda-blank-panel component
         }
 
@@ -278,7 +278,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         this.aggregationSelected = _.cloneDeep(type);
 
         // En caso no tengamos agregación el selected Where/Having se establece en Where
-        if (this.aggregationSelected.value === 'none') {
+        if(this.aggregationSelected.value==='none') {
             this.whereHavingSwitch({
                 label: 'WHERE',
                 value: true,
@@ -286,7 +286,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         }
 
         // Changing to numeric type
-        if (this.aggregationsTypes.length === 3 && type.value !== 'none') {
+        if(this.aggregationsTypes.length === 3 && type.value !== 'none') {
             this.selectedColumn.column_type = 'numeric';
             const columnType = 'numeric';
             const allowed = [];
@@ -305,7 +305,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         }
 
         // Changing to text type
-        if (this.aggregationsTypes.length === 3 && type.value === 'none') {
+        if(this.aggregationsTypes.length === 3 && type.value === 'none') {
             this.selectedColumn.column_type = 'text';
             const columnType = 'text';
             const allowed = [];
@@ -410,7 +410,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             this.display.filterValue = !_.isEqual(this.selectedColumn.column_type, 'date') ? handler.value : false;
             this.display.calendar = _.isEqual(this.selectedColumn.column_type, 'date') ? handler.value : false;
             this.display.switchButton = _.isEqual(filter.value, 'not_null') || _.isEqual(filter.value, 'not_null_nor_empty') || _.isEqual(filter.value, 'null_or_empty'); // se usa para deshabilitar el boton que da las opciones en el selector.
-            this.display.filterButton = filter.value == 'not_null' || filter.value == 'not_null_nor_empty' || filter.value == 'null_or_empty' ? false : true;
+            this.display.filterButton = filter.value == 'not_null' || filter.value == 'not_null_nor_empty' || filter.value == 'null_or_empty' ? false : true ;
             this.limitSelectionFields = handler.limitFields === 1 ? 1 : 50;
             this.filter.switch = handler.switchBtn;
 
@@ -469,7 +469,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
                 }
 
                 return;
-            } else {
+            } else{
                 this.aggregationsTypes = JSON.parse(JSON.stringify(this.controller.params.selectedColumn.aggregation_type));
             }
 
@@ -549,13 +549,13 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         if (this.controller.params.panel.content) {
 
             const queryFromServer = this.controller.params.panel.content.query.query.fields;
-            const found = this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id && c.display_name.default === column.display_name.default)?.ordenation_type;
+            const found = this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id  && c.display_name.default === column.display_name.default)?.ordenation_type;
             if (found) {
                 this.ordenationTypes.forEach(o => {
                     o.value !== column.ordenation_type ? o.selected = false : o.selected = true;
                 });
 
-                this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id && c.display_name.default === column.display_name.default).ordenation_type = column.ordenation_type;
+                this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id  && c.display_name.default === column.display_name.default).ordenation_type = column.ordenation_type;
                 return;
             }
 
@@ -563,7 +563,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
                 column.ordenation_type = 'No';
             }
 
-            let ordenation = queryFromServer.filter(c => c.column_name === column.column_name && c.table_id === column.table_id && c.display_name.default === column.display_name.default)[0];
+            let ordenation = queryFromServer.filter(c => c.column_name === column.column_name && c.table_id === column.table_id  && c.display_name.default === column.display_name.default)[0];
             ordenation = ordenation ? ordenation.ordenation_type : column.ordenation_type;
             const d = this.ordenationTypes.find(ag => ag.selected === true && ordenation !== ag.value);
             if (!_.isNil(d)) {
@@ -587,7 +587,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             });
         }
 
-        addOrd = this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id && c.display_name.default === column.display_name.default);
+        addOrd = this.controller.params.currentQuery.find(c => c.column_name === column.column_name && c.table_id === column.table_id  && c.display_name.default === column.display_name.default);
 
         if (addOrd) {
             addOrd.ordenation_type = this.ordenationTypes.filter(ord => ord.selected === true)[0].value;
@@ -709,11 +709,11 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
                 if (res.length > 1) {
                     for (const item of res[1]) {
-                        if (item[0] === '' || item[0]) {
-                            if (column.valueListSource !== undefined) {
-                                this.dropDownFields.push({ label: item[0], value: item[0], id: item[1] });
+                        if (item[0] === '' || item[0] ) {
+                            if(column.valueListSource !== undefined) {
+                                this.dropDownFields.push({ label : item[0], value: item[0], id : item[1] });
                             } else {
-                                this.dropDownFields.push({ label: item[0], value: item[0], id: item[0] });
+                                this.dropDownFields.push({ label : item[0], value: item[0], id : item[0] });
                             }
                         }
                     }
@@ -730,7 +730,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     }
 
     getAggregationText(value: any) {
-        if (!value.aggregation_type) {
+        if(!value.aggregation_type){
             return 'none'; // if there isn`t aggregation, none is added
         } else {
             const label = aggTypes.filter(agg => {
@@ -741,7 +741,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     }
 
     getFilterText(value) {
-        if (value.filter_type === 'between') return this.textBetween;
+        if(value.filter_type === 'between') return this.textBetween;
         return value.filter_type;
     }
 
@@ -765,23 +765,23 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         }
     }
 
-    public renameColumn(newName: string) {
-        if (_.isNil(newName) || _.isEmpty(newName)) return;
+/*SDA COLUMN */    public renameColumn(newName: string) {
+/*SDA COLUMN */        if (_.isNil(newName) || _.isEmpty(newName)) return;
 
-        const colInQuery = this.controller.params.currentQuery.find((c: any) =>
-            this.selectedColumn.table_id === c.table_id &&
-            this.selectedColumn.column_name === c.column_name &&
-            this.originalName === c.display_name.default
-        );
+/*SDA COLUMN */        const colInQuery = this.controller.params.currentQuery.find((c: any) =>
+/*SDA COLUMN */            this.selectedColumn.table_id === c.table_id &&
+/*SDA COLUMN */            this.selectedColumn.column_name === c.column_name &&
+/*SDA COLUMN */            this.originalName === c.display_name.default
+/*SDA COLUMN */        );
 
-        if (colInQuery) {
-            colInQuery.display_name.default = newName;
-            this.originalName = newName;
-        }
+/*SDA COLUMN */        if (colInQuery) {
+/*SDA COLUMN */            colInQuery.display_name.default = newName;
+/*SDA COLUMN */            this.originalName = newName;
+/*SDA COLUMN */        }
 
-        const col = $localize`:@@col:Atributo`, from = $localize`:@@table:de la entidad`;
-        this.dialog.title = `${col} ${newName} ${from} ${this.controller.params.table}`;
-    }
+/*SDA COLUMN */        const col = $localize`:@@col:Atributo`, from = $localize`:@@table:de la entidad`;
+/*SDA COLUMN */        this.dialog.title = `${col} ${newName} ${from} ${this.controller.params.table}`;
+/*SDA COLUMN */    }
 
     public onCancelDuplicateColumn(): void {
         this.display.duplicateColumn = false;
@@ -798,7 +798,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         this.display.duplicateColumn = false;
         const newColumn = _.cloneDeep(this.selectedColumn);
         newColumn.display_name.default = this.duplicatedColumnName;
-        this.onClose(EdaDialogCloseEvent.NEW, { duplicated: true, column: newColumn });
+        this.onClose(EdaDialogCloseEvent.NEW, { duplicated: true, column: newColumn});
     }
 
     /* Close functions */
@@ -815,7 +815,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
     whereHavingSwitch(selected) {
 
-        if (selected.value) {
+        if(selected.value) {
             this.filterBeforeAfter.filterBeforeGrouping = true;
             return true
         } else {
@@ -829,15 +829,15 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
         const regexNumber = /^[0-9]/;
 
-        if (regexNumber.test(rangeString[rangeString.length - 1])) {
+        if(regexNumber.test(rangeString[rangeString.length-1])){
 
             const ranges = rangeString.split(":")
                 .map(item => parseFloat(item.replace(",", ".")));
 
-            for (let i = 0; i < ranges.length - 1; i++) {
+            for (let i = 0; i < ranges.length-1; i++) {
                 // Verificar si el número actual es menor o igual al anterior
                 if (ranges[i] >= ranges[i + 1]) {
-                    this.ranges = [];
+                    this.ranges=[];
                     this.alertService.addError('El correcto orden de los límites del rango van de menor a mayor');
                     return;
                 }
@@ -853,7 +853,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
             const selectionAggregationRange = { value: 'none', display_name: 'No', selected: 'true' };
             this.addAggregation(selectionAggregationRange);
 
-            // Encuentra la columna de turno y agrega el rango 
+            // Encuentra la columna de turno y agrega el rango
             const addAggr = this.findColumn(this.selectedColumn, this.controller.params.currentQuery);
             addAggr.column_type = 'text';
             addAggr.ranges = this.ranges;
@@ -866,8 +866,8 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     }
 
     removeRange() {
-        this.selectedRange = '';
-        this.showRange = false;
+        this.selectedRange='';
+        this.showRange=false;
         this.allowedAggregations = true;
         const addAggr = this.findColumn(this.selectedColumn, this.controller.params.currentQuery);
         addAggr.column_type = 'numeric';
@@ -895,9 +895,9 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
 
     verifyRange() {
 
-        if (this.selectedColumn.ranges !== undefined) {
+        if(this.selectedColumn.ranges !== undefined){
 
-            if (this.selectedColumn.ranges.length !== 0) {
+            if(this.selectedColumn.ranges.length !==0){
                 this.allowedAggregations = false;
                 this.showRange = true;
                 this.ranges = this.selectedColumn.ranges;
@@ -911,7 +911,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
         const validCharacters = /[1234567890.,:-]*/g;
         inputElement.value = inputElement.value.match(validCharacters)?.join('') || '';
         // Si el input inicia con (. , :) no se habilitara el botón del rango ni se agregará el signo en el input. Se debe empezar con un número o con un signo (-) y un número para los negativos.
-        if (inputElement.value === '.' || inputElement.value === ',' || inputElement.value === ':') inputElement.value = '';
+        if(inputElement.value=== '.' || inputElement.value===',' || inputElement.value===':') inputElement.value = '';
         this.rangeString = inputElement.value; // Se actualiza ngModel
     }
 

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -371,10 +371,6 @@
     <source>Etiqueta para el campo</source>
     <target>Etiqueta per al camp</target>
   </trans-unit>
-  <trans-unit id="cancelButton" datatype="html">
-    <source>Cancelar</source>
-    <target>Cancel·la</target>
-  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -367,6 +367,10 @@
     <source>Eliminar filtros</source>
     <target>Elimina filtres</target>
   </trans-unit>
+  <trans-unit id="nombreColumnaH4" datatype="html">
+    <source>Etiqueta para el campo</source>
+    <target>Etiqueta per al camp</target>
+  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -371,6 +371,10 @@
     <source>Etiqueta para el campo</source>
     <target>Etiqueta per al camp</target>
   </trans-unit>
+  <trans-unit id="cancelButton" datatype="html">
+    <source>Cancelar</source>
+    <target>Cancel·la</target>
+  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -367,6 +367,10 @@
     <source>Eliminar filtros</source>
     <target>Clear filters</target>
   </trans-unit>
+  <trans-unit id="nombreColumnaH4" datatype="html">
+    <source>Etiqueta para el campo</source>
+    <target>Label for the field</target>
+  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -371,10 +371,6 @@
     <source>Etiqueta para el campo</source>
     <target>Label for the field</target>
   </trans-unit>
-  <trans-unit id="cancelButton" datatype="html">
-    <source>Cancelar</source>
-    <target>Cancel</target>
-  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -371,6 +371,10 @@
     <source>Etiqueta para el campo</source>
     <target>Label for the field</target>
   </trans-unit>
+  <trans-unit id="cancelButton" datatype="html">
+    <source>Cancelar</source>
+    <target>Cancel</target>
+  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -371,10 +371,6 @@
     <source>Etiqueta para el campo</source>
     <target>Etiqueta para el campo</target>
   </trans-unit>
-  <trans-unit id="cancelButton" datatype="html">
-        <source>Cancelar</source>
-        <target>Cancelar</target>
-  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -367,6 +367,10 @@
     <source>Eliminar filtros</source>
     <target>Eliminar filtros</target>
   </trans-unit>
+  <trans-unit id="nombreColumnaH4" datatype="html">
+    <source>Etiqueta para el campo</source>
+    <target>Etiqueta para el campo</target>
+  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -371,6 +371,10 @@
     <source>Etiqueta para el campo</source>
     <target>Etiqueta para el campo</target>
   </trans-unit>
+  <trans-unit id="cancelButton" datatype="html">
+        <source>Cancelar</source>
+        <target>Cancelar</target>
+  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -371,6 +371,10 @@
     <source>Etiqueta para el campo</source>
     <target>Etiqueta para o campo</target>
   </trans-unit>
+  <trans-unit id="cancelButton" datatype="html">
+    <source>Cancelar</source>
+    <target>Cancelar</target>
+  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -371,10 +371,6 @@
     <source>Etiqueta para el campo</source>
     <target>Etiqueta para o campo</target>
   </trans-unit>
-  <trans-unit id="cancelButton" datatype="html">
-    <source>Cancelar</source>
-    <target>Cancelar</target>
-  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -367,6 +367,10 @@
     <source>Eliminar filtros</source>
     <target>Eliminar filtros</target>
   </trans-unit>
+  <trans-unit id="nombreColumnaH4" datatype="html">
+    <source>Etiqueta para el campo</source>
+    <target>Etiqueta para o campo</target>
+  </trans-unit>
 </body>
 </file>
 </xliff>


### PR DESCRIPTION
## Descripción
Esta mejora permite a los usuarios modificar el nombre de visualización de una columna directamente desde su diálogo de configuración. Anteriormente, era necesario duplicar la columna para poder renombrarla, lo que generaba pasos innecesarios. Además, se ha incorporado un botón de "Cancelar" que permite descartar cualquier edición, asegurando que el estado original se restaure correctamente.

## Cambios realizados

### 🎨 Interfaz de Usuario (UI)
- **Nuevo campo de renombrado**: Añadido un input de texto en la parte superior del diálogo para editar el nombre actual.
- **Etiqueta informativa**: Se muestra la procedencia del campo con el formato: `Etiqueta para el campo [Tabla - Nombre Original]:`.
- **Botón Cancelar**: Añadido un botón de "Cancelar" en el footer del diálogo, estilizado en rojo (`p-button-danger`) y con el icono consistente `fa fa-times`, posicionado a la derecha del botón de confirmación.

### ⚙️ Lógica (Frontend)
- **Método [renameColumn](cci:1://file:///home/jchstic/code/workkit_sda/app/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts:769:0-785:23)**: Implementada la lógica en [ColumnDialogComponent](cci:2://file:///home/jchstic/code/workkit_sda/app/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts:17:0-939:1) para actualizar el nombre en la consulta (`currentQuery`) y el título del diálogo en tiempo real.
- **Gestión de Cancelación**: 
  - Se ha añadido la propiedad `backupName` para almacenar el nombre original al abrir el diálogo.
  - El nuevo método [cancelDialog](cci:1://file:///home/jchstic/code/workkit_sda/app/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts:805:4-824:1) revierte los cambios en `currentQuery` y en la columna seleccionada antes de cerrar el diálogo, garantizando la integridad de los datos si el usuario decide no guardar.
- **Identificación del Origen**: El componente ahora recupera la etiqueta original del modelo de datos para mostrarla como referencia al usuario.
- **Estabilidad**: Añadida protección con `*ngIf` para asegurar que el diálogo se renderiza correctamente solo cuando los datos están disponibles.

### Pruebas a realizar:
- Cambiar la etiqueta de cualquier columna, verificando que se muestra correctamente y funciona en cualquier contexto (Gráficos, tablas, filtros de panel, filtros de informe, etc)
- Probar a realizar cambios en cualquier columna y pulsar el botón cancelar, comprobando que los cambios no se han guardado.