### PR TITLE
Hotfix - Informes - Subtotales de porcentaje muestran 0% en tablas

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.component.ts
@@ -380,6 +380,7 @@ export class EdaTableComponent implements OnInit {
 
 /* SDA CUSTOM */ // maintains the order of the crosstable
 /* SDA CUSTOM */ this.inject.sortedColumn = { field: event.field, order: event.order };
+/* SDA CUSTOM */ this.inject.checkTotals(null);
     }
 
     public getColor(valor: number) {

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
@@ -483,7 +483,7 @@ export class EdaTable {
                             return sum + (isNaN(val) ? 0 : val);
                         }, 0);
                         this.partialTotalsRow.push({
-/**SDA CUSTOM  */         data: Math.min(100, percentageSum).toFixed(2) + '%', border: ' ', class: 'total-row-header text-right', type: col.type  /**  wen we summarize we can sumarize numbers with decimals and with more than 2. in this cas it will be over 100 */
+/**SDA CUSTOM  */         data: Math.min(100, percentageSum).toFixed(2) + '%', border: ' ', class: 'total-row-header text-right', type: col.type  /* when summarizing, results are capped at 100% */
                         });
 /**SDA CUSTOM  */   } else if (!this.pivot) {
 /**SDA CUSTOM  */   // Non-pivot non-percentage column (text, date, etc.) → leave blank

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
@@ -485,6 +485,9 @@ export class EdaTable {
                         this.partialTotalsRow.push({
 /**SDA CUSTOM  */         data: Math.min(100, percentageSum).toFixed(2) + '%', border: ' ', class: 'total-row-header text-right', type: col.type
                         });
+/**SDA CUSTOM  */   } else if (!this.pivot) {
+/**SDA CUSTOM  */   // Non-pivot non-percentage column (text, date, etc.) → leave blank
+/**SDA CUSTOM  */   this.partialTotalsRow.push({ data: '', border: ' ', class: 'sub-total-row-header', type: col.type });
                     } else {
 /**SDA CUSTOM  */   //  To match we need to delete the % and add one or two space at the beginning
 /**SDA CUSTOM  */   // If the field starts with ~ ( no field name ) we add two spaces otherwise just one
@@ -578,6 +581,9 @@ export class EdaTable {
                         this.totalsRow.push({
 /**SDA CUSTOM  */         data: Math.min(100, percentageSum).toFixed(2) + '%', border: ' ', class: 'total-row-header text-right', type: col.type
                         });
+/**SDA CUSTOM  */   } else if (!this.pivot) {
+/**SDA CUSTOM  */   // Non-pivot non-percentage column (text, date, etc.) → leave blank
+/**SDA CUSTOM  */   this.totalsRow.push({ data: '', border: ' ', class: 'total-row-header', type: col.type });
                     } else {
 /**SDA CUSTOM  */   //  To match we need to delete the % and add one or two space at the beginning
 /**SDA CUSTOM  */   // If the field starts with ~( no field name ) we add two spaces otherwise just one

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
@@ -468,25 +468,41 @@ export class EdaTable {
                         border: '',
                         type: col.type
                     });
-            } else if(col.type === "EdaColumnPercentage") { // Subtotal of the percentages
-
-                const value = Math.round(parseFloat(partialRow[col.field]));
-
-                this.partialTotalsRow.push(
-                    {
-                        data: !isNaN(value) ? `${value.toLocaleString('de-DE')}%` : "0%",
-                        style: "right",
-                        class: "sub-total-row",
-                        border: '',
-                        type: col.type
-                    });
             }
             else {
                 if (firstNonNumericRow) {
                     this.partialTotalsRow.push({ data: `${this.SubTotals} `, border: " ", class: 'sub-total-row-header', type: col.type });
                     firstNonNumericRow = false;
                 } else {
-                    this.partialTotalsRow.push({ data: " ", border: " ", class: 'sub-total-row', type: col.type });
+/**SDA CUSTOM  */   // WE ADD THE PERCENTAGE COLUMNS HERE
+                    if (!this.pivot && col.type === 'EdaColumnPercentage') {
+/**SDA CUSTOM  */       // For non-pivot tables: sum visible rows' percentage values
+                        const lastValue = Math.min(offset + this.initRows, this._value.length);
+                        const percentageSum = this._value.slice(offset, lastValue).reduce((sum, row) => {
+                            const val = parseFloat(String(row[col.field]).replace('%', ''));
+                            return sum + (isNaN(val) ? 0 : val);
+                        }, 0);
+                        this.partialTotalsRow.push({
+                            data: percentageSum.toFixed(2) + '%', border: ' ', class: 'total-row-header text-right', type: col.type
+                        });
+                    } else {
+/**SDA CUSTOM  */   //  To match we need to delete the % and add one or two space at the beginning
+/**SDA CUSTOM  */   // If the field starts with ~ ( no field name ) we add two spaces otherwise just one
+/**SDA CUSTOM  */   const baseField = (col.field.trimStart().startsWith('~') ? '  ' : ' ') + col.field.replace('%', '').trim();
+/**SDA CUSTOM  */
+/**SDA CUSTOM  */   const value: number = Number(partialRow[baseField]); // Actual row value
+/**SDA CUSTOM  */   const total: number = Object.keys(partialRow)// Get total row value
+/**SDA CUSTOM  */       .filter(key => !key.endsWith('%') && key.includes('~')) // N fields always contains ~ and ends with %
+/**SDA CUSTOM  */       .reduce((sum, key) => sum + Number(partialRow[key] || 0), 0);
+/**SDA CUSTOM  */
+/**SDA CUSTOM  */   // Calculate percentage (check if total is not zero to avoid division by zero ==> Infinity or NaN)
+/**SDA CUSTOM  */   const percentage = (!Number.isNaN(value) && !Number.isNaN(total) && total !== 0) ? ((value / total) * 100).toFixed(2) : '0';
+/**SDA CUSTOM  */
+/**SDA CUSTOM  */   // Push the total row value with % sign
+/**SDA CUSTOM  */   this.partialTotalsRow.push({
+/**SDA CUSTOM  */       data: percentage + '%', border: ' ', class: 'total-row-header text-right', type: col.type
+/**SDA CUSTOM  */   });
+                    }
                 }
             }
         });
