### PR TITLE
Enhancement - Informes - Crear flag activo/inactivo para la gestión de informes en la página de inicio

### DIFF
--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -497,6 +497,14 @@ export class DashboardController {
           userGroupDashboards.length === 0 &&
           dashboard.user.toString() !== user
 
+        /* SDA CUSTOM*/// Check if dashboard is active. 
+        /* SDA CUSTOM*/// If inactive, only admins can access it.
+        /* SDA CUSTOM*/const isActive = dashboard.config.active !== false;
+        /* SDA CUSTOM*/const isAdmin = userRoles.includes('EDA_ADMIN') || req.user.role.includes("135792467811111111111110");
+        /* SDA CUSTOM*/if (!isActive && !isAdmin) {
+        /* SDA CUSTOM*/  console.log(`Dashboard ${req.params.id} is inactive and user is not admin`);
+        /* SDA CUSTOM*/  return next(new HttpException(403, "DashboardInactive"));
+        /* SDA CUSTOM*/}
         if (visibilityCheck && roleCheck) {
           console.log(
             "You don't have permission " +

--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -67,7 +67,8 @@ export class DashboardController {
   static async getPrivateDashboards(req: Request) {
     try {
       const dashboards = await Dashboard.find(
-        { user: req.user._id },
+        /* SDA CUSTOM - Only active dashboards for non-admins */
+        /* SDA CUSTOM */{ user: req.user._id, "config.active": true },
         /* SDA CUSTOM */ 'config.title config.visible config.tag config.onlyIcanEdit config.description config.createdAt config.modifiedAt config.ds config.active user'
       ).populate('user','name').exec()
       const privates = []
@@ -115,7 +116,8 @@ export class DashboardController {
         users: { $in: req.user._id }
       }).exec();
       const dashboards = await Dashboard.find(
-        { group: { $in: userGroups.map(g => g._id) } },
+        /* SDA CUSTOM - Only active dashboards for non-admins */
+        /* SDA CUSTOM */ { group: { $in: userGroups.map(g => g._id) }, "config.active": true },
         /* SDA CUSTOM */'config.title config.visible group config.tag config.onlyIcanEdit config.description config.createdAt config.ds config.active user'
       ).populate('user','name').exec()
       const groupDashboards = []
@@ -215,7 +217,8 @@ export class DashboardController {
   static async getPublicsDashboards(req: Request, dss: any[]) {
     try {
       const dashboards = await Dashboard.find(
-        {},
+        /* SDA CUSTOM - Only active dashboards for non-admins */
+        /* SDA CUSTOM */{ "config.active": true },
         /* SDA CUSTOM */'config.title config.visible config.tag config.onlyIcanEdit config.description config.createdAt config.modifiedAt config.ds config.active user'
       ).populate('user','name').exec()
       const publics = []
@@ -264,7 +267,8 @@ export class DashboardController {
   static async getSharedDashboards(req: Request) {
     try {
       const dashboards = await Dashboard.find(
-        {},
+        /* SDA CUSTOM - Only active dashboards for non-admins */
+        /* SDA CUSTOM */ { "config.active": true },
         /* SDA CUSTOM */ 'config.title config.visible config.tag config.onlyIcanEdit config.description config.createdAt config.modifiedAt config.ds config.active user'
       ).populate('user','name').exec()
       const shared = []

--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -68,7 +68,7 @@ export class DashboardController {
     try {
       const dashboards = await Dashboard.find(
         { user: req.user._id },
-        'config.title config.visible config.tag config.onlyIcanEdit config.description config.createdAt config.modifiedAt config.ds user'
+        /* SDA CUSTOM */ 'config.title config.visible config.tag config.onlyIcanEdit config.description config.createdAt config.modifiedAt config.ds config.active user'
       ).populate('user','name').exec()
       const privates = []
       for (const dashboard of dashboards) {
@@ -116,7 +116,7 @@ export class DashboardController {
       }).exec();
       const dashboards = await Dashboard.find(
         { group: { $in: userGroups.map(g => g._id) } },
-        'config.title config.visible group config.tag config.onlyIcanEdit config.description config.createdAt config.ds user'
+        /* SDA CUSTOM */'config.title config.visible group config.tag config.onlyIcanEdit config.description config.createdAt config.ds config.active user'
       ).populate('user','name').exec()
       const groupDashboards = []
       for (let i = 0, n = dashboards.length; i < n; i += 1) {
@@ -216,7 +216,7 @@ export class DashboardController {
     try {
       const dashboards = await Dashboard.find(
         {},
-        'config.title config.visible config.tag config.onlyIcanEdit config.description config.createdAt config.modifiedAt config.ds user'
+        /* SDA CUSTOM */'config.title config.visible config.tag config.onlyIcanEdit config.description config.createdAt config.modifiedAt config.ds config.active user'
       ).populate('user','name').exec()
       const publics = []
 
@@ -265,7 +265,7 @@ export class DashboardController {
     try {
       const dashboards = await Dashboard.find(
         {},
-        'config.title config.visible config.tag config.onlyIcanEdit config.description config.createdAt config.modifiedAt config.ds user'
+        /* SDA CUSTOM */ 'config.title config.visible config.tag config.onlyIcanEdit config.description config.createdAt config.modifiedAt config.ds config.active user'
       ).populate('user','name').exec()
       const shared = []
       for (const dashboard of dashboards) {
@@ -346,11 +346,17 @@ export class DashboardController {
         ]
       );
 
+      /* SDA CUSTOM */ // Initialize config.active to true if it doesn't exist
+      /* SDA CUSTOM */const activeUpdateResult = await Dashboard.updateMany(
+      /* SDA CUSTOM */  { 'config.active': { $exists: false } },
+      /* SDA CUSTOM */  { $set: { 'config.active': true } }
+      /* SDA CUSTOM */);
+
 
       //si no lleva filtro, pasamos directamente a recuperarlos todos
       const dashboards =  JSON.stringify(filter) !== '{}'  ? 
-      await Dashboard.find({ $or : Object.entries(filter).map(([clave, valor]) => ({ [clave]: valor }))},  'user config.title config.visible group config.tag config.onlyIcanEdit config.description config.createdAt config.modifiedAt config.ds config.external').exec() : 
-      await Dashboard.find({}, 'user config.title config.visible group config.tag config.onlyIcanEdit config.description config.createdAt config.modifiedAt config.ds config.external').exec();
+      /* SDA CUSTOM */ await Dashboard.find({ $or : Object.entries(filter).map(([clave, valor]) => ({ [clave]: valor }))},  'user config.title config.visible group config.tag config.onlyIcanEdit config.description config.createdAt config.modifiedAt config.ds config.external config.active').exec() : 
+      /* SDA CUSTOM */ await Dashboard.find({}, 'user config.title config.visible group config.tag config.onlyIcanEdit config.description config.createdAt config.modifiedAt config.ds config.external config.active').exec();
       
       const publics = []
       const privates = []

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -481,10 +481,13 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
 
                 },
                 err => {
-                    me.alertService.addError(err);
-                    if (err.text === "You don't have permission") {
+/* SDA CUSTOM*/                    if (err.text === "DashboardInactive") {
+/* SDA CUSTOM*/                        this.router.navigate(['/home']);
+/* SDA CUSTOM*/                    } else if (err.text === "You don't have permission") {
                         console.log("You don't have permission");
                         this.router.navigate(['/login']);
+/* SDA CUSTOM*/                    } else {
+/* SDA CUSTOM*/                        this.alertService.addError(err);
                     }
                 }
             );

--- a/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.html
+++ b/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.html
@@ -533,7 +533,7 @@
             [checked]="dashboard.active"
             (change)="toggleDashboardActive(dashboard)"
             [disabled]="!canIEdit(dashboard)"
-            [title]="dashboard.active ? 'Desactivar informe' : 'Activar informe'"
+            [title]="dashboard.active ? titleInactive : titleActive"
           />
         </td>
 
@@ -699,14 +699,15 @@
                 [title]="
                   canIEdit(dashboard)
                     ? dashboard.active
-                      ? 'Desactivar informe'
-                      : 'Activar informe'
+                      ? titleInactive
+                      : titleActive
                     : ''
                 "
               />
-              <small class="ml-1" style="vertical-align: middle">{{
-                dashboard.active ? "Activo" : "Inactivo"
-              }}</small>
+              <small class="ml-1" style="vertical-align: middle">
+                <ng-container *ngIf="dashboard.active" i18n="@@activeLabel">Activo</ng-container>
+                <ng-container *ngIf="!dashboard.active" i18n="@@inactiveLabel">Inactivo</ng-container>
+              </small>
             </div>
           </div>
           <div class="mt-auto">

--- a/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.html
+++ b/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.html
@@ -151,6 +151,53 @@
     </div>
   </div>
 
+  <!--Status filter visible only to admins with multiselect -->
+  <div *ngIf="isAdmin" class="ml-2" id="active-filter">
+    <div class="dropdown">
+      <button
+        class="btn btn-secondary dropdown-toggle"
+        type="button"
+        id="dropdownActiveButton"
+        data-toggle="dropdown"
+        aria-haspopup="true"
+        aria-expanded="false"
+      >
+        <i class="fa fa-filter"></i>&nbsp;<span i18n="@@status"> Estado </span>
+        <span *ngIf="selectedStatuses.length === 1" class="counter bg-warning pull-right">1</span>
+      </button>
+      <div class="dropdown-menu" aria-labelledby="dropdownActiveButton">
+        <div class="dropdown-item">
+          <div class="form-check">
+            <input
+              class="form-check-input"
+              type="checkbox"
+              id="activeFilterActive"
+              [checked]="isStatusSelected('active')"
+              (change)="toggleStatusSelection('active')"
+            />
+            <label class="form-check-label" for="activeFilterActive" i18n="@@active">
+              Activos
+            </label>
+          </div>
+        </div>
+        <div class="dropdown-item">
+          <div class="form-check">
+            <input
+              class="form-check-input"
+              type="checkbox"
+              id="activeFilterInactive"
+              [checked]="isStatusSelected('inactive')"
+              (change)="toggleStatusSelection('inactive')"
+            />
+            <label class="form-check-label" for="activeFilterInactive" i18n="@@inactive">
+              Inactivos
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Type filter -->
   <div id="type-filter" class="ml-2">
     <div class="dropdown">
@@ -229,9 +276,9 @@
   <div class="ml-2" id="clear-filters-button">
     <button
       class="btn"
-      [class.btn-warning]="selectedTags.length > 0 || selectedGroups.length > 0 || selectedTypes.length > 0 || searchTerm.length > 0"
-      [class.btn-secondary]="selectedTags.length === 0 && selectedGroups.length === 0 && selectedTypes.length === 0 && searchTerm.length === 0"
-      [disabled]="selectedTags.length === 0 && selectedGroups.length === 0 && selectedTypes.length === 0 && searchTerm.length === 0"
+      [class.btn-warning]="hasActiveFilters()"
+      [class.btn-secondary]="!hasActiveFilters()"
+      [disabled]="!hasActiveFilters()"
       (click)="clearAllFilters()"
       i18n-title="@@clearAllFilters"
       title="Eliminar todos los filtros"
@@ -359,6 +406,8 @@
           Fuente de datos
         </th>
 
+        <!--Status column visible only to admins -->
+        <th *ngIf="isAdmin" i18n="@@status" class="text-center">Estado</th>
         <th i18n="@@actions">Acciones</th>
       </tr>
     </thead>
@@ -475,6 +524,18 @@
           </p>
         </td>
         <td>{{ dashboard.config.ds.name }}</td>
+        <!-- Status cell visible only to admins -->
+        <td *ngIf="isAdmin" class="text-center">
+          <input
+            type="checkbox"
+            class="form-check-input"
+            style="position: relative; margin-left: 0"
+            [checked]="dashboard.active"
+            (change)="toggleDashboardActive(dashboard)"
+            [disabled]="!canIEdit(dashboard)"
+            [title]="dashboard.active ? 'Desactivar informe' : 'Activar informe'"
+          />
+        </td>
 
         <td>
           <div class="btn-group">
@@ -618,9 +679,36 @@
             </span>
           </p>
 
-          <p class="card-text">
-            <span *ngIf="dashboard.config.tag" class="tag-label">{{ dashboard.config.tag }}</span>
-          </p>
+          <div class="card-text">
+            <span *ngIf="dashboard.config.tag" class="tag-label">{{
+              dashboard.config.tag
+            }}</span>
+            <!--Status toggle visible only to admins -->
+            <div *ngIf="isAdmin" class="pull-right">
+              <input
+                type="checkbox"
+                class="form-check-input"
+                style="
+                  position: relative;
+                  margin-left: 0;
+                  vertical-align: middle;
+                "
+                [checked]="dashboard.active"
+                (change)="toggleDashboardActive(dashboard)"
+                [disabled]="!canIEdit(dashboard)"
+                [title]="
+                  canIEdit(dashboard)
+                    ? dashboard.active
+                      ? 'Desactivar informe'
+                      : 'Activar informe'
+                    : ''
+                "
+              />
+              <small class="ml-1" style="vertical-align: middle">{{
+                dashboard.active ? "Activo" : "Inactivo"
+              }}</small>
+            </div>
+          </div>
           <div class="mt-auto">
             <button
               class="btn btn-primary btn-sm mr-2 stic-button-green"

--- a/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.ts
+++ b/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.ts
@@ -1,5 +1,5 @@
 import { GroupService } from "../../../services/api/group.service";
-import { Component, OnInit } from "@angular/core";
+import { Component, OnInit, ChangeDetectorRef, NgZone } from "@angular/core";
 import { Router } from "@angular/router";
 import { AlertService, DashboardService, SidebarService, StyleProviderService } from "@eda/services/service.index";
 import { EdaDialogController, EdaDialogCloseEvent } from "@eda/shared/components/shared-components.index";
@@ -149,7 +149,9 @@ export class HomeSdaComponent implements OnInit {
     private router: Router,
     private alertService: AlertService,
     // Service for group management
-    private groupService: GroupService
+    private groupService: GroupService,
+    private cdr: ChangeDetectorRef,
+    private ngZone: NgZone
   ) {
     // Initialize data sources
     this.sidebarService.getDataSourceNames();
@@ -938,6 +940,38 @@ public filterGroups() {
    */
   public toggleDashboardActive(dashboard: any): void {
     const newStatus = !dashboard.active;
+    /* Confirm deactivation of shared reports */
+    if (!newStatus && (dashboard.config.visible === "shared")) {
+      Swal.fire({
+        title: $localize`:@@Sure:Are you sure?`,
+        text: $localize`:@@deactivatePublicDashboardWarning:Si desactiva este informe público, la URL pública dejará de estar disponible y el informe ya no podrá visualizarse.`,
+        icon: "warning",
+        showCancelButton: true,
+        confirmButtonColor: "#3085d6",
+        cancelButtonColor: "#d33",
+        confirmButtonText: $localize`:@@ConfirmDeactivate:Yes, deactivate it!`,
+        cancelButtonText: $localize`:@@Cancel:Cancelar`
+      }).then(result => {
+        if (result.value) {
+          this.executeToggleDashboardActive(dashboard, newStatus);
+        } else {
+          this.ngZone.run(() => {
+            dashboard.active = !newStatus;
+            if (dashboard.config) dashboard.config.active = !newStatus;
+            this.cdr.detectChanges();
+            window.location.reload();
+          });
+        }
+      });
+    } else {
+      this.executeToggleDashboardActive(dashboard, newStatus);
+    }
+  }
+
+  /**
+   * Internal function to execute the dashboard status toggle
+   */
+  private executeToggleDashboardActive(dashboard: any, newStatus: boolean): void {
     dashboard.active = newStatus;
     if (!dashboard.config) dashboard.config = {};
     dashboard.config.active = newStatus;

--- a/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.ts
+++ b/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.ts
@@ -33,6 +33,8 @@ export class HomeSdaComponent implements OnInit {
     direction: "asc" | "desc";
   };
   public selectedStatuses: string[] = ["active", "inactive"];
+  public titleActive: string = $localize`:@@activateReport:Activar informe`;
+  public titleInactive: string = $localize`:@@deactivateReport:Desactivar informe`;
 
   // User and Group Management
   public groups: IGroup[] = [];
@@ -1054,9 +1056,7 @@ public filterGroups() {
       try {
         const filterState = JSON.parse(savedFilters);
         this.searchTerm = filterState.searchTerm || "";
-        // SDA CUSTOM - Load selectedStatuses
         this.selectedStatuses = filterState.selectedStatuses || ["active", "inactive"];
-        // END SDA CUSTOM
         this.sortColumn = filterState.sortColumn || "config.title";
         this.sortDirection = filterState.sortDirection || "asc";
         // Note: selectedTags, selectedGroups, and selectedTypes will be restored after tags/groups are initialized

--- a/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.ts
+++ b/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.ts
@@ -32,6 +32,7 @@ export class HomeSdaComponent implements OnInit {
     column: string;
     direction: "asc" | "desc";
   };
+  public selectedStatuses: string[] = ["active", "inactive"];
 
   // User and Group Management
   public groups: IGroup[] = [];
@@ -268,6 +269,7 @@ export class HomeSdaComponent implements OnInit {
     return {
       ...dashboard,
       type,
+      active: dashboard.config.active !== undefined ? dashboard.config.active : true,
       config: {
         ...dashboard.config,
         tag: Array.isArray(dashboard.config.tag)
@@ -509,6 +511,21 @@ public filterGroups() {
   public filterDashboards() {
     // Reset visibleDashboards
     this.visibleDashboards = [...this.allDashboards];
+
+    // Apply active filter
+    // Restrict status filtering to admins and support multiselect
+    if (this.isAdmin) {
+      if (this.selectedStatuses.length < 2) {
+        this.visibleDashboards = this.visibleDashboards.filter(db => {
+          if (this.selectedStatuses.includes("active") && db.active) return true;
+          if (this.selectedStatuses.includes("inactive") && !db.active) return true;
+          return false;
+        });
+      }
+    } else {
+      // Non-admins only see active reports
+      this.visibleDashboards = this.visibleDashboards.filter(db => db.active === true);
+    }
 
     // Apply type filter
     if (this.selectedTypes.length > 0) {
@@ -913,6 +930,41 @@ public filterGroups() {
     this.editingTypeId = null;
   }
 
+  /**
+   * Toggles the active status of a dashboard
+   * @param dashboard The dashboard to toggle
+   */
+  public toggleDashboardActive(dashboard: any): void {
+    const newStatus = !dashboard.active;
+    dashboard.active = newStatus;
+    if (!dashboard.config) dashboard.config = {};
+    dashboard.config.active = newStatus;
+
+    this.dashboardService
+      .updateDashboardSpecific(dashboard._id, {
+        data: {
+          key: "config.active",
+          newValue: newStatus
+        }
+      })
+      .subscribe(
+        () => {
+          this.alertService.addSuccess(
+            newStatus
+              ? $localize`:@@DashboardActivated:Informe activado correctamente.`
+              : $localize`:@@DashboardDeactivated:Informe desactivado correctamente.`
+          );
+          this.filterDashboards();
+        },
+        error => {
+          this.alertService.addError($localize`:@@ErrorUpdatingDashboardStatus:Error al actualizar el estado del informe.`);
+          dashboard.active = !newStatus;
+          dashboard.config.active = !newStatus;
+          console.error("Error updating dashboard status:", error);
+        }
+      );
+  }
+
   public filterTypes() {
     this.filteredTypes = this.dashboardTypes.filter(type =>
       type.label.toLowerCase().includes(this.typeSearchTerm.toLowerCase())
@@ -972,6 +1024,7 @@ public filterGroups() {
     this.selectedGroups = [];
     this.selectedTypes = [];
     this.searchTerm = "";
+    this.selectedStatuses = ["active", "inactive"];
     this.filterDashboards();
     this.saveFiltersToStorage();
   }
@@ -979,12 +1032,13 @@ public filterGroups() {
   /**
    * Saves the current filter state and sorting to LocalStorage
    */
-  private saveFiltersToStorage(): void {
+  public saveFiltersToStorage(): void {
     const filterState = {
       selectedTags: this.selectedTags,
       selectedGroups: this.selectedGroups,
       selectedTypes: this.selectedTypes,
       searchTerm: this.searchTerm,
+      selectedStatuses: this.selectedStatuses,
       sortColumn: this.sortColumn,
       sortDirection: this.sortDirection
     };
@@ -1000,6 +1054,9 @@ public filterGroups() {
       try {
         const filterState = JSON.parse(savedFilters);
         this.searchTerm = filterState.searchTerm || "";
+        // SDA CUSTOM - Load selectedStatuses
+        this.selectedStatuses = filterState.selectedStatuses || ["active", "inactive"];
+        // END SDA CUSTOM
         this.sortColumn = filterState.sortColumn || "config.title";
         this.sortDirection = filterState.sortDirection || "asc";
         // Note: selectedTags, selectedGroups, and selectedTypes will be restored after tags/groups are initialized
@@ -1085,5 +1142,43 @@ public filterGroups() {
       // If no saved filters, just apply current (empty) filters
       this.filterDashboards();
     }
+  }
+
+  /**
+   * Checks if a status is selected
+   * @param status The status to check
+   * @returns Boolean indicating if the status is selected
+   */
+  public isStatusSelected(status: string): boolean {
+    return this.selectedStatuses.includes(status);
+  }
+
+  /**
+   * Toggles the selection of a status
+   * @param status The status to toggle
+   */
+  public toggleStatusSelection(status: string): void {
+    const index = this.selectedStatuses.indexOf(status);
+    if (index > -1) {
+      this.selectedStatuses.splice(index, 1);
+    } else {
+      this.selectedStatuses.push(status);
+    }
+    this.filterDashboards();
+    this.saveFiltersToStorage();
+  }
+
+  /**
+   * Checks if any filters are currently active (different from default state)
+   * @returns Boolean indicating if any filter is active
+   */
+  public hasActiveFilters(): boolean {
+    return (
+      this.selectedTags.length > 0 ||
+      this.selectedGroups.length > 0 ||
+      this.selectedTypes.length > 0 ||
+      this.searchTerm.length > 0 ||
+      this.selectedStatuses.length < 2
+    );
   }
 }

--- a/eda/eda_app/src/app/shared/models/dashboard-models/dashboard.model.ts
+++ b/eda/eda_app/src/app/shared/models/dashboard-models/dashboard.model.ts
@@ -9,6 +9,7 @@ export class Dashboard {
     public filters: any[];
     public applytoAllFilter: {present: boolean, refferenceTable: string, id: string};
     public visible: string;
+    /* SDA CUSTOM */ public active: boolean = true;
     public onlyIcanEdit: boolean = false;
 
     constructor(init: Partial<Dashboard>) {

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -409,15 +409,15 @@
       </trans-unit>
       <trans-unit id="deactivatePublicDashboardWarning" datatype="html">
         <source>Si desactiva este informe público, la URL pública dejará de estar disponible y el informe ya no podrá visualizarse.</source>
-        <target>Si desactiva aquest informe públic, l’URL pública deixarà de ser disponible i l’informe ja no es podrà visualitzar.</target>
+        <target>Si desactiveu aquest informe públic, la URL pública deixarà d'estar disponible i l'informe ja no es podrà visualitzar.</target>
       </trans-unit>
       <trans-unit id="ConfirmDeactivate" datatype="html">
         <source>Sí, desactivarlo</source>
-        <target>Sí, desactivar-lo</target>
+        <target>Sí, desactiva'l</target>
       </trans-unit>
       <trans-unit id="Cancel" datatype="html">
         <source>Cancelar</source>
-        <target>Cancel·lar</target>
+        <target>Cancel·la</target>
       </trans-unit>
     </body>
 </file>

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -389,11 +389,11 @@
       </trans-unit>
       <trans-unit id="activateReport" datatype="html">
         <source>Activar informe</source>
-        <target>Activar informe</target>
+        <target>Activa l'informe</target>
       </trans-unit>
       <trans-unit id="deactivateReport" datatype="html">
         <source>Desactivar informe</source>
-        <target>Desactivar informe</target>
+        <target>Desactiva l'informe</target>
       </trans-unit>
       <trans-unit id="DashboardActivated" datatype="html">
         <source>Informe activado correctamente.</source>
@@ -405,7 +405,7 @@
       </trans-unit>
       <trans-unit id="ErrorUpdatingDashboardStatus" datatype="html">
         <source>Error al actualizar el estado del informe.</source>
-        <target>S'ha produït un error en actualitzar l'estat de l'informe.</target>
+        <target>S'ha produït un error a l'actualitzar l'estat de l'informe.</target>
       </trans-unit>
     </body>
 </file>

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -407,6 +407,18 @@
         <source>Error al actualizar el estado del informe.</source>
         <target>S'ha produït un error a l'actualitzar l'estat de l'informe.</target>
       </trans-unit>
+      <trans-unit id="deactivatePublicDashboardWarning" datatype="html">
+        <source>Si desactiva este informe público, la URL pública dejará de estar disponible y el informe ya no podrá visualizarse.</source>
+        <target>Si desactiva aquest informe públic, l’URL pública deixarà de ser disponible i l’informe ja no es podrà visualitzar.</target>
+      </trans-unit>
+      <trans-unit id="ConfirmDeactivate" datatype="html">
+        <source>Sí, desactivarlo</source>
+        <target>Sí, desactivar-lo</target>
+      </trans-unit>
+      <trans-unit id="Cancel" datatype="html">
+        <source>Cancelar</source>
+        <target>Cancel·lar</target>
+      </trans-unit>
     </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -367,6 +367,46 @@
     <source>Eliminar filtros</source>
     <target>Elimina filtres</target>
   </trans-unit>
-</body>
+      <trans-unit id="status" datatype="html">
+        <source>Estado</source>
+        <target>Estat</target>
+      </trans-unit>
+      <trans-unit id="active" datatype="html">
+        <source>Activos</source>
+        <target>Actius</target>
+      </trans-unit>
+      <trans-unit id="inactive" datatype="html">
+        <source>Inactivos</source>
+        <target>Inactius</target>
+      </trans-unit>
+      <trans-unit id="activeLabel" datatype="html">
+        <source>Activo</source>
+        <target>Actiu</target>
+      </trans-unit>
+      <trans-unit id="inactiveLabel" datatype="html">
+        <source>Inactivo</source>
+        <target>Inactiu</target>
+      </trans-unit>
+      <trans-unit id="activateReport" datatype="html">
+        <source>Activar informe</source>
+        <target>Activar informe</target>
+      </trans-unit>
+      <trans-unit id="deactivateReport" datatype="html">
+        <source>Desactivar informe</source>
+        <target>Desactivar informe</target>
+      </trans-unit>
+      <trans-unit id="DashboardActivated" datatype="html">
+        <source>Informe activado correctamente.</source>
+        <target>L'informe s'ha activat correctament.</target>
+      </trans-unit>
+      <trans-unit id="DashboardDeactivated" datatype="html">
+        <source>Informe desactivado correctamente.</source>
+        <target>L'informe s'ha desactivat correctament.</target>
+      </trans-unit>
+      <trans-unit id="ErrorUpdatingDashboardStatus" datatype="html">
+        <source>Error al actualizar el estado del informe.</source>
+        <target>S'ha produït un error en actualitzar l'estat de l'informe.</target>
+      </trans-unit>
+    </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -409,7 +409,7 @@
       </trans-unit>
       <trans-unit id="deactivatePublicDashboardWarning" datatype="html">
         <source>Si desactiva este informe público, la URL pública dejará de estar disponible y el informe ya no podrá visualizarse.</source>
-        <target>If you deactivate this public report, the public URL will no longer be available and the report will no longer be viewable.</target>
+        <target>If this public report is deactivated, the public URL will no longer be available and the report will no longer be viewable.</target>
       </trans-unit>
       <trans-unit id="ConfirmDeactivate" datatype="html">
         <source>Sí, desactivarlo</source>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -367,6 +367,46 @@
     <source>Eliminar filtros</source>
     <target>Clear filters</target>
   </trans-unit>
-</body>
+      <trans-unit id="status" datatype="html">
+        <source>Estado</source>
+        <target>Status</target>
+      </trans-unit>
+      <trans-unit id="active" datatype="html">
+        <source>Activos</source>
+        <target>Active</target>
+      </trans-unit>
+      <trans-unit id="inactive" datatype="html">
+        <source>Inactivos</source>
+        <target>Inactive</target>
+      </trans-unit>
+      <trans-unit id="activeLabel" datatype="html">
+        <source>Activo</source>
+        <target>Active</target>
+      </trans-unit>
+      <trans-unit id="inactiveLabel" datatype="html">
+        <source>Inactivo</source>
+        <target>Inactive</target>
+      </trans-unit>
+      <trans-unit id="activateReport" datatype="html">
+        <source>Activar informe</source>
+        <target>Activate report</target>
+      </trans-unit>
+      <trans-unit id="deactivateReport" datatype="html">
+        <source>Desactivar informe</source>
+        <target>Deactivate report</target>
+      </trans-unit>
+      <trans-unit id="DashboardActivated" datatype="html">
+        <source>Informe activado correctamente.</source>
+        <target>Report successfully activated.</target>
+      </trans-unit>
+      <trans-unit id="DashboardDeactivated" datatype="html">
+        <source>Informe desactivado correctamente.</source>
+        <target>Report successfully deactivated.</target>
+      </trans-unit>
+      <trans-unit id="ErrorUpdatingDashboardStatus" datatype="html">
+        <source>Error al actualizar el estado del informe.</source>
+        <target>Error updating report status.</target>
+      </trans-unit>
+    </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -405,7 +405,7 @@
       </trans-unit>
       <trans-unit id="ErrorUpdatingDashboardStatus" datatype="html">
         <source>Error al actualizar el estado del informe.</source>
-        <target>Error updating report status.</target>
+        <target>Error while updating report status.</target>
       </trans-unit>
     </body>
 </file>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -407,6 +407,18 @@
         <source>Error al actualizar el estado del informe.</source>
         <target>Error while updating report status.</target>
       </trans-unit>
+      <trans-unit id="deactivatePublicDashboardWarning" datatype="html">
+        <source>Si desactiva este informe público, la URL pública dejará de estar disponible y el informe ya no podrá visualizarse.</source>
+        <target>If you deactivate this public report, the public URL will no longer be available and the report will no longer be viewable.</target>
+      </trans-unit>
+      <trans-unit id="ConfirmDeactivate" datatype="html">
+        <source>Sí, desactivarlo</source>
+        <target>Yes, deactivate it</target>
+      </trans-unit>
+      <trans-unit id="Cancel" datatype="html">
+        <source>Cancelar</source>
+        <target>Cancel</target>
+      </trans-unit>
     </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -409,7 +409,7 @@
       </trans-unit>
       <trans-unit id="deactivatePublicDashboardWarning" datatype="html">
         <source>Si desactiva este informe público, la URL pública dejará de estar disponible y el informe ya no podrá visualizarse.</source>
-        <source>Si desactiva un informe público dejará de funcionar la URL pública del mismo, por lo que ya no podrá visualizarse</source>
+        <source>Si desactiva un informe público dejará de funcionar la URL pública del mismo, por lo que ya no podrá visualizarse.</source>
       </trans-unit>
       <trans-unit id="ConfirmDeactivate" datatype="html">
         <source>Sí, desactivarlo</source>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -407,6 +407,18 @@
         <source>Error al actualizar el estado del informe.</source>
         <target>Error al actualizar el estado del informe.</target>
       </trans-unit>
+      <trans-unit id="deactivatePublicDashboardWarning" datatype="html">
+        <source>Si desactiva este informe público, la URL pública dejará de estar disponible y el informe ya no podrá visualizarse.</source>
+        <source>Si desactiva un informe público dejará de funcionar la URL pública del mismo, por lo que ya no podrá visualizarse</source>
+      </trans-unit>
+      <trans-unit id="ConfirmDeactivate" datatype="html">
+        <source>Sí, desactivarlo</source>
+        <target>Sí, desactivarlo</target>
+      </trans-unit>
+      <trans-unit id="Cancel" datatype="html">
+        <source>Cancelar</source>
+        <target>Cancelar</target>
+      </trans-unit>
     </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -367,6 +367,46 @@
     <source>Eliminar filtros</source>
     <target>Eliminar filtros</target>
   </trans-unit>
-</body>
+      <trans-unit id="status" datatype="html">
+        <source>Estado</source>
+        <target>Estado</target>
+      </trans-unit>
+      <trans-unit id="active" datatype="html">
+        <source>Activos</source>
+        <target>Activos</target>
+      </trans-unit>
+      <trans-unit id="inactive" datatype="html">
+        <source>Inactivos</source>
+        <target>Inactivos</target>
+      </trans-unit>
+      <trans-unit id="activeLabel" datatype="html">
+        <source>Activo</source>
+        <target>Activo</target>
+      </trans-unit>
+      <trans-unit id="inactiveLabel" datatype="html">
+        <source>Inactivo</source>
+        <target>Inactivo</target>
+      </trans-unit>
+      <trans-unit id="activateReport" datatype="html">
+        <source>Activar informe</source>
+        <target>Activar informe</target>
+      </trans-unit>
+      <trans-unit id="deactivateReport" datatype="html">
+        <source>Desactivar informe</source>
+        <target>Desactivar informe</target>
+      </trans-unit>
+      <trans-unit id="DashboardActivated" datatype="html">
+        <source>Informe activado correctamente.</source>
+        <target>Informe activado correctamente.</target>
+      </trans-unit>
+      <trans-unit id="DashboardDeactivated" datatype="html">
+        <source>Informe desactivado correctamente.</source>
+        <target>Informe desactivado correctamente.</target>
+      </trans-unit>
+      <trans-unit id="ErrorUpdatingDashboardStatus" datatype="html">
+        <source>Error al actualizar el estado del informe.</source>
+        <target>Error al actualizar el estado del informe.</target>
+      </trans-unit>
+    </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -407,6 +407,18 @@
         <source>Error al actualizar el estado del informe.</source>
         <target>Erro ao actualizar o estado do informe.</target>
       </trans-unit>
+      <trans-unit id="deactivatePublicDashboardWarning" datatype="html">
+        <source>Si desactiva este informe público, la URL pública dejará de estar disponible y el informe ya no podrá visualizarse.</source>
+        <target>Se desactiva este informe público, a URL pública deixará de estar dispoñible e o informe xa non se poderá visualizar.</target>
+      </trans-unit>
+      <trans-unit id="ConfirmDeactivate" datatype="html">
+        <source>Sí, desactivarlo</source>
+        <target>Si, desactivalo</target>
+      </trans-unit>
+      <trans-unit id="Cancel" datatype="html">
+        <source>Cancelar</source>
+        <target>Cancelar</target>
+      </trans-unit>
     </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -367,6 +367,46 @@
     <source>Eliminar filtros</source>
     <target>Eliminar filtros</target>
   </trans-unit>
-</body>
+      <trans-unit id="status" datatype="html">
+        <source>Estado</source>
+        <target>Estado</target>
+      </trans-unit>
+      <trans-unit id="active" datatype="html">
+        <source>Activos</source>
+        <target>Activos</target>
+      </trans-unit>
+      <trans-unit id="inactive" datatype="html">
+        <source>Inactivos</source>
+        <target>Inactivos</target>
+      </trans-unit>
+      <trans-unit id="activeLabel" datatype="html">
+        <source>Activo</source>
+        <target>Activo</target>
+      </trans-unit>
+      <trans-unit id="inactiveLabel" datatype="html">
+        <source>Inactivo</source>
+        <target>Inactivo</target>
+      </trans-unit>
+      <trans-unit id="activateReport" datatype="html">
+        <source>Activar informe</source>
+        <target>Activar informe</target>
+      </trans-unit>
+      <trans-unit id="deactivateReport" datatype="html">
+        <source>Desactivar informe</source>
+        <target>Desactivar informe</target>
+      </trans-unit>
+      <trans-unit id="DashboardActivated" datatype="html">
+        <source>Informe activado correctamente.</source>
+        <target>Informe activado correctamente.</target>
+      </trans-unit>
+      <trans-unit id="DashboardDeactivated" datatype="html">
+        <source>Informe desactivado correctamente.</source>
+        <target>Informe desactivado correctamente.</target>
+      </trans-unit>
+      <trans-unit id="ErrorUpdatingDashboardStatus" datatype="html">
+        <source>Error al actualizar el estado del informe.</source>
+        <target>Erro ao actualizar o estado do informe.</target>
+      </trans-unit>
+    </body>
 </file>
 </xliff>


### PR DESCRIPTION
## Descripción del Cambio

Este PR introduce un sistema de gestión de estado para los informes, que permite a los administradores activar o desactivar su visibilidad (Activo/Inactivo) y filtrarlos en consecuencia. La funcionalidad incluye persistencia en backend y actualizaciones en la interfaz tanto para la vista de tabla como para la vista de tarjetas.

El filtro se aplica al desmarcar alguna de las opciones de estado (Activos o Inactivos). En ese momento se estará aplicando el filtro correspondiente.
Si ambas opciones están seleccionadas, se mostrarán todos los informes, por lo que no se aplicará ningún filtro.

## Pruebas a realizar para validar el cambio

- Verificar que el filtro de estado filtra correctamente los informes tanto en vista de tarjetas como en vista de tabla.
- Confirmar que solo los administradores pueden ver e interactuar con el estado.
- Validar que los cambios de estado persisten tras recargar la página.
