### PR TITLE
Feature - Informes - No se permite mostrar dos campos numéricos en gráfico

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
@@ -101,7 +101,7 @@ export const QueryUtils = {
     const response = await ebp.queryService.executeAnalizedQuery(query).toPromise();
     return response;
   },
-
+  
   transformAnalizedQueryData: (ebp: EdaBlankPanelComponent, data: any) => {
     const labels = [$localize`:@@atributoLabel:Atributo`, $localize`:@@atributoConsulta:Consulta`, $localize`:@@atributoValor:Valor`];
     const values = [];
@@ -218,7 +218,7 @@ export const QueryUtils = {
         }
         return a;
       })); // canviem els null y els '' per valor customitzable
-
+       
       // ebp.chartData = response[1];       // Chart data
       ebp.ableBtnSave();                 // Button save
       /* Labels i Data - Arrays */
@@ -251,7 +251,7 @@ export const QueryUtils = {
       ebp.index = 1;
       ebp.display_v.saved_panel = true;
     } catch (err) {
-      ebp.alertService.addError(err);
+      ebp.alertService.addError(err); 
       ebp.spinnerService.off();
     }
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
@@ -207,6 +207,10 @@ export const QueryUtils = {
 
 
       // Execute query
+/* SDA CUSTOM */ // If all columns are numeric, convert the first one to text (regardless of aggregations) */
+/* SDA CUSTOM */ if (ebp.currentQuery.length > 0 && ebp.currentQuery.every((field: any) => field.column_type === 'numeric')) {
+/* SDA CUSTOM */ ebp.currentQuery[0].column_type = 'text';
+/* SDA CUSTOM */ }
       const response = await QueryUtils.switchAndRun(ebp, query);
       ebp.chartLabels = ebp.chartUtils.uniqueLabels(response[0]);   // Chart labels
       ebp.chartData = response[1].map(item => item.map(a => {

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
@@ -206,11 +206,7 @@ export const QueryUtils = {
       }
 
 
-      // Execute query
-/* SDA CUSTOM */ // If there is more than 1 column and all are numeric, convert the first one to text*/
-/* SDA CUSTOM */ if (ebp.currentQuery.length > 1 && ebp.currentQuery.every((field: any) => field.column_type === 'numeric')) {
-/* SDA CUSTOM */ ebp.currentQuery[0].column_type = 'text';
-/* SDA CUSTOM */ }
+
       const response = await QueryUtils.switchAndRun(ebp, query);
       ebp.chartLabels = ebp.chartUtils.uniqueLabels(response[0]);   // Chart labels
       ebp.chartData = response[1].map(item => item.map(a => {

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
@@ -207,8 +207,8 @@ export const QueryUtils = {
 
 
       // Execute query
-/* SDA CUSTOM */ // If all columns are numeric, convert the first one to text (regardless of aggregations) */
-/* SDA CUSTOM */ if (ebp.currentQuery.length > 0 && ebp.currentQuery.every((field: any) => field.column_type === 'numeric')) {
+/* SDA CUSTOM */ // If there is more than 1 column and all are numeric, convert the first one to text*/
+/* SDA CUSTOM */ if (ebp.currentQuery.length > 1 && ebp.currentQuery.every((field: any) => field.column_type === 'numeric')) {
 /* SDA CUSTOM */ ebp.currentQuery[0].column_type = 'text';
 /* SDA CUSTOM */ }
       const response = await QueryUtils.switchAndRun(ebp, query);

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
@@ -101,7 +101,7 @@ export const QueryUtils = {
     const response = await ebp.queryService.executeAnalizedQuery(query).toPromise();
     return response;
   },
-  
+
   transformAnalizedQueryData: (ebp: EdaBlankPanelComponent, data: any) => {
     const labels = [$localize`:@@atributoLabel:Atributo`, $localize`:@@atributoConsulta:Consulta`, $localize`:@@atributoValor:Valor`];
     const values = [];
@@ -206,7 +206,7 @@ export const QueryUtils = {
       }
 
 
-
+      // Execute query
       const response = await QueryUtils.switchAndRun(ebp, query);
       ebp.chartLabels = ebp.chartUtils.uniqueLabels(response[0]);   // Chart labels
       ebp.chartData = response[1].map(item => item.map(a => {
@@ -218,7 +218,7 @@ export const QueryUtils = {
         }
         return a;
       })); // canviem els null y els '' per valor customitzable
-       
+
       // ebp.chartData = response[1];       // Chart data
       ebp.ableBtnSave();                 // Button save
       /* Labels i Data - Arrays */
@@ -251,7 +251,7 @@ export const QueryUtils = {
       ebp.index = 1;
       ebp.display_v.saved_panel = true;
     } catch (err) {
-      ebp.alertService.addError(err); 
+      ebp.alertService.addError(err);
       ebp.spinnerService.off();
     }
 

--- a/eda/eda_app/src/app/services/utils/chart-utils.service.ts
+++ b/eda/eda_app/src/app/services/utils/chart-utils.service.ts
@@ -147,6 +147,11 @@ export class ChartUtilsService {
         numberOfColumns es el numero de columnes que farem servidr en el histograma
     */
     public transformDataQuery(type: string, subType: string,  values: any[], dataTypes: string[], dataDescription: any, isBarline: boolean, numberOfColumns: number) {
+        
+        console.log('forzando');
+        console.log(dataTypes);
+        dataTypes = [ 'text', 'numeric', 'numeric'] ;
+        console.log(dataTypes);
 
         dataTypes.forEach( (e,indice)=>{            
             if(e=='text'){

--- a/eda/eda_app/src/app/services/utils/chart-utils.service.ts
+++ b/eda/eda_app/src/app/services/utils/chart-utils.service.ts
@@ -659,12 +659,13 @@ export class ChartUtilsService {
             notAllowed.splice(notAllowed.indexOf('dynamicText'), 1);
         }
         // Pie && Polar (Only one numeric column and one char/date column)
-        if (dataDescription.totalColumns === 2 && dataDescription.numericColumns.length === 1) {
+/* SDA CUSTOM */ if ((dataDescription.totalColumns === 2 && dataDescription.numericColumns.length === 1) ||
+/* SDA CUSTOM */    (dataDescription.totalColumns === 2 && dataDescription.numericColumns.length === 2))  {         
             notAllowed.splice(notAllowed.indexOf('doughnut'), 1);
             notAllowed.splice(notAllowed.indexOf('polarArea'), 1);
             notAllowed.splice(notAllowed.indexOf('kpibar'), 1);
             notAllowed.splice(notAllowed.indexOf('kpiline'), 1);
-            notAllowed.splice(notAllowed.indexOf('kpiarea',), 1);
+/* SDA CUSTOM */notAllowed.splice(notAllowed.indexOf('kpiarea'), 1);
         }
         // barchart i horizontalbar  poden ser grafics normals o poden ser histograms....
         if (dataDescription.numericColumns.length >= 1 && dataDescription.totalColumns > 1 && dataDescription.otherColumns.length < 2

--- a/eda/eda_app/src/app/services/utils/chart-utils.service.ts
+++ b/eda/eda_app/src/app/services/utils/chart-utils.service.ts
@@ -148,10 +148,13 @@ export class ChartUtilsService {
     */
     public transformDataQuery(type: string, subType: string,  values: any[], dataTypes: string[], dataDescription: any, isBarline: boolean, numberOfColumns: number) {
         
-        console.log('forzando');
-        console.log(dataTypes);
-        dataTypes = [ 'text', 'numeric', 'numeric'] ;
-        console.log(dataTypes);
+        /* SDA CUSTOM */ // If there is more than 1 column and all are numeric, convert the first one to text
+        /* SDA CUSTOM */ const allNumeric = dataTypes.length > 1 && !dataTypes.find(t => t !== 'numeric');
+        /* SDA CUSTOM */ if (allNumeric) {
+        /* SDA CUSTOM */     dataTypes[0] = "text";
+        /* SDA CUSTOM */     const columnaNumerica = dataDescription.numericColumns.shift();
+        /* SDA CUSTOM */     dataDescription.otherColumns.unshift(columnaNumerica);
+        /* SDA CUSTOM */ }
 
         dataTypes.forEach( (e,indice)=>{            
             if(e=='text'){

--- a/eda/eda_app/src/app/services/utils/chart-utils.service.ts
+++ b/eda/eda_app/src/app/services/utils/chart-utils.service.ts
@@ -643,7 +643,7 @@ export class ChartUtilsService {
                 'table', 'crosstable', 'kpi','dynamicText', 'geoJsonMap', 'coordinatesMap',
                 'doughnut', 'polarArea', 'line', 'kpiline', 'area', 'kpiarea', 'bar', 'kpibar', 'histogram',  'funnel', 'bubblechart',
                 'horizontalBar', 'barline', 'stackedbar', 'parallelSets', 'treeMap', 'scatterPlot', 'knob' ,
-                'pyramid', 'radar', 'stackedbar100', 'treetable'
+                'pyramid', 'radar', 'stackedbar100', 'treetable', 'sunburst'
             ];
 
         //table (at least one column)
@@ -761,6 +761,13 @@ export class ChartUtilsService {
         if(  dataDescription.totalColumns > 2 && dataDescription.otherColumns.length >= 1) {
             notAllowed.splice(notAllowed.indexOf('treetable'), 1);
         }
+
+
+        // sunbrust two or more value columns and one numeric
+        if(  dataDescription.totalColumns > 2 && dataDescription.otherColumns.length >= 1 && dataDescription.numericColumns.length === 1  ) {
+            notAllowed.splice(notAllowed.indexOf('sunburst'), 1);
+        }
+
 
         return notAllowed;
 

--- a/eda/eda_app/src/app/services/utils/chart-utils.service.ts
+++ b/eda/eda_app/src/app/services/utils/chart-utils.service.ts
@@ -643,7 +643,7 @@ export class ChartUtilsService {
                 'table', 'crosstable', 'kpi','dynamicText', 'geoJsonMap', 'coordinatesMap',
                 'doughnut', 'polarArea', 'line', 'kpiline', 'area', 'kpiarea', 'bar', 'kpibar', 'histogram',  'funnel', 'bubblechart',
                 'horizontalBar', 'barline', 'stackedbar', 'parallelSets', 'treeMap', 'scatterPlot', 'knob' ,
-                'pyramid', 'radar', 'stackedbar100', 'treetable', 'sunburst'
+/*SDA CUSTOM*/  'pyramid', 'radar', 'stackedbar100', 'treetable', 'sunburst'
             ];
 
         //table (at least one column)
@@ -764,10 +764,10 @@ export class ChartUtilsService {
         }
 
 
-        // sunbrust two or more value columns and one numeric
-        if(  dataDescription.totalColumns > 2 && dataDescription.otherColumns.length >= 1 && dataDescription.numericColumns.length === 1  ) {
-            notAllowed.splice(notAllowed.indexOf('sunburst'), 1);
-        }
+/*SDA CUSTOM*/ // sunbrust two or more value columns and one numeric
+/*SDA CUSTOM*/ if(  dataDescription.totalColumns > 2 && dataDescription.otherColumns.length >= 1 && dataDescription.numericColumns.length === 1  ) {
+/*SDA CUSTOM*/     notAllowed.splice(notAllowed.indexOf('sunburst'), 1);
+/*SDA CUSTOM*/ }
 
 
         return notAllowed;


### PR DESCRIPTION
## Descripción del Cambio
Se habilita la posibilidad de hacer gráficos de barras  con conjuntos de datos sólo numéricos. 

## Issue(s) resuelto(s)
- solves #349

## Pruebas a realizar para validar el cambio
Hacer un conjunto de datos numerico y hacer un grafico de barras. La primera "columna" se convertirá en las categorías. 


## Información Adicional
No se implementa para todos y cada uno de los gráficos. Sinó para Baras y lineas. Los habilitados.