@@ -553,19 +569,25 @@ export class EdaTable {
                     firstNonNumericRow = false;
                 } else {
 /**SDA CUSTOM  */   //  WE ADD THE PERCENTAGE COLUMNS HERE
+                    if (!this.pivot && col.type === 'EdaColumnPercentage') {
+/**SDA CUSTOM  */       // For non-pivot tables: sum all rows' percentage values
+                        const percentageSum = this._value.reduce((sum, dataRow) => {
+                            const val = parseFloat(String(dataRow[col.field]).replace('%', ''));
+                            return sum + (isNaN(val) ? 0 : val);
+                        }, 0);
+                        this.totalsRow.push({
+                            data: percentageSum.toFixed(2) + '%', border: ' ', class: 'total-row-header text-right', type: col.type
+                        });
+                    } else {
 /**SDA CUSTOM  */   //  To match we need to delete the % and add one or two space at the beginning
 /**SDA CUSTOM  */   // If the field starts with ~( no field name ) we add two spaces otherwise just one
-/**SDA CUSTOM  */   const baseField = this.pivot
-/**SDA CUSTOM  */       ? (col.field.trimStart().startsWith('~') ? '  ' : ' ') + col.field.replace('%', '').trim() // pivot fields have leading spaces
-/**SDA CUSTOM  */       : col.field.replace('%', '').trim(); // non-pivot fields have no leading spaces
-/**SDA CUSTOM  */                    
+/**SDA CUSTOM  */   const baseField = (col.field.trimStart().startsWith('~') ? '  ' : ' ') + col.field.replace('%', '').trim();
+/**SDA CUSTOM  */
 /**SDA CUSTOM  */   const value: number = Number(row[baseField]); // Actual row value
 /**SDA CUSTOM  */   const total: number = Object.keys(row)// Get total row value
-/**SDA CUSTOM  */       .filter(key => this.pivot
-/**SDA CUSTOM  */           ? (!key.endsWith('%') && key.includes('~'))  // pivot: numeric fields contain ~
-/**SDA CUSTOM  */           : (!key.endsWith('%') && this.cols.some(c => c.field === key && c.type === 'EdaColumnNumber'))) // non-pivot: EdaColumnNumber cols
+/**SDA CUSTOM  */       .filter(key => !key.endsWith('%') && key.includes('~')) // N fields always contains ~ and ends with %
 /**SDA CUSTOM  */       .reduce((sum, key) => sum + Number(row[key] || 0), 0);
-/**SDA CUSTOM  */                    
+/**SDA CUSTOM  */
 /**SDA CUSTOM  */   // Calculate percentage (check if total is not zero to avoid division by zero ==> Infinity or NaN)
 /**SDA CUSTOM  */   const percentage = (!Number.isNaN(value) && !Number.isNaN(total) && total !== 0) ? ((value / total) * 100).toFixed(2) : '0';
 /**SDA CUSTOM  */
@@ -573,6 +595,7 @@ export class EdaTable {
 /**SDA CUSTOM  */   this.totalsRow.push({
 /**SDA CUSTOM  */       data: percentage + '%', border: ' ', class: 'total-row-header text-right', type: col.type
 /**SDA CUSTOM  */   });
+                    }
 /**SDA CUSTOM  */}
             }
         });
