### PR TITLE
Hotfix - APP- Duplicados en opciones de filtro

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
@@ -678,6 +678,7 @@ export class ColumnDialogComponent extends EdaDialogAbstract {
     async loadDropDrownData() {
         this.filterValue.value1 = null;
         this.filterValue.value2 = null;
+/* SDA CUSTOM*/ this.dropDownFields = [];
         if (this.filter.switch) {
             const column = _.cloneDeep(this.selectedColumn);
             column.table_id = column.table_id.split('.')[0];

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/filter-dialog/filter-dialog.component.ts
@@ -311,6 +311,7 @@ export class FilterDialogComponent extends EdaDialogAbstract {
     async loadDropDrownData() {
         this.filterValue.value1 = null;
         this.filterValue.value2 = null;
+/* SDA CUSTOM*/ this.dropDownFields = [];
         if (this.filter.switch) {
             const column = _.cloneDeep(this.selectedColumn);
             column.table_id = column.table_id.split('.')[0];


### PR DESCRIPTION
## Descripción del Cambio
Se limpia el array de los valores posibles en los filtos  con cada ejecución para que no se duplique 

## Issue(s) resuelto(s)

- solves #261

## Pruebas a realizar para validar el cambio
Las descritas en el issue:
1. Seleccionar un filtro.
2. Seleccionar un tipo de filtro  y filtrar.
3. Seleccionar otro tipo de filtro con valores posibles y comprobar que no se duplica.

