### PR TITLE
Improvement - General - Agregar formato de fecha a los logs de PM2

### DIFF
--- a/eda/eda_api/package.json
+++ b/eda/eda_api/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "start": "nodemon",
         "start:forever": "npm run build && forever start -c node ./dist/server.js",
-        "start:pm2": "npm run build && pm2 start ./dist/server.js    ",
+        "start:pm2": "npm run build && pm2 start ./dist/server.js --log-date-format 'YYYY-MM-DD HH:mm:ss'",
         "edapi": "forever start -c node ./dist/server.js",
         "build": "tsc && npm run movejpgs",
         "dev": "ts-node ./lib/server.ts",


### PR DESCRIPTION
Asegurar que se incluye la marca de tiempo en los logs de PM2.
