### PR TITLE
Enhancement - APP - Las dimensiones de la visualización de los KPI se pierde tras la actualización del core

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.component.html
+++ b/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.component.html
@@ -7,11 +7,11 @@
 </ng-container>
 
 <ng-container *ngIf="inject.showChart">
-    <div  #kpiContainer class="w-100 h-100">    
-        <div class="w-100 d-flex flex-column justify-content-center text-center text-wrap" style="height: auto;">
+    <div  #kpiContainer class="w-100 h-100 d-flex flex-column overflow-hidden" style="position: relative;">
+        <div class="w-100 d-flex flex-column justify-content-center text-center text-wrap" style="position: absolute; top: 0; left: 0; z-index: 1; width: 100%;">
             <ng-container *ngTemplateOutlet="kpiValueContainer;"></ng-container>
         </div>
-        <div  style="height: 60%; max-height: 320px; max-width: 1300px;">
+        <div  style="position: absolute; bottom: 0; left: 0; width: 100%; height: 70%;  max-width: 1300px;">
             <!-- {{inject.edaChart?.chartOptions | json}} -->
             <eda-chart #EdaChart [inject]="inject.edaChart"></eda-chart>
         </div>

--- a/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, EventEmitter, Output, ViewChild, ElementRef, AfterViewInit, ChangeDetectorRef } from '@angular/core';
+/*SDA CUSTOM*/import { Component, OnInit, Input, EventEmitter, Output, ViewChild, ElementRef, AfterViewInit, ChangeDetectorRef } from '@angular/core';
 import { registerLocaleData } from '@angular/common';
 import { EdaKpi } from './eda-kpi';
 import es from '@angular/common/locales/es';
@@ -9,7 +9,7 @@ import { EdaChartComponent } from '../component.index';
     templateUrl: './eda-kpi.component.html'
 })
 
