### PR TITLE
Improvement - APP - Implementar carga dinámica del módulo mariadb en getSdaInfo y updateModel

### DIFF
--- a/eda/eda_api/lib/module/getSdaInfo/getSdaInfo.controller.ts
+++ b/eda/eda_api/lib/module/getSdaInfo/getSdaInfo.controller.ts
@@ -3,10 +3,13 @@ import * as fs from "fs";
 import * as path from "path";
 const sinergiaDatabase = require("../../../config/sinergiacrm.config");
 let mariadbModule: any;
+const dynamicImport = new Function("modulePath", "return import(modulePath);") as (
+  modulePath: string
+) => Promise<any>;
 
 const getMariaDb = async () => {
   if (!mariadbModule) {
-    const mod = await import("mariadb");
+    const mod = await dynamicImport("mariadb");
     mariadbModule = mod.default || mod;
   }
   return mariadbModule;

--- a/eda/eda_api/lib/module/getSdaInfo/getSdaInfo.controller.ts
+++ b/eda/eda_api/lib/module/getSdaInfo/getSdaInfo.controller.ts
@@ -2,7 +2,15 @@ import { Request, Response } from "express";
 import * as fs from "fs";
 import * as path from "path";
 const sinergiaDatabase = require("../../../config/sinergiacrm.config");
-const mariadb = require("mariadb");
+let mariadbModule: any;
+
+const getMariaDb = async () => {
+  if (!mariadbModule) {
+    const mod = await import("mariadb");
+    mariadbModule = mod.default || mod;
+  }
+  return mariadbModule;
+};
 
 
 /**
@@ -67,6 +75,7 @@ export class getSdaInfo {
 
       // Retrieve the last synchronization date with SinergiaCRM.
       let connection: any;
+      const mariadb = await getMariaDb();
       connection = await mariadb.createConnection(sinergiaDatabase.sinergiaConn);
       const rows = await connection.query("SELECT value from sda_def_config WHERE `key` = 'last_rebuild';");
 

--- a/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
+++ b/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
@@ -10,8 +10,16 @@ import path from 'path';
 import fs from "fs";
 import { CleanModel } from "./service/cleanModel";
 
-const mariadb = require("mariadb");
 const sinergiaDatabase = require("../../../config/sinergiacrm.config");
+let mariadbModule: any;
+
+const getMariaDb = async () => {
+  if (!mariadbModule) {
+    const mod = await import("mariadb");
+    mariadbModule = mod.default || mod;
+  }
+  return mariadbModule;
+};
 
 export class updateModel {
   /** Updates the SinergiaDA data model of an instance */
@@ -22,6 +30,7 @@ export class updateModel {
     let enumerator: any;
     let connection: any;
     console.time("UpdateModel");
+    const mariadb = await getMariaDb();
     connection = await mariadb.createConnection(sinergiaDatabase.sinergiaConn);
     console.timeLog("UpdateModel", "(Create connection)");
 

--- a/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
+++ b/eda/eda_api/lib/module/updateModel/updateModel.controller.ts
@@ -12,10 +12,13 @@ import { CleanModel } from "./service/cleanModel";
 
 const sinergiaDatabase = require("../../../config/sinergiacrm.config");
 let mariadbModule: any;
+const dynamicImport = new Function("modulePath", "return import(modulePath);") as (
+  modulePath: string
+) => Promise<any>;
 
 const getMariaDb = async () => {
   if (!mariadbModule) {
-    const mod = await import("mariadb");
+    const mod = await dynamicImport("mariadb");
     mariadbModule = mod.default || mod;
   }
   return mariadbModule;


### PR DESCRIPTION
## Descripción del cambio
Este PR implementa la carga dinámica del módulo MariaDB en los puntos donde realmente se utiliza.

## Motivo
El cambio se realiza porque se estaba produciendo un error al ejecutar `npm run build`.  
Aunque no se ha identificado con certeza la causa raíz, con esta aproximación se evita la carga estática de MariaDB durante el proceso de compilación/inicialización y se desbloquea el build.

## Cambios aplicados
- Sustitución de carga estática de MariaDB por carga dinámica en:
  - [eda/eda_api/lib/module/getSdaInfo/getSdaInfo.controller.ts](eda/eda_api/lib/module/getSdaInfo/getSdaInfo.controller.ts)
  - [eda/eda_api/lib/module/updateModel/updateModel.controller.ts](eda/eda_api/lib/module/updateModel/updateModel.controller.ts)
- Se mantiene la lógica funcional existente; solo cambia la forma de resolver el módulo.


## Validación recomendada
- Ejecutar `npm run build` y verificar que finaliza correctamente.
- Probar el endpoint de información SDA.
- Probar el flujo de actualización de modelo contra una instancia real de SinergiaCRM.