@@ -602,16 +625,9 @@ export class EdaTable {
                     if (currentCol.type === "EdaColumnNumber") {
                         if(values[i][keys[j]] === '') {
                             row[keys[j]] = row[keys[j]] + 0;
-                        } 
+                        }
                         else {
                             row[keys[j]] = row[keys[j]] + parseFloat(values[i][keys[j]]);
-                        }
-                    } else if(currentCol.type === "EdaColumnPercentage") {
-                        if(values[i][keys[j]] === '') {
-                            row[keys[j]] = row[keys[j]] + 0;
-                        } 
-                        else {
-                            row[keys[j]] =  row[keys[j]] + parseFloat(values[i][keys[j]]);
                         }
                     }
                 }
@@ -656,21 +672,26 @@ export class EdaTable {
             }
         }  else if (!this.noRepetitions && ( this.resultAsPecentage || this.onlyPercentages)) {
             // si  quiero repetidos pero tengo porcentajes....
-            // Se usa acceso por nombre de campo para evitar desalineamiento posicional
-            // entre _value (porcentajes al final) y this.cols (porcentajes intercalados).
-            let output = [];
-            for (let i = 0; i < this._value.length; i += 1) {
-                const obj: any = {};
-                this.cols.forEach(col => {
-                    if (!['EdaColumnPercentage', 'EdaColumnNumber'].includes(col.type)) {
-                        obj[col.field] = this.origValues[i] ? this.origValues[i][col.field] : this._value[i][col.field];
-                    } else {
-                        obj[col.field] = this._value[i][col.field];
+        //separamos valores de claves
+        let values = this.extractDataValues(this.value);
+        //tomamos claves que serán el cabecero
+        let labels = this.extractLabels(this.value)
+        labels.shift(); //borramos el primer objeto.
+        let output = [];
+        // ESTO SE HACE PARA EVITAR REPETIDOS EN LA TABLA. SI UN CAMPO TIENE UNA COLUMNA QUE SE REPITE
+
+        for (let i = 0; i < values.length; i += 1) {
+            const obj = [];
+            for (let e = 0; e < values[i].length; e += 1) {
+                    if( ! ['EdaColumnPercentage', 'EdaColumnNumber'].includes(  this.cols[e].type ) ) {
+                        obj[labels[e]] =  this.origValues[i][labels[e]];
+                    }else{
+                        obj[labels[e]] = values[i][e];
                     }
-                });
-                output.push(obj);
             }
-            this.value = output;
+            output.push(obj);
+            }
+        this.value = output;
 
         }else {
             //separamos valores de claves

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
@@ -470,7 +470,7 @@ export class EdaTable {
                     });
             }
             else {
-                if (firstNonNumericRow) {
+/**SDA CUSTOM  */if (firstNonNumericRow && col.type !== 'EdaColumnPercentage') {
                     this.partialTotalsRow.push({ data: `${this.SubTotals} `, border: " ", class: 'sub-total-row-header', type: col.type });
                     firstNonNumericRow = false;
                 } else {
@@ -483,7 +483,7 @@ export class EdaTable {
                             return sum + (isNaN(val) ? 0 : val);
                         }, 0);
                         this.partialTotalsRow.push({
-                            data: percentageSum.toFixed(2) + '%', border: ' ', class: 'total-row-header text-right', type: col.type
+/**SDA CUSTOM  */         data: Math.min(100, percentageSum).toFixed(2) + '%', border: ' ', class: 'total-row-header text-right', type: col.type
                         });
                     } else {
 /**SDA CUSTOM  */   //  To match we need to delete the % and add one or two space at the beginning
@@ -563,7 +563,7 @@ export class EdaTable {
                     });
             }
             else {
-                if (firstNonNumericRow) {
+/**SDA CUSTOM  */if (firstNonNumericRow && col.type !== 'EdaColumnPercentage') {
 /**SDA CUSTOM  */   // add header
                     this.totalsRow.push({ data: `${this.Totals} `, border: " ", class: 'total-row-header', type: col.type });
                     firstNonNumericRow = false;
@@ -576,7 +576,7 @@ export class EdaTable {
                             return sum + (isNaN(val) ? 0 : val);
                         }, 0);
                         this.totalsRow.push({
-                            data: percentageSum.toFixed(2) + '%', border: ' ', class: 'total-row-header text-right', type: col.type
+/**SDA CUSTOM  */         data: Math.min(100, percentageSum).toFixed(2) + '%', border: ' ', class: 'total-row-header text-right', type: col.type
                         });
                     } else {
 /**SDA CUSTOM  */   //  To match we need to delete the % and add one or two space at the beginning
@@ -683,7 +683,8 @@ export class EdaTable {
         for (let i = 0; i < values.length; i += 1) {
             const obj = [];
             for (let e = 0; e < values[i].length; e += 1) {
-                    if( ! ['EdaColumnPercentage', 'EdaColumnNumber'].includes(  this.cols[e].type ) ) {
+/**SDA CUSTOM  */   const colType = (this.cols.find(c => c.field === labels[e]) || {}).type;
+/**SDA CUSTOM  */   if( ! ['EdaColumnPercentage', 'EdaColumnNumber'].includes( colType ) ) {
                         obj[labels[e]] =  this.origValues[i][labels[e]];
                     }else{
                         obj[labels[e]] = values[i][e];

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
@@ -468,43 +468,38 @@ export class EdaTable {
                         border: '',
                         type: col.type
                     });
+            } else if(col.type === "EdaColumnPercentage") { // Subtotal of the percentages
+
+                const value = parseFloat(partialRow[col.field]);
+
+                this.partialTotalsRow.push(
+                    {
+                        data: !isNaN(value) ? `${value.toLocaleString('de-DE')}%` : "0%",
+                        style: "right",
+                        class: "sub-total-row",
+                        border: '',
+                        type: col.type
+                    });
             }
             else {
                 if (firstNonNumericRow) {
                     this.partialTotalsRow.push({ data: `${this.SubTotals} `, border: " ", class: 'sub-total-row-header', type: col.type });
                     firstNonNumericRow = false;
                 } else {
-/**SDA CUSTOM  */   // WE ADD THE PERCENTAGE COLUMNS HERE
-/**SDA CUSTOM  */   //  To match we need to delete the % and add one or two space at the beginning
-/**SDA CUSTOM  */   // If the field starts with ~( no field name ) we add two spaces otherwise just one
-/**SDA CUSTOM  */   const baseField = (col.field.trimStart().startsWith('~') ? '  ' : ' ') + col.field.replace('%', '').trim();
-/**SDA CUSTOM  */
-/**SDA CUSTOM  */   const value: number = Number(partialRow[baseField]); // Actual row value
-/**SDA CUSTOM  */   const total: number = Object.keys(partialRow)// Get total row value
-/**SDA CUSTOM  */       .filter(key => !key.endsWith('%') && key.includes('~')) // N fields always contains ~ and ends with %
-/**SDA CUSTOM  */       .reduce((sum, key) => sum + Number(partialRow[key] || 0), 0); 
-/**SDA CUSTOM  */
-/**SDA CUSTOM  */   // Calculate percentage (check if total is not zero to avoid division by zero ==> Infinity or NaN)
-/**SDA CUSTOM  */   const percentage = (!Number.isNaN(value) && !Number.isNaN(total) && total !== 0) ? ((value / total) * 100).toFixed(2) : '0';
-/**SDA CUSTOM  */
-/**SDA CUSTOM  */   // Push the total row value with % sign
-/**SDA CUSTOM  */   this.partialTotalsRow.push({
-/**SDA CUSTOM  */       data: percentage + '%', border: ' ', class: 'total-row-header text-right', type: col.type
-/**SDA CUSTOM  */   });
+                    this.partialTotalsRow.push({ data: " ", border: " ", class: 'sub-total-row', type: col.type });
                 }
             }
         });
     }
 
     coltotals() {
+
         this.withColTotals = true;
         this.totalsRow = [];
-
 
         let row = this.buildTotalRow();
         const values = this._value;
         const keys = this.cols.map(col => col.field);
-
 
         for (let i = 0; i < values.length; i++) {
             for (let j = 0; j < keys.length; j++) {
@@ -530,6 +525,12 @@ export class EdaTable {
                             row[keys[j]] = row[keys[j]].toFixed(decimalplaces );
                         }
 
+                    } else if(currentCol.type === "EdaColumnPercentage") {
+                        let total = 0;
+                        values.forEach((e: any) => {
+                            total = total + parseFloat(e[currentCol.field].replace('%', ''));
+                        })
+                        row[keys[j]] = Math.round(total);
                     } else {
                         row[keys[j]] = NaN;
                     }
@@ -538,12 +539,24 @@ export class EdaTable {
         }
 
         let firstNonNumericRow = true;
+
         this.cols.forEach((col, i) => {
-            if (col.type === "EdaColumnNumber") {
+            if (col.type === "EdaColumnNumber") { 
                 this.totalsRow.push(
                     {
-                        data: parseFloat(row[col.field])
-                            .toLocaleString('de-DE'),
+                        data: parseFloat(row[col.field]).toLocaleString('de-DE'),
+                        style: "right",
+                        class: "total-row",
+                        border: '',
+                        type: col.type
+                    });
+            } else if(col.type === "EdaColumnPercentage") { // Total of the percentages
+
+                const value = parseFloat(row[col.field]);
+
+                this.totalsRow.push(
+                    {
+                        data: !isNaN(value) ? `${value.toLocaleString('de-DE')}%` : "0%",
                         style: "right",
                         class: "total-row",
                         border: '',
@@ -552,28 +565,11 @@ export class EdaTable {
             }
             else {
                 if (firstNonNumericRow) {
-/**SDA CUSTOM  */   // add header
                     this.totalsRow.push({ data: `${this.Totals} `, border: " ", class: 'total-row-header', type: col.type });
                     firstNonNumericRow = false;
                 } else {
-/**SDA CUSTOM  */   //  WE ADD THE PERCENTAGE COLUMNS HERE
-/**SDA CUSTOM  */   //  To match we need to delete the % and add one or two space at the beginning
-/**SDA CUSTOM  */   // If the field starts with ~( no field name ) we add two spaces otherwise just one
-/**SDA CUSTOM  */   const baseField = (col.field.trimStart().startsWith('~') ? '  ' : ' ') + col.field.replace('%', '').trim();
-/**SDA CUSTOM  */                    
-/**SDA CUSTOM  */   const value: number = Number(row[baseField]); // Actual row value
-/**SDA CUSTOM  */   const total: number = Object.keys(row)// Get total row value
-/**SDA CUSTOM  */       .filter(key => !key.endsWith('%') && key.includes('~')) // N fields always contains ~ and ends with %
-/**SDA CUSTOM  */       .reduce((sum, key) => sum + Number(row[key] || 0), 0); 
-/**SDA CUSTOM  */                    
-/**SDA CUSTOM  */   // Calculate percentage (check if total is not zero to avoid division by zero ==> Infinity or NaN)
-/**SDA CUSTOM  */   const percentage = (!Number.isNaN(value) && !Number.isNaN(total) && total !== 0) ? ((value / total) * 100).toFixed(2) : '0';
-/**SDA CUSTOM  */
-/**SDA CUSTOM  */   // Push the total row value with % sign
-/**SDA CUSTOM  */   this.totalsRow.push({
-/**SDA CUSTOM  */       data: percentage + '%', border: ' ', class: 'total-row-header text-right', type: col.type
-/**SDA CUSTOM  */   });
-/**SDA CUSTOM  */}
+                    this.totalsRow.push({ data: " ", border: " ", class: 'total-row', type: col.type });
+                }
             }
         });
     }
@@ -602,9 +598,16 @@ export class EdaTable {
                     if (currentCol.type === "EdaColumnNumber") {
                         if(values[i][keys[j]] === '') {
                             row[keys[j]] = row[keys[j]] + 0;
-                        }
+                        } 
                         else {
                             row[keys[j]] = row[keys[j]] + parseFloat(values[i][keys[j]]);
+                        }
+                    } else if(currentCol.type === "EdaColumnPercentage") {
+                        if(values[i][keys[j]] === '') {
+                            row[keys[j]] = row[keys[j]] + 0;
+                        } 
+                        else {
+                            row[keys[j]] =  row[keys[j]] + parseFloat(values[i][keys[j]]);
                         }
                     }
                 }

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
@@ -526,29 +526,36 @@ export class EdaTable {
                 if (i < values.length) {
                     const currentCol = this.cols.filter(col => col.field === keys[j])[0];
                     if (currentCol.type === "EdaColumnNumber") {
-
-                        let decimalplaces = 0;
-                        try{
-                            let c =  <EdaColumnNumber>currentCol;
-                            decimalplaces =  c.decimals;  /** esta mierda se hace  para ajustar el número de dicimales porque 3.1+2.5 puede dar 5.600004 */
-                        }catch(e){
-                            console.log('error getting decimal places');
-                            console.log(e);
-                        }
-
                         if(values[i][keys[j]]===''){
-                            row[keys[j]] = parseFloat(row[keys[j]] ) + 0;
-                            row[keys[j]] = row[keys[j]].toFixed(decimalplaces );
+                            row[keys[j]] = parseFloat(row[keys[j]]) + 0;
                         }
                         else {
-                            row[keys[j]] = parseFloat(row[keys[j]] ) + parseFloat(values[i][keys[j]]);
-                            row[keys[j]] = row[keys[j]].toFixed(decimalplaces );
+                            row[keys[j]] = parseFloat(row[keys[j]]) + parseFloat(values[i][keys[j]]);
                         }
-
                     } else {
                         row[keys[j]] = NaN;
                     }
                 }
+            }
+        }
+
+        // Apply rounding once after all rows are accumulated to avoid mid-sum rounding errors
+        for (let j = 0; j < keys.length; j++) {
+            const currentCol = this.cols.filter(col => col.field === keys[j])[0];
+            if (currentCol.type === "EdaColumnNumber") {
+                let decimalplaces: number = (currentCol as any).decimals;
+                // If decimals is not a valid positive integer, detect from actual data values
+                if (!Number.isInteger(decimalplaces) || decimalplaces <= 0) {
+                    decimalplaces = 0;
+                    for (let i = 0; i < values.length; i++) {
+                        const strVal = String(values[i][keys[j]]);
+                        const dotIndex = strVal.indexOf('.');
+                        if (dotIndex !== -1) {
+                            decimalplaces = Math.max(decimalplaces, strVal.length - dotIndex - 1);
+                        }
+                    }
+                }
+                row[keys[j]] = parseFloat(row[keys[j]]).toFixed(decimalplaces);
             }
         }
 

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
@@ -652,26 +652,21 @@ export class EdaTable {
             }
         }  else if (!this.noRepetitions && ( this.resultAsPecentage || this.onlyPercentages)) {
             // si  quiero repetidos pero tengo porcentajes....
-        //separamos valores de claves
-        let values = this.extractDataValues(this.value);
-        //tomamos claves que serán el cabecero
-        let labels = this.extractLabels(this.value)
-        labels.shift(); //borramos el primer objeto.
-        let output = [];
-        // ESTO SE HACE PARA EVITAR REPETIDOS EN LA TABLA. SI UN CAMPO TIENE UNA COLUMNA QUE SE REPITE 
-
-        for (let i = 0; i < values.length; i += 1) {
-            const obj = [];
-            for (let e = 0; e < values[i].length; e += 1) {
-                    if( ! ['EdaColumnPercentage', 'EdaColumnNumber'].includes(  this.cols[e].type ) ) {
-                        obj[labels[e]] =  this.origValues[i][labels[e]];
-                    }else{
-                        obj[labels[e]] = values[i][e];
+            // Se usa acceso por nombre de campo para evitar desalineamiento posicional
+            // entre _value (porcentajes al final) y this.cols (porcentajes intercalados).
+            let output = [];
+            for (let i = 0; i < this._value.length; i += 1) {
+                const obj: any = {};
+                this.cols.forEach(col => {
+                    if (!['EdaColumnPercentage', 'EdaColumnNumber'].includes(col.type)) {
+                        obj[col.field] = this.origValues[i] ? this.origValues[i][col.field] : this._value[i][col.field];
+                    } else {
+                        obj[col.field] = this._value[i][col.field];
                     }
+                });
+                output.push(obj);
             }
-            output.push(obj);   
-            }
-        this.value = output;  
+            this.value = output;
 
         }else {
             //separamos valores de claves

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
@@ -493,13 +493,14 @@ export class EdaTable {
     }
 
     coltotals() {
-
         this.withColTotals = true;
         this.totalsRow = [];
+
 
         let row = this.buildTotalRow();
         const values = this._value;
         const keys = this.cols.map(col => col.field);
+
 
         for (let i = 0; i < values.length; i++) {
             for (let j = 0; j < keys.length; j++) {
@@ -525,12 +526,6 @@ export class EdaTable {
                             row[keys[j]] = row[keys[j]].toFixed(decimalplaces );
                         }
 
-                    } else if(currentCol.type === "EdaColumnPercentage") {
-                        let total = 0;
-                        values.forEach((e: any) => {
-                            total = total + parseFloat(e[currentCol.field].replace('%', ''));
-                        })
-                        row[keys[j]] = Math.round(total);
                     } else {
                         row[keys[j]] = NaN;
                     }
@@ -539,24 +534,12 @@ export class EdaTable {
         }
 
         let firstNonNumericRow = true;
-
         this.cols.forEach((col, i) => {
-            if (col.type === "EdaColumnNumber") { 
+            if (col.type === "EdaColumnNumber") {
                 this.totalsRow.push(
                     {
-                        data: parseFloat(row[col.field]).toLocaleString('de-DE'),
-                        style: "right",
-                        class: "total-row",
-                        border: '',
-                        type: col.type
-                    });
-            } else if(col.type === "EdaColumnPercentage") { // Total of the percentages
-
-                const value = parseFloat(row[col.field]);
-
-                this.totalsRow.push(
-                    {
-                        data: !isNaN(value) ? `${value.toLocaleString('de-DE')}%` : "0%",
+                        data: parseFloat(row[col.field])
+                            .toLocaleString('de-DE'),
                         style: "right",
                         class: "total-row",
                         border: '',
@@ -565,11 +548,32 @@ export class EdaTable {
             }
             else {
                 if (firstNonNumericRow) {
+/**SDA CUSTOM  */   // add header
                     this.totalsRow.push({ data: `${this.Totals} `, border: " ", class: 'total-row-header', type: col.type });
                     firstNonNumericRow = false;
                 } else {
-                    this.totalsRow.push({ data: " ", border: " ", class: 'total-row', type: col.type });
-                }
+/**SDA CUSTOM  */   //  WE ADD THE PERCENTAGE COLUMNS HERE
+/**SDA CUSTOM  */   //  To match we need to delete the % and add one or two space at the beginning
+/**SDA CUSTOM  */   // If the field starts with ~( no field name ) we add two spaces otherwise just one
+/**SDA CUSTOM  */   const baseField = this.pivot
+/**SDA CUSTOM  */       ? (col.field.trimStart().startsWith('~') ? '  ' : ' ') + col.field.replace('%', '').trim() // pivot fields have leading spaces
+/**SDA CUSTOM  */       : col.field.replace('%', '').trim(); // non-pivot fields have no leading spaces
+/**SDA CUSTOM  */                    
+/**SDA CUSTOM  */   const value: number = Number(row[baseField]); // Actual row value
+/**SDA CUSTOM  */   const total: number = Object.keys(row)// Get total row value
+/**SDA CUSTOM  */       .filter(key => this.pivot
+/**SDA CUSTOM  */           ? (!key.endsWith('%') && key.includes('~'))  // pivot: numeric fields contain ~
+/**SDA CUSTOM  */           : (!key.endsWith('%') && this.cols.some(c => c.field === key && c.type === 'EdaColumnNumber'))) // non-pivot: EdaColumnNumber cols
+/**SDA CUSTOM  */       .reduce((sum, key) => sum + Number(row[key] || 0), 0);
+/**SDA CUSTOM  */                    
+/**SDA CUSTOM  */   // Calculate percentage (check if total is not zero to avoid division by zero ==> Infinity or NaN)
+/**SDA CUSTOM  */   const percentage = (!Number.isNaN(value) && !Number.isNaN(total) && total !== 0) ? ((value / total) * 100).toFixed(2) : '0';
+/**SDA CUSTOM  */
+/**SDA CUSTOM  */   // Push the total row value with % sign
+/**SDA CUSTOM  */   this.totalsRow.push({
+/**SDA CUSTOM  */       data: percentage + '%', border: ' ', class: 'total-row-header text-right', type: col.type
+/**SDA CUSTOM  */   });
+/**SDA CUSTOM  */}
             }
         });
     }

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
@@ -483,7 +483,7 @@ export class EdaTable {
                             return sum + (isNaN(val) ? 0 : val);
                         }, 0);
                         this.partialTotalsRow.push({
-/**SDA CUSTOM  */         data: Math.min(100, percentageSum).toFixed(2) + '%', border: ' ', class: 'total-row-header text-right', type: col.type
+/**SDA CUSTOM  */         data: Math.min(100, percentageSum).toFixed(2) + '%', border: ' ', class: 'total-row-header text-right', type: col.type  /**  wen we summarize we can sumarize numbers with decimals and with more than 2. in this cas it will be over 100 */
                         });
 /**SDA CUSTOM  */   } else if (!this.pivot) {
 /**SDA CUSTOM  */   // Non-pivot non-percentage column (text, date, etc.) → leave blank

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
@@ -470,7 +470,7 @@ export class EdaTable {
                     });
             } else if(col.type === "EdaColumnPercentage") { // Subtotal of the percentages
 
-                const value = parseFloat(partialRow[col.field]);
+                const value = Math.round(parseFloat(partialRow[col.field]));
 
                 this.partialTotalsRow.push(
                     {

--- a/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
+++ b/eda/eda_app/src/app/module/components/eda-table/eda-table.ts
@@ -476,7 +476,7 @@ export class EdaTable {
                 } else {
 /**SDA CUSTOM  */   // WE ADD THE PERCENTAGE COLUMNS HERE
                     if (!this.pivot && col.type === 'EdaColumnPercentage') {
-/**SDA CUSTOM  */       // For non-pivot tables: sum visible rows' percentage values
+/**SDA CUSTOM  */       // For non-pivot tables: sum the % values of the rows in this group
                         const lastValue = Math.min(offset + this.initRows, this._value.length);
                         const percentageSum = this._value.slice(offset, lastValue).reduce((sum, row) => {
                             const val = parseFloat(String(row[col.field]).replace('%', ''));
@@ -573,13 +573,9 @@ export class EdaTable {
                 } else {
 /**SDA CUSTOM  */   //  WE ADD THE PERCENTAGE COLUMNS HERE
                     if (!this.pivot && col.type === 'EdaColumnPercentage') {
-/**SDA CUSTOM  */       // For non-pivot tables: sum all rows' percentage values
-                        const percentageSum = this._value.reduce((sum, dataRow) => {
-                            const val = parseFloat(String(dataRow[col.field]).replace('%', ''));
-                            return sum + (isNaN(val) ? 0 : val);
-                        }, 0);
+/**SDA CUSTOM  */       // Total row always = 100% (grand total / grand total by definition, avoids rounding errors)
                         this.totalsRow.push({
-/**SDA CUSTOM  */         data: Math.min(100, percentageSum).toFixed(2) + '%', border: ' ', class: 'total-row-header text-right', type: col.type
+/**SDA CUSTOM  */         data: '100%', border: ' ', class: 'total-row-header text-right', type: col.type
                         });
 /**SDA CUSTOM  */   } else if (!this.pivot) {
 /**SDA CUSTOM  */   // Non-pivot non-percentage column (text, date, etc.) → leave blank


### PR DESCRIPTION
## Descripción del Cambio
Se cambia la forma en que se calculan los totales y los subtotales.

## Issue(s) resuelto(s)

- solves #422

## Pruebas a realizar para validar el cambio
Hacer una tabla y una tabla cruzada y comprobar que se muestra correctamente el total y el subtotal.

## Información Adicional
Resolviendo este issue se ha detectado que no se muestra el porcentaje en la tabla normal. Aunque esto es otro issue ya que ya existía previamente.