-export class EdaKpiComponent implements OnInit, AfterViewInit {
+/*SDA CUSTOM*/export class EdaKpiComponent implements OnInit, AfterViewInit {
     @Input() inject: EdaKpi;
     @Output() onNotify: EventEmitter<any> = new EventEmitter();
     @ViewChild('kpiContainer') kpiContainer: ElementRef;
@@ -21,14 +21,16 @@ export class EdaKpiComponent implements OnInit, AfterViewInit {
     warningColor = '#ff8100';
     containerHeight: number = 20;
     containerWidth: number = 20;
+/*SDA CUSTOM*/baseResultSize: number = 0;
 
     showChart: boolean = true;
 
-    constructor(private cdr: ChangeDetectorRef) { }
+/*SDA CUSTOM*/constructor(private cdr: ChangeDetectorRef) { }
 
     ngAfterViewInit() {
         this.initDimensions();
-        this.cdr.detectChanges();
+/*SDA CUSTOM*/this.baseResultSize = this.computeBaseSize();
+/*SDA CUSTOM*/this.cdr.detectChanges();
     }
 
     ngOnInit() {
@@ -80,39 +82,34 @@ export class EdaKpiComponent implements OnInit, AfterViewInit {
         return { 'font-weight': 'bold', 'font-size': this.getFontSize(), display: 'flex', 'justify-content': 'center', color: this.color }
     }
 
-    /**
-     * This function returns a string with the given font size (in px) based on the panel width and height 
-     * @returns {string}
-    */
-    getFontSize(): string {
-        this.initDimensions();
-
+/*SDA CUSTOM*/    private computeBaseSize(): number {
         let resultSize: number = this.containerHeight / 2;
-        let textLongitude = (this.inject.value + this.inject.sufix).length;
-        const ratio = (  this.containerHeight / this.containerWidth ) ;
-
         const sufix = this.inject.sufix || '';
-
-        textLongitude = this.inject.value.toString().length
-
-        // Comprobaciones
+/*SDA CUSTOM*/const ratio = (this.containerHeight / this.containerWidth);
+/*SDA CUSTOM*/const textLongitude = this.inject.value.toString().length;
         let textWidth = textLongitude * resultSize;
-        // Redimensiono en funcion del ancho
-        if ( ( textWidth > this.containerWidth )  && ( sufix.length < 4 ) ) resultSize = (this.containerWidth / textLongitude) * 1.4;
-        // Redimensiono en función del alto
-        if (resultSize > this.containerHeight   && ratio < 0.4  ) resultSize = this.containerHeight;
-        // Última comprobación
-        if (textLongitude * resultSize > this.containerWidth * 1.2   && ratio < 0.4  )  resultSize = resultSize / 1.5;
-        // Si tengo un sufijo y es muy grande compruebo que no me pase
+/*SDA CUSTOM*/if ((textWidth > this.containerWidth) && (sufix.length < 4)) resultSize = (this.containerWidth / textLongitude) * 1.4;
+/*SDA CUSTOM*/if (resultSize > this.containerHeight && ratio < 0.4) resultSize = this.containerHeight;
+/*SDA CUSTOM*/if (textLongitude * resultSize > this.containerWidth * 1.2 && ratio < 0.4) resultSize = resultSize / 1.5;
         if (sufix.length > 4 && this.containerHeight < (resultSize * 4) && this.containerWidth < textWidth) {
             resultSize = resultSize / 1.8;
         }
-        // Si tengo ung gráfico lo hago más pequeño
         if (this.showChart) {
             resultSize = resultSize / 1.8;
         }
-      
-        resultSize = resultSize * (1 + (this.inject.modifiedFontPoints || 0) / 100);
+/*SDA CUSTOM*/return resultSize;
+    }
+
+    /**
+     * This function returns a string with the given font size (in px) based on the panel width and height
+     * @returns {string}
+    */
+/*SDA CUSTOM*/    getFontSize(): string {
+/*SDA CUSTOM*/if (this.baseResultSize === 0) {
+/*SDA CUSTOM*/    this.initDimensions();
+/*SDA CUSTOM*/    this.baseResultSize = this.computeBaseSize();
+/*SDA CUSTOM*/}
+/*SDA CUSTOM*/const resultSize = this.baseResultSize * (1 + (this.inject.modifiedFontPoints || 0) / 100);
         return resultSize.toFixed().toString() + 'px';
     }
 

--- a/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.component.ts
@@ -111,6 +111,7 @@ export class EdaKpiComponent implements OnInit {
             resultSize = resultSize / 1.8;
         }
       
+        resultSize += (this.inject.variablePX || 0);
         return resultSize.toFixed().toString() + 'px';
     }
 

--- a/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, EventEmitter, Output, ViewChild, ElementRef, AfterViewInit } from '@angular/core';
+import { Component, OnInit, Input, EventEmitter, Output, ViewChild, ElementRef, AfterViewInit, ChangeDetectorRef } from '@angular/core';
 import { registerLocaleData } from '@angular/common';
 import { EdaKpi } from './eda-kpi';
 import es from '@angular/common/locales/es';
@@ -9,7 +9,7 @@ import { EdaChartComponent } from '../component.index';
     templateUrl: './eda-kpi.component.html'
 })
 
-export class EdaKpiComponent implements OnInit {
+export class EdaKpiComponent implements OnInit, AfterViewInit {
     @Input() inject: EdaKpi;
     @Output() onNotify: EventEmitter<any> = new EventEmitter();
     @ViewChild('kpiContainer') kpiContainer: ElementRef;
@@ -24,13 +24,14 @@ export class EdaKpiComponent implements OnInit {
 
     showChart: boolean = true;
 
-    constructor() { }
+    constructor(private cdr: ChangeDetectorRef) { }
 
     ngAfterViewInit() {
         this.initDimensions();
+        this.cdr.detectChanges();
     }
 
-    ngOnInit() {;
+    ngOnInit() {
         try {
             registerLocaleData(es);
 
@@ -111,7 +112,7 @@ export class EdaKpiComponent implements OnInit {
             resultSize = resultSize / 1.8;
         }
       
-        resultSize += (this.inject.variablePX || 0);
+        resultSize = resultSize * (1 + (this.inject.modifiedFontPoints || 0) / 100);
         return resultSize.toFixed().toString() + 'px';
     }
 

--- a/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.ts
+++ b/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.ts
@@ -9,5 +9,5 @@ export class EdaKpi {
     alertLimits : Array<{value:number, operand:string, color:string}>;
     edaChart: EdaChart;
     showChart: boolean;
-    modifiedFontPoints: number;
+/*SDA CUSTOM*/    modifiedFontPoints: number;
 }

--- a/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.ts
+++ b/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.ts
@@ -9,5 +9,5 @@ export class EdaKpi {
     alertLimits : Array<{value:number, operand:string, color:string}>;
     edaChart: EdaChart;
     showChart: boolean;
-    variablePX: number;
+    modifiedFontPoints: number;
 }

--- a/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.ts
+++ b/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.ts
@@ -9,4 +9,5 @@ export class EdaKpi {
     alertLimits : Array<{value:number, operand:string, color:string}>;
     edaChart: EdaChart;
     showChart: boolean;
+    variablePX: number;
 }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -569,7 +569,7 @@ export class EdaBlankPanelComponent implements OnInit {
             this.panel.content = { query, chart, edaChart };
 
             /**This is to repaint on panel redimension */
-            if (['parallelSets', 'kpi','dynamicText', 'treeMap', 'scatterPlot', 'knob', 'funnel','bubblechart', 'sunburst'].includes(chart)) {
+            if (['parallelSets', 'kpi', 'kpibar', 'kpiline', 'kpiarea', 'dynamicText', 'treeMap', 'scatterPlot', 'knob', 'funnel','bubblechart', 'sunburst'].includes(chart)) {
                 this.renderChart(this.currentQuery, this.chartLabels, this.chartData, chart, edaChart, this.panelChartConfig.config);
             }
         } else {

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -1422,7 +1422,7 @@ export class EdaBlankPanelComponent implements OnInit {
         if (!_.isEqual(event, EdaDialogCloseEvent.NONE)) {
             this.panel.content.query.output.config.alertLimits = response.alerts;
             this.panel.content.query.output.config.sufix = response.sufix;
-            this.panel.content.query.output.config.variablePx = response.variablePx || 0;
+            this.panel.content.query.output.config.modifiedFontPoints = response.modifiedFontPoints || 0;
 
             let layout: any;
             if (response.edaChart) {
@@ -1441,7 +1441,7 @@ export class EdaBlankPanelComponent implements OnInit {
                 );
             }
 
-            const config = new ChartConfig(new KpiConfig({ sufix: response.sufix, alertLimits: response.alerts, edaChart: layout, extraPx: response.extraPx || 0 }));
+            const config = new ChartConfig(new KpiConfig({ sufix: response.sufix, alertLimits: response.alerts, edaChart: layout, modifiedFontPoints: response.modifiedFontPoints || 0 }));
             this.renderChart(this.currentQuery, this.chartLabels, this.chartData, response.chartType, response.chartSubType, config);
             this.dashboardService._notSaved.next(true);
         }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -1422,6 +1422,7 @@ export class EdaBlankPanelComponent implements OnInit {
         if (!_.isEqual(event, EdaDialogCloseEvent.NONE)) {
             this.panel.content.query.output.config.alertLimits = response.alerts;
             this.panel.content.query.output.config.sufix = response.sufix;
+            this.panel.content.query.output.config.variablePx = response.variablePx || 0;
 
             let layout: any;
             if (response.edaChart) {
@@ -1440,7 +1441,7 @@ export class EdaBlankPanelComponent implements OnInit {
                 );
             }
 
-            const config = new ChartConfig(new KpiConfig({ sufix: response.sufix, alertLimits: response.alerts, edaChart: layout }));
+            const config = new ChartConfig(new KpiConfig({ sufix: response.sufix, alertLimits: response.alerts, edaChart: layout, extraPx: response.extraPx || 0 }));
             this.renderChart(this.currentQuery, this.chartLabels, this.chartData, response.chartType, response.chartSubType, config);
             this.dashboardService._notSaved.next(true);
         }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -1422,7 +1422,7 @@ export class EdaBlankPanelComponent implements OnInit {
         if (!_.isEqual(event, EdaDialogCloseEvent.NONE)) {
             this.panel.content.query.output.config.alertLimits = response.alerts;
             this.panel.content.query.output.config.sufix = response.sufix;
-            this.panel.content.query.output.config.modifiedFontPoints = response.modifiedFontPoints || 0;
+/*SDA CUSTOM*/this.panel.content.query.output.config.modifiedFontPoints = response.modifiedFontPoints || 0;
 
             let layout: any;
             if (response.edaChart) {
@@ -1441,7 +1441,7 @@ export class EdaBlankPanelComponent implements OnInit {
                 );
             }
 
-            const config = new ChartConfig(new KpiConfig({ sufix: response.sufix, alertLimits: response.alerts, edaChart: layout, modifiedFontPoints: response.modifiedFontPoints || 0 }));
+/*SDA CUSTOM*/const config = new ChartConfig(new KpiConfig({ sufix: response.sufix, alertLimits: response.alerts, edaChart: layout, modifiedFontPoints: response.modifiedFontPoints || 0 }));
             this.renderChart(this.currentQuery, this.chartLabels, this.chartData, response.chartType, response.chartSubType, config);
             this.dashboardService._notSaved.next(true);
         }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
@@ -2,29 +2,12 @@
   
   <div body class="grid h-100 p-5">
 
-    <div class="col-7" style="background-color: var(--panel-color); width: 90%; height: 15vh;">
+    <div class="col-7" style="background-color: var(--panel-color); width: 90%; height: auto;">
       <panel-chart *ngIf="display" #PanelChartComponent [props]="panelChartConfig" class="component"></panel-chart>
     </div>
 
     <div class="col-4 col-offset-1">
-
-        <div class="col-12">
-            <h6 class="custom-border-b1">Tamaño</h6>
-            <div class="grid align-items-center">
-                <div class="col-12">
-                    <label i18n="@@kpiExtraPxLabel">Ajuste de tamaño (px)</label>
-                    <div class="p-inputgroup mt-1">
-                        <button pButton type="button" icon="fa fa-minus" class="p-button-secondary"
-                            (click)="extraPx = extraPx - 1"></button>
-                        <input type="number" pInputText [(ngModel)]="extraPx" style="width: 60px; text-align: center;" />
-                        <button pButton type="button" icon="fa fa-plus" class="p-button-secondary"
-                            (click)="extraPx = extraPx + 1"></button>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="col-12">
+<!--SDA CUSTOM--> <div *ngIf="edaChart" class="col-12">
             <h6 i18n="@@colorsChartH6" class="custom-border-b1">
                 Colores
             </h6>
@@ -39,6 +22,18 @@
             </div>
         </div>
 
+<!--SDA CUSTOM-->       <div class="col-12">
+<!--SDA CUSTOM-->         <h6 class="custom-border-b1">Tamaño</h6>
+<!--SDA CUSTOM-->         <div class="grid align-items-center">
+<!--SDA CUSTOM-->             <div class="col-12">
+<!--SDA CUSTOM-->                 <label i18n="@@kpiExtraPxLabel">Ajuste de tamaño (%)</label>
+<!--SDA CUSTOM-->                 <div class="p-inputgroup mt-1">
+<!--SDA CUSTOM-->                     <input type="number" pInputText [(ngModel)]="modifiedFontPoints" style="width: 60px; text-align: center;" 
+                                          min="-90" max="200" (input)="modifyKpiSize(0)"/>
+<!--SDA CUSTOM-->                 </div>
+<!--SDA CUSTOM-->             </div>
+<!--SDA CUSTOM-->           </div>
+<!--SDA CUSTOM-->       </div>
     </div>
 
     <div class="col-12 mt-5">

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
@@ -28,8 +28,8 @@
 <!--SDA CUSTOM-->             <div class="col-12">
 <!--SDA CUSTOM-->                 <label i18n="@@kpiExtraPxLabel">Ajuste de tamaño (%)</label>
 <!--SDA CUSTOM-->                 <div class="p-inputgroup mt-1">
-<!--SDA CUSTOM-->                     <input type="number" pInputText [(ngModel)]="modifiedFontPoints" style="width: 60px; text-align: center;" 
-                                          min="-90" max="200" (input)="modifyKpiSize(0)"/>
+<!--SDA CUSTOM-->                     <input type="number" pInputText [ngModel]="modifiedFontPoints" style="width: 60px; text-align: center;"
+                                          min="-90" max="300" (ngModelChange)="modifyKpiSize($event)"/>
 <!--SDA CUSTOM-->                 </div>
 <!--SDA CUSTOM-->             </div>
 <!--SDA CUSTOM-->           </div>

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
@@ -7,6 +7,20 @@
     </div>
 
     <div class="col-4 col-offset-1">
+
+<!--SDA CUSTOM-->       <div class="col-12">
+<!--SDA CUSTOM-->         <h6 class="custom-border-b1">Tamaño</h6>
+<!--SDA CUSTOM-->         <div class="grid align-items-center">
+<!--SDA CUSTOM-->             <div class="col-12">
+<!--SDA CUSTOM-->                 <label i18n="@@kpiExtraPxLabel">Ajuste de tamaño (%)</label>
+<!--SDA CUSTOM-->                 <div class="p-inputgroup mt-1">
+<!--SDA CUSTOM-->                     <input type="number" pInputText [ngModel]="modifiedFontPoints" style="width: 60px; text-align: center;"
+                                          min="-90" max="300" (ngModelChange)="modifyKpiSize($event)"/>
+<!--SDA CUSTOM-->                 </div>
+<!--SDA CUSTOM-->             </div>
+<!--SDA CUSTOM-->           </div>
+<!--SDA CUSTOM-->       </div>
+
 <!--SDA CUSTOM--> <div *ngIf="edaChart" class="col-12">
             <h6 i18n="@@colorsChartH6" class="custom-border-b1">
                 Colores
@@ -22,18 +36,7 @@
             </div>
         </div>
 
-<!--SDA CUSTOM-->       <div class="col-12">
-<!--SDA CUSTOM-->         <h6 class="custom-border-b1">Tamaño</h6>
-<!--SDA CUSTOM-->         <div class="grid align-items-center">
-<!--SDA CUSTOM-->             <div class="col-12">
-<!--SDA CUSTOM-->                 <label i18n="@@kpiExtraPxLabel">Ajuste de tamaño (%)</label>
-<!--SDA CUSTOM-->                 <div class="p-inputgroup mt-1">
-<!--SDA CUSTOM-->                     <input type="number" pInputText [ngModel]="modifiedFontPoints" style="width: 60px; text-align: center;"
-                                          min="-90" max="300" (ngModelChange)="modifyKpiSize($event)"/>
-<!--SDA CUSTOM-->                 </div>
-<!--SDA CUSTOM-->             </div>
-<!--SDA CUSTOM-->           </div>
-<!--SDA CUSTOM-->       </div>
+
     </div>
 
     <div class="col-12 mt-5">

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
@@ -9,6 +9,22 @@
     <div class="col-4 col-offset-1">
 
         <div class="col-12">
+            <h6 class="custom-border-b1">Tamaño</h6>
+            <div class="grid align-items-center">
+                <div class="col-12">
+                    <label i18n="@@kpiExtraPxLabel">Ajuste de tamaño (px)</label>
+                    <div class="p-inputgroup mt-1">
+                        <button pButton type="button" icon="fa fa-minus" class="p-button-secondary"
+                            (click)="extraPx = extraPx - 1"></button>
+                        <input type="number" pInputText [(ngModel)]="extraPx" style="width: 60px; text-align: center;" />
+                        <button pButton type="button" icon="fa fa-plus" class="p-button-secondary"
+                            (click)="extraPx = extraPx + 1"></button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-12">
             <h6 i18n="@@colorsChartH6" class="custom-border-b1">
                 Colores
             </h6>

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
@@ -27,7 +27,8 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     public alertInfo: string = $localize`:@@alertsInfo: Cuando el valor del kpi sea (=, <,>) que el valor definido cambiará el color del texto`;
     public ptooltipViewAlerts: string = $localize`:@@ptooltipViewAlerts:Configurar alertas`;
 
-    public modifiedFontPoints: number = 0;
+/*SDA CUSTOM*/public modifiedFontPoints: number = 0;
+/*SDA CUSTOM*/public panelBaseResultSize: number = 0;
 
     public units: string;
     public quantity: number;
@@ -72,7 +73,7 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
                 edaChart: this.edaChart,
                 chartType: this.panelChartConfig.chartType,
                 chartSubType: this.panelChartConfig.edaChart,
-                modifiedFontPoints: this.modifiedFontPoints
+/*SDA CUSTOM*/  modifiedFontPoints: this.modifiedFontPoints
             });
     }
 
@@ -83,14 +84,24 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     onShow(): void {
         this.panelChartConfig = this.controller.params.panelChart;
         this.edaChart = this.controller.params.edaChart;
+/*SDA CUSTOM*/this.panelBaseResultSize = this.controller.params.panelBaseResultSize || 0;
 
         const config: any = this.panelChartConfig.config.getConfig();
 
         this.loadChartColors();
         this.alerts = config.alertLimits || []; //deepcopy
-        this.modifiedFontPoints = config.modifiedFontPoints || 0;
+/*SDA CUSTOM*/this.modifiedFontPoints = config.modifiedFontPoints || 0;
         this.display = true;
-    }
+/*SDA CUSTOM*/if (this.panelBaseResultSize > 0) {
+/*SDA CUSTOM*/  setTimeout(() => {
+/*SDA CUSTOM*/      const kpiInstance = this.panelChartComponent?.componentRef?.instance;
+/*SDA CUSTOM*/          if (kpiInstance) {
+/*SDA CUSTOM*/              kpiInstance.baseResultSize = this.panelBaseResultSize;
+/*SDA CUSTOM*/              this.panelChartComponent.componentRef.changeDetectorRef.detectChanges();
+/*SDA CUSTOM*/          }
+/*SDA CUSTOM*/      }, 100);
+/*SDA CUSTOM*/  }
+/*SDA CUSTOM*/}
 
     loadChartColors() {
         if (this.edaChart) {
@@ -259,16 +270,16 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
         return (!this.quantity || !this.units || !(this.selectedUsers.length > 0) || !this.mailMessage)
     }
 
-    modifyKpiSize(numberToAdd: number) {
-        const step = 5;
-        const min = -90;
-        const max = 200;
-        if (numberToAdd !== 0) {
-            this.modifiedFontPoints = Math.min(max, Math.max(min, this.modifiedFontPoints + numberToAdd * step));
-        } else {
-            this.modifiedFontPoints = Math.min(max, Math.max(min, this.modifiedFontPoints));
-        }
-        this.panelChartComponent.componentRef.instance.inject.modifiedFontPoints = this.modifiedFontPoints;
-        this.panelChartComponent.componentRef.instance.updateChart();
-    }
+/*SDA CUSTOM*/modifyKpiSize(newValue?: number) {
+/*SDA CUSTOM*/    const min = -90;
+/*SDA CUSTOM*/    const max = 300;
+/*SDA CUSTOM*/    if (newValue !== undefined) {
+/*SDA CUSTOM*/        this.modifiedFontPoints = Math.min(max, Math.max(min, newValue || 0));
+/*SDA CUSTOM*/    } else {
+/*SDA CUSTOM*/        this.modifiedFontPoints = Math.min(max, Math.max(min, this.modifiedFontPoints));
+/*SDA CUSTOM*/    }
+/*SDA CUSTOM*/    const instance = this.panelChartComponent.componentRef.instance;
+/*SDA CUSTOM*/    instance.inject.modifiedFontPoints = this.modifiedFontPoints;
+/*SDA CUSTOM*/    this.panelChartComponent.componentRef.changeDetectorRef.detectChanges();
+/*SDA CUSTOM*/}
 }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
@@ -27,7 +27,7 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     public alertInfo: string = $localize`:@@alertsInfo: Cuando el valor del kpi sea (=, <,>) que el valor definido cambiará el color del texto`;
     public ptooltipViewAlerts: string = $localize`:@@ptooltipViewAlerts:Configurar alertas`;
 
-    public variablePx: number = 0;
+    public modifiedFontPoints: number = 0;
 
     public units: string;
     public quantity: number;
@@ -72,7 +72,7 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
                 edaChart: this.edaChart,
                 chartType: this.panelChartConfig.chartType,
                 chartSubType: this.panelChartConfig.edaChart,
-                variablePx: this.variablePx
+                modifiedFontPoints: this.modifiedFontPoints
             });
     }
 
@@ -88,7 +88,7 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
 
         this.loadChartColors();
         this.alerts = config.alertLimits || []; //deepcopy
-        this.variablePx = config.variablePx || 0;
+        this.modifiedFontPoints = config.modifiedFontPoints || 0;
         this.display = true;
     }
 
@@ -259,4 +259,16 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
         return (!this.quantity || !this.units || !(this.selectedUsers.length > 0) || !this.mailMessage)
     }
 
+    modifyKpiSize(numberToAdd: number) {
+        const step = 5;
+        const min = -90;
+        const max = 200;
+        if (numberToAdd !== 0) {
+            this.modifiedFontPoints = Math.min(max, Math.max(min, this.modifiedFontPoints + numberToAdd * step));
+        } else {
+            this.modifiedFontPoints = Math.min(max, Math.max(min, this.modifiedFontPoints));
+        }
+        this.panelChartComponent.componentRef.instance.inject.modifiedFontPoints = this.modifiedFontPoints;
+        this.panelChartComponent.componentRef.instance.updateChart();
+    }
 }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
@@ -27,6 +27,8 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     public alertInfo: string = $localize`:@@alertsInfo: Cuando el valor del kpi sea (=, <,>) que el valor definido cambiará el color del texto`;
     public ptooltipViewAlerts: string = $localize`:@@ptooltipViewAlerts:Configurar alertas`;
 
+    public variablePx: number = 0;
+
     public units: string;
     public quantity: number;
     public hours: any;
@@ -69,7 +71,8 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
                 sufix: this.panelChartComponent.componentRef.instance.inject.sufix,
                 edaChart: this.edaChart,
                 chartType: this.panelChartConfig.chartType,
-                chartSubType: this.panelChartConfig.edaChart
+                chartSubType: this.panelChartConfig.edaChart,
+                variablePx: this.variablePx
             });
     }
 
