### PR TITLE
Hotfix - APP - No se conserva el orden en rangos numéricos

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-table/eda-columns/eda-column.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-columns/eda-column.ts
@@ -17,7 +17,7 @@ export abstract class EdaColumn {
     rowspan: number = 4;
     rowTotal : boolean = false;
     visible : boolean = true;
-    rangeOption : boolean;
+/* SDA CUSTOM */    rangeOption : boolean;
     click : (row:any) => void  = () => {};
 
     cellStyle: (value: any, row: any) => any = () => {};

--- a/eda/eda_app/src/app/module/components/eda-table/eda-columns/eda-column.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-columns/eda-column.ts
@@ -17,6 +17,7 @@ export abstract class EdaColumn {
     rowspan: number = 4;
     rowTotal : boolean = false;
     visible : boolean = true;
+    rangeOption : boolean;
     click : (row:any) => void  = () => {};
 
     cellStyle: (value: any, row: any) => any = () => {};

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.component.ts
@@ -34,8 +34,8 @@ export class EdaTableComponent implements OnInit {
         this.chartOptions = EdaColumnChartOptions;
     }
     ngOnInit(): void {
-        
-        
+
+
         if(this.inject.styles && !this.inject.pivot){
             this.applyStyles(this.inject.styles)
         }else if(this.inject.styles && this.inject.pivot){
@@ -57,9 +57,9 @@ export class EdaTableComponent implements OnInit {
         if (this.inject.linkedDashboardProps && this.inject.linkedDashboardProps.sourceCol === colname) {
             const props = this.inject.linkedDashboardProps;
             const url = window.location.href.substr(0, window.location.href.indexOf('/dashboard')) + `/dashboard/${props.dashboardID}?${props.table}.${props.col}=${item}`;
-            
+
             window.open(url, "_blank");
-            
+
         } else {
             let filterBy = colname;
             let label = item;
@@ -320,12 +320,12 @@ export class EdaTableComponent implements OnInit {
                     valor = negativos[0];
                     str = `<span> <span style = "color: red">${valor}</span> <span> - </span> <span>${positivos[0]}</span> </span>`;
                 }
-            } 
+            }
             else {
                 str = `<span> <span style = "color: red">${negativos[0]}</span> <span> - </span> <span style = "color: red">${negativos[1]}</span> </span>`;
             }
         }
-        
+
         return this.sanitizer.bypassSecurityTrustHtml(str);
 
     }
@@ -333,7 +333,7 @@ export class EdaTableComponent implements OnInit {
     extractNumberRange(input) {
         const regex = /(?:<|<=|>|>=)?\s*(-?\d+)\s*(?:-|<|<=|>|>=)?\s*(-?\d+)?/;
         const match = input.trim().match(regex);
-        
+
         if (match) {
           // Determina qué número extraer en base al formato del string
           if (input.includes('<') || input.includes('>')) {
@@ -345,11 +345,11 @@ export class EdaTableComponent implements OnInit {
         return null; // Si no hay coincidencia
     }
 
-    customSort(event: any, cols: any) {
-        
+/* SDA CUSTOM */ customSort(event: any, cols: any) {
+
         const actualField = event.field;
         const actualCol = cols.find(col => col.field === actualField)
-        
+
         event.data.sort((data1, data2) => {
             let value1 = data1[event.field];
             let value2 = data2[event.field];
@@ -378,14 +378,14 @@ export class EdaTableComponent implements OnInit {
             return (event.order * result);
         });
 
-        // maintains the order of the crosstable
-        this.inject.sortedColumn = { field: event.field, order: event.order };
+/* SDA CUSTOM */ // maintains the order of the crosstable
+/* SDA CUSTOM */ this.inject.sortedColumn = { field: event.field, order: event.order };
     }
 
-    public getColor(valor: number) { 
-        // modify true with a variable that is modified when editing negative values. 
+    public getColor(valor: number) {
+        // modify true with a variable that is modified when editing negative values.
         if(valor<0 && this.inject.negativeNumbers) {
-            return '#FF0000' 
+            return '#FF0000'
         }
     }
 

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.component.ts
@@ -345,7 +345,7 @@ export class EdaTableComponent implements OnInit {
         return null; // Si no hay coincidencia
     }
 
-    customSort(event, cols) {
+    customSort(event: any, cols: any) {
         
         const actualField = event.field;
         const actualCol = cols.find(col => col.field === actualField)
@@ -377,11 +377,13 @@ export class EdaTableComponent implements OnInit {
 
             return (event.order * result);
         });
+
+        // maintains the order of the crosstable
+        this.inject.sortedColumn = { field: event.field, order: event.order };
     }
+
     public getColor(valor: number) { 
-
-        // modificar el true por una variable que se modifica en la edición de valores negativos. 
-
+        // modify true with a variable that is modified when editing negative values. 
         if(valor<0 && this.inject.negativeNumbers) {
             return '#FF0000' 
         }

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
@@ -73,8 +73,8 @@ export class EdaTable {
     public resultAsPecentage: boolean = false;
     public onlyPercentages: boolean = false;
     public percentageColumns: Array<any> = [];
-    public noRepetitions: boolean; 
-    public negativeNumbers: boolean; 
+    public noRepetitions: boolean;
+    public negativeNumbers: boolean;
     public origValues: any[] = [];
 
 
@@ -103,7 +103,7 @@ export class EdaTable {
     set value(values: any[]) {
         if( this.origValues.length == 0 ){
             this.origValues = _.cloneDeep(values);
-        } 
+        }
         this.clear();
         this._value = values;
         /* Inicialitzar filtres */
@@ -234,7 +234,7 @@ export class EdaTable {
         }
         if (this.withColSubTotals) {
             event ? this.colSubTotals(event.first / event.rows + 1) : this.colSubTotals(1);
-        } 
+        }
         if (!this.pivot) {
             this.noRepeatedRows();
         }
@@ -338,7 +338,7 @@ export class EdaTable {
                 valuesKeys.forEach(key => {
                     totals[key] = 0;
                     row[key] = 0;
-                });                
+                });
 
                 numericCols.forEach(key => {
                     valuesKeys.forEach(valueKey => {
@@ -482,7 +482,7 @@ export class EdaTable {
 /**SDA CUSTOM  */   const value: number = Number(partialRow[baseField]); // Actual row value
 /**SDA CUSTOM  */   const total: number = Object.keys(partialRow)// Get total row value
 /**SDA CUSTOM  */       .filter(key => !key.endsWith('%') && key.includes('~')) // N fields always contains ~ and ends with %
-/**SDA CUSTOM  */       .reduce((sum, key) => sum + Number(partialRow[key] || 0), 0); 
+/**SDA CUSTOM  */       .reduce((sum, key) => sum + Number(partialRow[key] || 0), 0);
 /**SDA CUSTOM  */
 /**SDA CUSTOM  */   // Calculate percentage (check if total is not zero to avoid division by zero ==> Infinity or NaN)
 /**SDA CUSTOM  */   const percentage = (!Number.isNaN(value) && !Number.isNaN(total) && total !== 0) ? ((value / total) * 100).toFixed(2) : '0';
@@ -560,12 +560,12 @@ export class EdaTable {
 /**SDA CUSTOM  */   //  To match we need to delete the % and add one or two space at the beginning
 /**SDA CUSTOM  */   // If the field starts with ~( no field name ) we add two spaces otherwise just one
 /**SDA CUSTOM  */   const baseField = (col.field.trimStart().startsWith('~') ? '  ' : ' ') + col.field.replace('%', '').trim();
-/**SDA CUSTOM  */                    
+/**SDA CUSTOM  */
 /**SDA CUSTOM  */   const value: number = Number(row[baseField]); // Actual row value
 /**SDA CUSTOM  */   const total: number = Object.keys(row)// Get total row value
 /**SDA CUSTOM  */       .filter(key => !key.endsWith('%') && key.includes('~')) // N fields always contains ~ and ends with %
-/**SDA CUSTOM  */       .reduce((sum, key) => sum + Number(row[key] || 0), 0); 
-/**SDA CUSTOM  */                    
+/**SDA CUSTOM  */       .reduce((sum, key) => sum + Number(row[key] || 0), 0);
+/**SDA CUSTOM  */
 /**SDA CUSTOM  */   // Calculate percentage (check if total is not zero to avoid division by zero ==> Infinity or NaN)
 /**SDA CUSTOM  */   const percentage = (!Number.isNaN(value) && !Number.isNaN(total) && total !== 0) ? ((value / total) * 100).toFixed(2) : '0';
 /**SDA CUSTOM  */
@@ -597,7 +597,7 @@ export class EdaTable {
 
         for (let i = offset; i < lastValue; i++) {
             for (let j = 0; j < keys.length; j++) {
-                const currentCol = this.cols.filter(col => col.field === keys[j])[0];                
+                const currentCol = this.cols.filter(col => col.field === keys[j])[0];
                 if (i < values.length) {
                     if (currentCol.type === "EdaColumnNumber") {
                         if(values[i][keys[j]] === '') {
@@ -643,9 +643,9 @@ export class EdaTable {
         //Es una secuencia similar a la de quitar los valores, pero opuesta.
         if (!this.noRepetitions &&  !this.resultAsPecentage && !this.onlyPercentages) {
             // si no he tocado nada, dejo el valor origintal
-            if (this.noRepetitions !== undefined) { 
-                // securityTable check 
-                this.value = _.cloneDeep(this.origValues); 
+            if (this.noRepetitions !== undefined) {
+                // securityTable check
+                this.value = _.cloneDeep(this.origValues);
             }
         }  else if (!this.noRepetitions && ( this.resultAsPecentage || this.onlyPercentages)) {
             // si  quiero repetidos pero tengo porcentajes....
@@ -655,7 +655,7 @@ export class EdaTable {
         let labels = this.extractLabels(this.value)
         labels.shift(); //borramos el primer objeto.
         let output = [];
-        // ESTO SE HACE PARA EVITAR REPETIDOS EN LA TABLA. SI UN CAMPO TIENE UNA COLUMNA QUE SE REPITE 
+        // ESTO SE HACE PARA EVITAR REPETIDOS EN LA TABLA. SI UN CAMPO TIENE UNA COLUMNA QUE SE REPITE
 
         for (let i = 0; i < values.length; i += 1) {
             const obj = [];
@@ -666,9 +666,9 @@ export class EdaTable {
                         obj[labels[e]] = values[i][e];
                     }
             }
-            output.push(obj);   
+            output.push(obj);
             }
-        this.value = output;  
+        this.value = output;
 
         }else {
             //separamos valores de claves
@@ -760,7 +760,7 @@ export class EdaTable {
 
             const numericColumns = Array.from(new Set(this.series[this.series.length - 1].labels
                 .map(serie => serie.title))).length;
-            
+
             this.series.forEach((serie, i) => {
                 serie.labels.forEach((column, j) => {
                     if (column.isTotal) {
@@ -775,7 +775,7 @@ export class EdaTable {
 
                 });
             })
-            
+
         }
         if (this.onlyPercentages === true) {
             this.cols.forEach(col => {
@@ -786,7 +786,7 @@ export class EdaTable {
         }
     }
 
-    removePercentages() {        
+    removePercentages() {
         const cols = [];
         const hidenColumns = this.cols.filter(col => col.visible === false).length > 0;
         //remove labels
@@ -831,7 +831,7 @@ export class EdaTable {
 
 
     public onSort($event) {
-        if (this.cols.find(col => col.field === $event.field).sortable) {            
+        if (this.cols.find(col => col.field === $event.field).sortable) {
             this.sortedColumn = $event;
             this.onSortColEvent.emit($event);
             this.checkTotals(null);
@@ -969,16 +969,16 @@ export class EdaTable {
 
         const tableColumns = [];
         params.mainCols.forEach(element => {
-            tableColumns.push(new EdaColumnText({ header: element['header'], field: element['field'], rangeOption: element['rangeOption'] }))
+        /* SDA CUSTOM */ tableColumns.push(new EdaColumnText({ header: element['header'], field: element['field'], rangeOption: element['rangeOption'] }))
         })
         newColNames.forEach(col => {
             tableColumns.push(new EdaColumnNumber({ header: col, field: col }));
         })
-        
+
         let newLabels = { mainsLabels: [], seriesLabels: [], metricsLabels: [] };
         newLabels.mainsLabels = params.mainColsLabels;
         newLabels.seriesLabels = params.newCols.splice(params.mainColsLabels.length);
-        
+
         return { cols: tableColumns, rows: newRows, newLabels: newLabels }
 
     }
@@ -1310,7 +1310,7 @@ export class EdaTable {
      * Generates params to build crosstable
      */
     generatePivotParams(): PivotTableSerieParams {
-        //get old rows to build new ones 
+        //get old rows to build new ones
         const oldRows = this.getValues();
         //get index for numeric and text/date columns
         const typesIndex = this.getColsInfo();

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
@@ -969,7 +969,7 @@ export class EdaTable {
 
         const tableColumns = [];
         params.mainCols.forEach(element => {
-            tableColumns.push(new EdaColumnText({ header: element['header'], field: element['field'] }))
+            tableColumns.push(new EdaColumnText({ header: element['header'], field: element['field'], rangeOption: element['rangeOption'] }))
         })
         newColNames.forEach(col => {
             tableColumns.push(new EdaColumnNumber({ header: col, field: col }));


### PR DESCRIPTION
## Descripción del Cambio
Se cambia la forma en la que se hace la ordenación de las columnas para que se tenga en cuenta el caso de las columnas con rangos.

## Issue(s) resuelto(s)

- solves #362

## Pruebas a realizar para validar el cambio
Hacer una tabla y ordenarla por la columna de rangos.
Hacer una tabla cruzada y ordenarla por la coluna de rangos.

 

## Información Adicional
Si la consulta no está ordenada por la columna de los rangos puede que el resultado no salga ordenado. Pero es el comportamiento "normal". Si se indica que se quiere la consulta ordenada. Se ordena correctamente.