@@ -85,6 +88,7 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
 
         this.loadChartColors();
         this.alerts = config.alertLimits || []; //deepcopy
+        this.variablePx = config.variablePx || 0;
         this.display = true;
     }
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/chart-configuration-models/kpi-config.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/chart-configuration-models/kpi-config.ts
@@ -4,6 +4,7 @@ export class KpiConfig {
     sufix: string = '';
     alertLimits: any[] = [];
     edaChart: ChartJsConfig;
+    variablePx: number = 0;
     constructor(init?: Partial<KpiConfig>) {
         this.edaChart = new ChartJsConfig(
           init?.edaChart?.colors || [],

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/chart-configuration-models/kpi-config.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/chart-configuration-models/kpi-config.ts
@@ -4,7 +4,7 @@ export class KpiConfig {
     sufix: string = '';
     alertLimits: any[] = [];
     edaChart: ChartJsConfig;
-    modifiedFontPoints: number = 0;
+/*SDA CUSTOM*/modifiedFontPoints: number = 0;
     constructor(init?: Partial<KpiConfig>) {
         this.edaChart = new ChartJsConfig(
           init?.edaChart?.colors || [],

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/chart-configuration-models/kpi-config.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/chart-configuration-models/kpi-config.ts
@@ -4,7 +4,7 @@ export class KpiConfig {
     sufix: string = '';
     alertLimits: any[] = [];
     edaChart: ChartJsConfig;
-    variablePx: number = 0;
+    modifiedFontPoints: number = 0;
     constructor(init?: Partial<KpiConfig>) {
         this.edaChart = new ChartJsConfig(
           init?.edaChart?.colors || [],

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.ts
@@ -495,11 +495,11 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
             chartConfig.sufix = (<KpiConfig>config.getConfig())?.sufix || '';
             chartConfig.alertLimits = alertLimits;
             chartConfig.edaChart =  (<KpiConfig>config.getConfig())?.edaChart;
-            chartConfig.modifiedFontPoints = (<KpiConfig>config.getConfig())?.modifiedFontPoints || 0;
+/*SDA CUSTOM*/chartConfig.modifiedFontPoints = (<KpiConfig>config.getConfig())?.modifiedFontPoints || 0;
         } else {
             chartConfig.sufix = '';
             chartConfig.alertLimits = [];
-            chartConfig.modifiedFontPoints = 0;
+/*SDA CUSTOM*/chartConfig.modifiedFontPoints = 0;
         }
 
         this.createEdaKpiComponent(chartConfig);
@@ -515,7 +515,7 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         this.componentRef = this.entry.createComponent(factory);
         this.componentRef.instance.inject = inject;
         this.componentRef.instance.onNotify.subscribe(data => {
-            const kpiConfig = new KpiConfig({ sufix: data.sufix, alertLimits: inject.alertLimits, modifiedFontPoints: inject.modifiedFontPoints || 0 });
+/*SDA CUSTOM*/const kpiConfig = new KpiConfig({ sufix: data.sufix, alertLimits: inject.alertLimits, modifiedFontPoints: inject.modifiedFontPoints || 0 });
             (<KpiConfig><unknown>this.props.config.setConfig(kpiConfig));
         })
     }
@@ -658,11 +658,11 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         if (propsConfig) {
             chartConfig.sufix = (<KpiConfig>propsConfig.getConfig())?.sufix || '';
             chartConfig.alertLimits = alertLimits;
-            chartConfig.modifiedFontPoints = (<KpiConfig>propsConfig.getConfig())?.modifiedFontPoints || 0;
+/*SDA CUSTOM*/chartConfig.modifiedFontPoints = (<KpiConfig>propsConfig.getConfig())?.modifiedFontPoints || 0;
         } else {
             chartConfig.sufix = '';
             chartConfig.alertLimits = [];
-            chartConfig.modifiedFontPoints = 0;
+/*SDA CUSTOM*/chartConfig.modifiedFontPoints = 0;
         }
 
         this.createEdaKpiChartComponent(chartConfig);
@@ -687,7 +687,7 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         this.componentRef.instance.inject = inject;
 
         this.componentRef.instance.onNotify.subscribe(data => {
-            const kpiConfig = new KpiConfig({ sufix: data.sufix, alertLimits: inject.alertLimits||[], edaChart: inject.edaChart, modifiedFontPoints: inject.modifiedFontPoints || 0 });
+/*SDA CUSTOM*/const kpiConfig = new KpiConfig({ sufix: data.sufix, alertLimits: inject.alertLimits||[], edaChart: inject.edaChart, modifiedFontPoints: inject.modifiedFontPoints || 0 });
             (<KpiConfig><unknown>this.props.config.setConfig(kpiConfig));
         })
         this.configUpdated.emit();

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.ts
@@ -495,11 +495,11 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
             chartConfig.sufix = (<KpiConfig>config.getConfig())?.sufix || '';
             chartConfig.alertLimits = alertLimits;
             chartConfig.edaChart =  (<KpiConfig>config.getConfig())?.edaChart;
-            chartConfig.variablePx = (<KpiConfig>config.getConfig())?.variablePx || 0;
+            chartConfig.modifiedFontPoints = (<KpiConfig>config.getConfig())?.modifiedFontPoints || 0;
         } else {
             chartConfig.sufix = '';
             chartConfig.alertLimits = [];
-            chartConfig.variablePx = 0;
+            chartConfig.modifiedFontPoints = 0;
         }
 
         this.createEdaKpiComponent(chartConfig);
@@ -515,7 +515,7 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         this.componentRef = this.entry.createComponent(factory);
         this.componentRef.instance.inject = inject;
         this.componentRef.instance.onNotify.subscribe(data => {
-            const kpiConfig = new KpiConfig({ sufix: data.sufix, alertLimits: inject.alertLimits, variablePx: inject.variablePx || 0 });
+            const kpiConfig = new KpiConfig({ sufix: data.sufix, alertLimits: inject.alertLimits, modifiedFontPoints: inject.modifiedFontPoints || 0 });
             (<KpiConfig><unknown>this.props.config.setConfig(kpiConfig));
         })
     }
@@ -658,11 +658,11 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         if (propsConfig) {
             chartConfig.sufix = (<KpiConfig>propsConfig.getConfig())?.sufix || '';
             chartConfig.alertLimits = alertLimits;
-            chartConfig.variablePx = (<KpiConfig>propsConfig.getConfig())?.variablePx || 0;
+            chartConfig.modifiedFontPoints = (<KpiConfig>propsConfig.getConfig())?.modifiedFontPoints || 0;
         } else {
             chartConfig.sufix = '';
             chartConfig.alertLimits = [];
-            chartConfig.variablePx = 0;
+            chartConfig.modifiedFontPoints = 0;
         }
 
         this.createEdaKpiChartComponent(chartConfig);
@@ -687,7 +687,7 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         this.componentRef.instance.inject = inject;
 
         this.componentRef.instance.onNotify.subscribe(data => {
-            const kpiConfig = new KpiConfig({ sufix: data.sufix, alertLimits: inject.alertLimits||[], edaChart: inject.edaChart, variablePx: inject.variablePx || 0 });
+            const kpiConfig = new KpiConfig({ sufix: data.sufix, alertLimits: inject.alertLimits||[], edaChart: inject.edaChart, modifiedFontPoints: inject.modifiedFontPoints || 0 });
             (<KpiConfig><unknown>this.props.config.setConfig(kpiConfig));
         })
         this.configUpdated.emit();

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.ts
@@ -495,9 +495,11 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
             chartConfig.sufix = (<KpiConfig>config.getConfig())?.sufix || '';
             chartConfig.alertLimits = alertLimits;
             chartConfig.edaChart =  (<KpiConfig>config.getConfig())?.edaChart;
+            chartConfig.variablePx = (<KpiConfig>config.getConfig())?.variablePx || 0;
         } else {
             chartConfig.sufix = '';
             chartConfig.alertLimits = [];
+            chartConfig.variablePx = 0;
         }
 
         this.createEdaKpiComponent(chartConfig);
@@ -513,7 +515,7 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         this.componentRef = this.entry.createComponent(factory);
         this.componentRef.instance.inject = inject;
         this.componentRef.instance.onNotify.subscribe(data => {
-            const kpiConfig = new KpiConfig({ sufix: data.sufix, alertLimits: inject.alertLimits });
+            const kpiConfig = new KpiConfig({ sufix: data.sufix, alertLimits: inject.alertLimits, variablePx: inject.variablePx || 0 });
             (<KpiConfig><unknown>this.props.config.setConfig(kpiConfig));
         })
     }
@@ -656,9 +658,11 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         if (propsConfig) {
             chartConfig.sufix = (<KpiConfig>propsConfig.getConfig())?.sufix || '';
             chartConfig.alertLimits = alertLimits;
+            chartConfig.variablePx = (<KpiConfig>propsConfig.getConfig())?.variablePx || 0;
         } else {
             chartConfig.sufix = '';
             chartConfig.alertLimits = [];
+            chartConfig.variablePx = 0;
         }
 
         this.createEdaKpiChartComponent(chartConfig);
@@ -683,7 +687,7 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         this.componentRef.instance.inject = inject;
 
         this.componentRef.instance.onNotify.subscribe(data => {
-            const kpiConfig = new KpiConfig({ sufix: data.sufix, alertLimits: inject.alertLimits||[], edaChart: inject.edaChart });
+            const kpiConfig = new KpiConfig({ sufix: data.sufix, alertLimits: inject.alertLimits||[], edaChart: inject.edaChart, variablePx: inject.variablePx || 0 });
             (<KpiConfig><unknown>this.props.config.setConfig(kpiConfig));
         })
         this.configUpdated.emit();

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/charts-config-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/charts-config-utils.ts
@@ -46,11 +46,11 @@ export const ChartsConfigUtils = {
       config = {
         sufix: ebp.panelChart.componentRef.instance.inject.sufix,
         alertLimits: ebp.panelChart.componentRef.instance.inject.alertLimits,
-        modifiedFontPoints: ebp.panelChart.componentRef.instance.inject.modifiedFontPoints || 0,
+/*SDA CUSTOM*/modifiedFontPoints: ebp.panelChart.componentRef.instance.inject.modifiedFontPoints || 0,
         edaChart: {}
       }
 
-      if (kpiChart?.edaChart) {
+/*SDA CUSTOM*/if (kpiChart?.edaChart) {
         config.edaChart.colors = kpiChart.chartColors;
         config.edaChart.chartType = ebp.panelChart.props.chartType;
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/charts-config-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/charts-config-utils.ts
@@ -46,10 +46,11 @@ export const ChartsConfigUtils = {
       config = {
         sufix: ebp.panelChart.componentRef.instance.inject.sufix,
         alertLimits: ebp.panelChart.componentRef.instance.inject.alertLimits,
+        modifiedFontPoints: ebp.panelChart.componentRef.instance.inject.modifiedFontPoints || 0,
         edaChart: {}
       }
 
-      if (kpiChart.edaChart) {
+      if (kpiChart?.edaChart) {
         config.edaChart.colors = kpiChart.chartColors;
         config.edaChart.chartType = ebp.panelChart.props.chartType;
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-menu-options.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-menu-options.ts
@@ -97,7 +97,8 @@ export const PanelOptions = {
                 panelID: _.get(panelComponent.panel, 'id'),
                 panelChart: panelComponent.panelChartConfig,
                 alertLimits: panelComponent.panelChart.componentRef.instance.alertLimits || [],
-                edaChart: panelComponent.panelChart.componentRef.instance.edaChartComponent?.inject
+                edaChart: panelComponent.panelChart.componentRef.instance.edaChartComponent?.inject,
+                panelBaseResultSize: panelComponent.panelChart.componentRef.instance.baseResultSize || 0
               },
               close: (event, response) => { panelComponent.onCloseKpiProperties(event, response) }
             });

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -1455,7 +1455,7 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
             found
             && panel.content
             && !found.panelChart.NO_DATA
-            && (['parallelSets', 'kpi',  'dynamicText', 'treeMap', 'scatterPlot', 'knob', 'funnel','bubblechart', 'sunburst'].includes(panel.content.chart))
+            && (['parallelSets', 'kpi', 'kpibar', 'kpiline', 'kpiarea', 'dynamicText', 'treeMap', 'scatterPlot', 'knob', 'funnel','bubblechart', 'sunburst'].includes(panel.content.chart))
             && !$event.isNew) {
             found.savePanel();
         }


### PR DESCRIPTION


## Descripción del Cambio
Se añade un control en las propiedades del gráfico que permiten ajustar el tamaño en porcentaje  a partir de taño calculado por SDA. Esto se hace para que sea adaptativo a las diferentes pantallas.

## Issue(s) resuelto(s)
- solves  #390

## Pruebas a realizar para validar el cambio
Hacer un kpi  y ajustar el tamaño mediante el ajuste
Hacer un kpi   +  gráfico de barras y ajustar el tamaño mediante el ajuste  

## Información Adicional

