### PR TITLE
Enhancement - Gráficos - Mejoras en la configuración de los KPI

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.component.html
+++ b/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.component.html
@@ -6,27 +6,40 @@
     </div>
 </ng-container>
 
+<!-- SDA CUSTOM - KPI with chart overlay and editable font controls -->
 <ng-container *ngIf="inject.showChart">
-    <div  #kpiContainer class="w-100 h-100">    
-        <div class="w-100 d-flex flex-column justify-content-center text-center text-wrap" style="height: auto;">
-            <ng-container *ngTemplateOutlet="kpiValueContainer;"></ng-container>
+    <div #kpiContainer class="w-100 h-100" style="position: relative;">
+        <div style="position: absolute; top: 0; left: 0; right: 0; z-index: 2; display: flex; justify-content: center; pointer-events: none;">
+            <div style="width: 100%; pointer-events: auto;">
+                <ng-container *ngTemplateOutlet="kpiValueContainer;"></ng-container>
+            </div>
         </div>
-        <div  style="height: 60%; max-height: 320px; max-width: 1300px;">
+        <div style="position: absolute; bottom: 0; left: 0; right: 0; height: 50%; max-height: 50%; max-width: 1300px;">
             <!-- {{inject.edaChart?.chartOptions | json}} -->
             <eda-chart #EdaChart [inject]="inject.edaChart"></eda-chart>
         </div>
     </div>
 </ng-container>
+<!-- END SDA CUSTOM -->
 
 <ng-template #kpiValueContainer>
-    <div #sufixContainer class="pointer" title="Añadir unidades" style="color: var(--panel-font-color); font-family: var(--panel-font-family);" >
-        <div [ngStyle]="getStyle()" (click)="setSufix()">
-            {{inject.value | number:'1.0-10':'es' }} {{inject.sufix}}
+    <!-- SDA CUSTOM - KPI value controls and sufix editor -->
+    <div style="position: relative; width: 100%; height: 100%;" (mouseenter)="onMouseEnter()" (mouseleave)="onMouseLeave()">
+        <div *ngIf="shouldShowControls()" style="position: absolute; top: 4px; right: 4px; display: flex; gap: 6px; align-items: center; z-index: 1;">
+            <button type="button" (click)="decreaseFont()" title="Reducir tamaño" style="width: 24px; height: 24px; border: 1px solid #ccc; background: #fff; border-radius: 4px; line-height: 20px;">-</button>
+            <button type="button" (click)="increaseFont()" title="Aumentar tamaño" style="width: 24px; height: 24px; border: 1px solid #ccc; background: #fff; border-radius: 4px; line-height: 20px;">+</button>
+            <span style="font-size: 12px; color: #666; min-width: 44px; text-align: right;">{{getFontSize()}}</span>
         </div>
+        <div #sufixContainer class="pointer" title="Añadir unidades" style="color: var(--panel-font-color); font-family: var(--panel-font-family);" >
+            <div [ngStyle]="getStyle()" (click)="setSufix()">
+                {{inject.value | number:'1.0-10':'es' }} {{inject.sufix}}
+            </div>
 
-        <div *ngIf="!!sufixClick" class="ui-inputgroup w-100">
-            <input type="text" pInputText class="w-100" [(ngModel)]="inject.sufix" (focusout)="setSufix()" (keydown.enter)="setSufix()" name="unidades" autofocusOnShow>
+            <div *ngIf="!!sufixClick" class="ui-inputgroup w-100">
+                <input type="text" pInputText class="w-100" [(ngModel)]="inject.sufix" (focusout)="setSufix()" (keydown.enter)="setSufix()" name="unidades" autofocusOnShow>
+            </div>
         </div>
     </div>
+    <!-- END SDA CUSTOM -->
 </ng-template>
 

--- a/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.component.ts
@@ -23,6 +23,12 @@ export class EdaKpiComponent implements OnInit {
     containerWidth: number = 20;
 
     showChart: boolean = true;
+    /* SDA CUSTOM */ private readonly minFontScale = 0.6;
+    /* SDA CUSTOM */ private readonly maxFontScale = 2.0;
+    /* SDA CUSTOM */ private readonly fontScaleStep = 0.1;
+    /* SDA CUSTOM */ private readonly scaleTolerance = 0.15;
+    /* SDA CUSTOM */ private baseWidth: number | undefined;
+    /* SDA CUSTOM */ public isHovered = false;
 
     constructor() { }
 
@@ -33,20 +39,11 @@ export class EdaKpiComponent implements OnInit {
     ngOnInit() {;
         try {
             registerLocaleData(es);
-
-            if (this.inject.alertLimits?.length > 0) {
-                this.inject.alertLimits.forEach(alert => {
-                    const operand = alert.operand, warningColor = alert.color;
-                    const value1 = this.inject.value, value2 = alert.value;
-                    if (this.color !== this.defaultColor) this.defaultColor = this.color;
-                    switch (operand) {
-                        case '<': this.color = value1 < value2 ? warningColor : this.defaultColor; break;
-                        case '=': this.color = value1 === value2 ? warningColor : this.defaultColor; break;
-                        case '>': this.color = value1 > value2 ? warningColor : this.defaultColor; break;
-                        default: this.color = this.defaultColor;
-                    }
-                });
+            /* SDA CUSTOM */ if (typeof this.inject?.fontScale !== 'number') {
+                /* SDA CUSTOM */ this.inject.fontScale = 1;
             }
+            /* SDA CUSTOM */ this.setBaseColor(this.inject?.color);
+            /* SDA CUSTOM */ this.applyAlertColors();
 
         } catch (e) {
             console.log('No alert limits defined (alertLimits)');
@@ -54,17 +51,42 @@ export class EdaKpiComponent implements OnInit {
         }
     }
 
+    /* SDA CUSTOM */ setBaseColor(color: string): void {
+        /* SDA CUSTOM */ if (color) {
+            /* SDA CUSTOM */ this.defaultColor = color;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ this.color = this.defaultColor;
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ applyAlertColors(): void {
+        /* SDA CUSTOM */ if (this.inject.alertLimits?.length > 0) {
+            /* SDA CUSTOM */ this.inject.alertLimits.forEach(alert => {
+                /* SDA CUSTOM */ const operand = alert.operand, warningColor = alert.color;
+                /* SDA CUSTOM */ const value1 = this.inject.value, value2 = alert.value;
+                /* SDA CUSTOM */ switch (operand) {
+                    /* SDA CUSTOM */ case '<': this.color = value1 < value2 ? warningColor : this.defaultColor; break;
+                    /* SDA CUSTOM */ case '=': this.color = value1 === value2 ? warningColor : this.defaultColor; break;
+                    /* SDA CUSTOM */ case '>': this.color = value1 > value2 ? warningColor : this.defaultColor; break;
+                    /* SDA CUSTOM */ default: this.color = this.defaultColor;
+                /* SDA CUSTOM */ }
+            /* SDA CUSTOM */ });
+        /* SDA CUSTOM */ }
+    /* SDA CUSTOM */ }
+
     public initDimensions() {
         if (this.kpiContainer) {
             const widthKpiContainer = this.kpiContainer.nativeElement.offsetWidth;
             const heightKpiContainer = this.kpiContainer.nativeElement.offsetHeight;
             const sufixContainerReference = this.sufixContainer.nativeElement;
-    
+
             if (widthKpiContainer > 0) {
                 this.containerHeight = heightKpiContainer;
                 this.containerWidth = widthKpiContainer;
+                /* SDA CUSTOM */ if (!this.baseWidth) {
+                    /* SDA CUSTOM */ this.baseWidth = widthKpiContainer;
+                /* SDA CUSTOM */ }
             }
-    
+
             //Auto margin
             sufixContainerReference.style.margin = "auto"
         }
@@ -72,17 +94,48 @@ export class EdaKpiComponent implements OnInit {
 
     setSufix(): void {
         this.sufixClick = !this.sufixClick;
-        this.onNotify.emit({ sufix: this.inject.sufix })
+        /* SDA CUSTOM */ this.onNotify.emit({ sufix: this.inject.sufix, fontScale: this.inject.fontScale })
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ onMouseEnter(): void {
+        /* SDA CUSTOM */ this.isHovered = true;
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ onMouseLeave(): void {
+        /* SDA CUSTOM */ this.isHovered = false;
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ shouldShowControls(): boolean {
+        /* SDA CUSTOM */ return !!this.inject?.showResizeControls && this.isHovered;
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ increaseFont(): void {
+        /* SDA CUSTOM */ this.updateFontScale(this.fontScaleStep);
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ decreaseFont(): void {
+        /* SDA CUSTOM */ this.updateFontScale(-this.fontScaleStep);
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private updateFontScale(delta: number): void {
+        /* SDA CUSTOM */ const current = typeof this.inject.fontScale === 'number' ? this.inject.fontScale : 1;
+        /* SDA CUSTOM */ const next = this.clampFontScale(current + delta);
+        /* SDA CUSTOM */ this.inject.fontScale = next;
+        /* SDA CUSTOM */ if (this.containerWidth > 0) {
+            /* SDA CUSTOM */ this.baseWidth = this.containerWidth;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ this.onNotify.emit({ sufix: this.inject.sufix, fontScale: this.inject.fontScale });
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private clampFontScale(value: number): number {
+        /* SDA CUSTOM */ return Math.max(this.minFontScale, Math.min(this.maxFontScale, value));
     }
 
     getStyle(): any {
         return { 'font-weight': 'bold', 'font-size': this.getFontSize(), display: 'flex', 'justify-content': 'center', color: this.color }
     }
 
-    /**
-     * This function returns a string with the given font size (in px) based on the panel width and height 
-     * @returns {string}
-    */
+    /* SDA CUSTOM */ // This function returns a string with the given font size (in px) based on the panel width and height
     getFontSize(): string {
         this.initDimensions();
 
@@ -110,9 +163,22 @@ export class EdaKpiComponent implements OnInit {
         if (this.showChart) {
             resultSize = resultSize / 1.8;
         }
-      
+
+        /* SDA CUSTOM */ const scale = this.getEffectiveScale();
+        /* SDA CUSTOM */ resultSize = resultSize * scale;
+
         return resultSize.toFixed().toString() + 'px';
     }
+
+    /* SDA CUSTOM */ private getEffectiveScale(): number {
+        /* SDA CUSTOM */ const scale = typeof this.inject.fontScale === 'number' ? this.inject.fontScale : 1;
+        /* SDA CUSTOM */ if (!this.baseWidth || this.baseWidth <= 0 || this.containerWidth <= 0) {
+            /* SDA CUSTOM */ return scale;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ const ratio = this.containerWidth / this.baseWidth;
+        /* SDA CUSTOM */ const withinTolerance = ratio >= (1 - this.scaleTolerance) && ratio <= (1 + this.scaleTolerance);
+        /* SDA CUSTOM */ return withinTolerance ? scale : 1;
+    /* SDA CUSTOM */ }
 
     public updateChart(): void {
         if (this.inject.edaChart && this.edaChartComponent) {

--- a/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.ts
+++ b/eda/eda_app/src/app/module/components/eda-kpi/eda-kpi.ts
@@ -4,6 +4,14 @@ export class EdaKpi {
     header: string;
     value: number;
     sufix: string;
+    /* SDA CUSTOM */ fontScale?: number;
+    /* SDA CUSTOM */ showResizeControls?: boolean;
+    /* SDA CUSTOM */ color?: string;
+    /* SDA CUSTOM */ lineWidth?: number;
+    /* SDA CUSTOM */ lineStyle?: string;
+    /* SDA CUSTOM */ showXAxis?: boolean;
+    /* SDA CUSTOM */ showXAxisLabels?: boolean;
+    /* SDA CUSTOM */ xAxisLabelCount?: number;
     styleClass: any;
     style: any;
     alertLimits : Array<{value:number, operand:string, color:string}>;

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/chart-dialog/chart-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/chart-dialog/chart-dialog.component.html
@@ -39,7 +39,7 @@
         </div>
 
         <div class="col-2 col-offset-8">
-            <h6 i18n="@@showLabels" class="custom-border-b1" style="margin-top: 2em;">
+            <h6 i18n="@@showChartLabels" class="custom-border-b1" style="margin-top: 2em;">
                 Mostrar Etiquetas
             </h6>
 
@@ -51,7 +51,7 @@
 
         </div>
         <div class="col-2 col-offset-8">
-            <h6 i18n="@@showLabelsPercent" class="custom-border-b1" style="margin-top: 2em;">
+            <h6 i18n="@@showChartLabelsPercent" class="custom-border-b1" style="margin-top: 2em;">
                 Mostrar Etiquetas en Porcentajes
             </h6>
 
@@ -62,14 +62,14 @@
             </div>
 
         </div>
-        
+
         <div  *ngIf=showNumberOfColumns class="col-2" style="margin-top: 2em;">
             <h6 i18n="@@histogramColum" class="custom-border-b1">
                 Columnas
             </h6>
         <div   *ngIf=showNumberOfColumns [pTooltip]="columnsTooltip" tooltipPosition="left">
             <input type="number" pInputText id="columnes" name="columnes"
-            min="3" max="100" [(ngModel)]="numberOfColumns" (change)="SetNumberOfColumns()" > 
+            min="3" max="100" [(ngModel)]="numberOfColumns" (change)="SetNumberOfColumns()" >
         </div>
        </div>
 
@@ -86,7 +86,7 @@
                 <ng-container *ngFor="let serie of series; let i = index">
 
                     <div class=" col-6 ">
-                        <input type="text" pInputText style="width: 40%" [value]="serie.label" disabled="true" 
+                        <input type="text" pInputText style="width: 40%" [value]="serie.label" disabled="true"
                             [style.border-color]="serie.border" />
 
                         <p-colorPicker [(ngModel)]="serie.bg" (onChange)="handleInputColor(serie)" format="hex"

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/chart-dialog/chart-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/chart-dialog/chart-dialog.component.ts
@@ -65,7 +65,7 @@ export class ChartDialogComponent extends EdaDialogAbstract  {
 
         this.dialog.style = { width: '80%', height: '70%', top:"-4em", left:'1em'};
 
-  
+
         this.drops.pointStyles = [
             { label: 'Puntos', value: 'circle' },
             { label: 'Triangulos', value: 'triangle' },
@@ -120,21 +120,26 @@ export class ChartDialogComponent extends EdaDialogAbstract  {
             case 'doughnut':
             case 'polarArea':
                 if (this.chart.chartLabels) {
-                    this.series = this.chart.chartLabels.map((c, inx) => ({
-                        label: c,
-                        bg: this.rgb2hex(this.chart.chartColors[0].backgroundColor[inx])
-                    }));
-                    this.chart.chartColors[0].backgroundColor = this.series.map(d => (this.hex2rgb(d.bg, 90)));
+                    /* SDA CUSTOM */ this.series = this.chart.chartLabels.map((c, inx) => ({
+                    /* SDA CUSTOM */     label: c,
+                    /* SDA CUSTOM */     bg: this.normalizeHexColor(this.chart.chartColors?.[0]?.backgroundColor?.[inx], '#67757c')
+                    /* SDA CUSTOM */ }));
+                    /* SDA CUSTOM */ this.chart.chartColors[0].backgroundColor = this.series.map(d => (this.hex2rgb(d.bg, 90)));
                 }
                 break;
             default:
 
-                this.series = this.chart.chartDataset.map(dataset => ({
-                    label: dataset.label,
-                    bg: this.rgb2hex(dataset.backgroundColor),
-                    border: dataset.borderColor
-                }));
-                this.chart.chartColors = this.series.map(s => ({ backgroundColor: this.hex2rgb(s.bg, 90), borderColor:  this.hex2rgb(s.border, 90) }));
+                /* SDA CUSTOM */ this.series = this.chart.chartDataset.map((dataset, index) => {
+                /* SDA CUSTOM */     const chartColor = this.chart?.chartColors?.[index] || {};
+                /* SDA CUSTOM */     const bg = this.normalizeHexColor(dataset.backgroundColor, this.normalizeHexColor(chartColor.backgroundColor, '#67757c'));
+                /* SDA CUSTOM */     const border = this.normalizeHexColor(dataset.borderColor, this.normalizeHexColor(chartColor.borderColor, bg));
+                /* SDA CUSTOM */     return {
+                /* SDA CUSTOM */         label: dataset.label,
+                /* SDA CUSTOM */         bg,
+                /* SDA CUSTOM */         border
+                /* SDA CUSTOM */     };
+                /* SDA CUSTOM */ });
+                /* SDA CUSTOM */ this.chart.chartColors = this.series.map(s => ({ backgroundColor: this.hex2rgb(s.bg, 90), borderColor:  this.hex2rgb(s.border || s.bg, 100) }));
                 break;
         }
         if (!this.originalSeries || this.originalSeries.length === 0)
@@ -145,7 +150,7 @@ export class ChartDialogComponent extends EdaDialogAbstract  {
         if (this.chart.chartDataset) {
             const newDatasets = [];
             const dataset = this.chart.chartDataset;
-            
+
 
             for (let i = 0, n = dataset.length; i < n; i += 1) {
                 if (dataset[i].label === event.label) {
@@ -155,7 +160,7 @@ export class ChartDialogComponent extends EdaDialogAbstract  {
                 } else {
                     if (!_.isArray(dataset[i].backgroundColor)) {
                         dataset[i].backgroundColor = this.chart.chartColors[i].backgroundColor;
-                        dataset[i].borderColor = this.chart.chartColors[i].backgroundColor;
+                        /* SDA CUSTOM */ dataset[i].borderColor = this.chart.chartColors[i].borderColor || this.chart.chartColors[i].backgroundColor;
                         this.chart.chartColors[i] = _.pick(dataset[i], [  'backgroundColor', 'borderColor']);
                     } else {
                         if (this.chart.chartLabels) {
@@ -180,7 +185,7 @@ export class ChartDialogComponent extends EdaDialogAbstract  {
             //     for (let i = 0, n = dataset.length; i < n; i += 1) {
             //         if (dataset[i].label === event.label) {
             //             //dataset[i].hoverBackgroundColor = this.hex2rgb(event.bg, 90);
-            //             //dataset[i].hoverBorderColor = 'rgb(255,255,255)'; 
+            //             //dataset[i].hoverBorderColor = 'rgb(255,255,255)';
             //             dataset[i].backgroundColor = this.hex2rgb(event.bg, 90);
             //             dataset[i].borderColor = this.hex2rgb(event.bg, 100);
             //             this.chart.chartColors[i] = _.pick(dataset[i], [ 'backgroundColor', 'borderColor']);
@@ -224,7 +229,7 @@ export class ChartDialogComponent extends EdaDialogAbstract  {
         config.numberOfColumns = this.numberOfColumns;
         config.colors = this.chart.chartColors;
         properties.config = c;
-        /**Update chart */  
+        /**Update chart */
         this.panelChartConfig = new PanelChart(this.panelChartConfig);
         setTimeout(_ => {
             this.chart = this.panelChartComponent.componentRef.instance.inject;
@@ -287,7 +292,7 @@ export class ChartDialogComponent extends EdaDialogAbstract  {
         });
 
     }
-    
+
     setShowLables(){
 
         const properties = this.panelChartConfig;
@@ -316,6 +321,42 @@ export class ChartDialogComponent extends EdaDialogAbstract  {
             ('0' + parseInt(rgb[2], 10).toString(16)).slice(-2) +
             ('0' + parseInt(rgb[3], 10).toString(16)).slice(-2) : '';
     }
+
+    /* SDA CUSTOM */ // SDA CUSTOM - Normalize color values for dialog inputs
+    /**
+     * Normalizes a color input into a 6-digit hexadecimal string.
+     *
+     * Rules:
+     * - If the value is an array, the first element is used.
+     * - Accepts #RGB and expands it to #RRGGBB.
+     * - Accepts #RRGGBB and returns it unchanged.
+     * - Accepts rgb(...) / rgba(...) and converts it to hex using rgb2hex.
+     * - If the value cannot be normalized, returns fallback.
+     *
+     * @param color Color value to normalize.
+     * @param fallback Default value when the input is invalid.
+     * @returns A color in #RRGGBB format or fallback.
+     */
+    /* SDA CUSTOM */ private normalizeHexColor(color: any, fallback: string = ''): string {
+    /* SDA CUSTOM */     const resolvedColor = Array.isArray(color) ? color[0] : color;
+    /* SDA CUSTOM */     if (typeof resolvedColor !== 'string') {
+    /* SDA CUSTOM */         return fallback;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     const trimmed = resolvedColor.trim();
+    /* SDA CUSTOM */     const shortHexMatch = /^#([0-9a-fA-F]{3})$/.exec(trimmed);
+    /* SDA CUSTOM */     if (shortHexMatch) {
+    /* SDA CUSTOM */         const [r, g, b] = shortHexMatch[1].split('');
+    /* SDA CUSTOM */         return `#${r}${r}${g}${g}${b}${b}`;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     if (/^#([0-9a-fA-F]{6})$/.test(trimmed)) {
+    /* SDA CUSTOM */         return trimmed;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     if (/^rgba?\(/i.test(trimmed)) {
+    /* SDA CUSTOM */         return this.rgb2hex(trimmed) || fallback;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     return fallback;
+    /* SDA CUSTOM */ }
+    /* SDA CUSTOM */ // END SDA CUSTOM
 
     hex2rgb(hex, opacity = 100): string {
         hex = hex.replace('#', '');
@@ -387,7 +428,7 @@ export class ChartDialogComponent extends EdaDialogAbstract  {
 
         return haveDate && chartAllowed && onlyTwoCols && monthformat && aggregation;
 
-    } 
+    }
 
     onChangeDirection() {
     }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -312,6 +312,14 @@ export class EdaBlankPanelComponent implements OnInit {
 
     /* SDA CUSTOM */  public toggleLock() {
     /* SDA CUSTOM */    this.panel.locked = !this.panel.locked;
+    /* SDA CUSTOM */    if (this.panelChartConfig) {
+    /* SDA CUSTOM */      this.panelChartConfig.locked = this.panel.locked;
+    /* SDA CUSTOM */    }
+    /* SDA CUSTOM */    const showResizeControls = this.getEditMode() && !!this.inject?.canSave && !this.panel.locked;
+    /* SDA CUSTOM */    const chartInstance = this.panelChart?.componentRef?.instance;
+    /* SDA CUSTOM */    if (chartInstance?.inject) {
+    /* SDA CUSTOM */      chartInstance.inject.showResizeControls = showResizeControls;
+    /* SDA CUSTOM */    }
     /* SDA CUSTOM */    this.dashboardService._notSaved.next(true);
     /* SDA CUSTOM */  }
 
@@ -638,6 +646,9 @@ export class EdaBlankPanelComponent implements OnInit {
             maps: this.inject.dataSource.model.maps,
             size: { x: this.panel.w, y: this.panel.h },
             linkedDashboardProps: this.panel.linkedDashboardProps,
+            /* SDA CUSTOM */ canEdit: this.getEditMode(),
+            /* SDA CUSTOM */ canSave: !!this.inject?.canSave,
+            /* SDA CUSTOM */ locked: this.panel.locked,
         });
     }
 
@@ -1432,6 +1443,18 @@ export class EdaBlankPanelComponent implements OnInit {
         if (!_.isEqual(event, EdaDialogCloseEvent.NONE)) {
             this.panel.content.query.output.config.alertLimits = response.alerts;
             this.panel.content.query.output.config.sufix = response.sufix;
+            /* SDA CUSTOM */ this.panel.content.query.output.config.fontScale = response.fontScale;
+            /* SDA CUSTOM */ this.panel.content.query.output.config.lineWidth = response.lineWidth;
+            /* SDA CUSTOM */ this.panel.content.query.output.config.lineStyle = response.lineStyle;
+            /* SDA CUSTOM */ this.panel.content.query.output.config.showXAxis = response.showXAxis;
+            /* SDA CUSTOM */ this.panel.content.query.output.config.showXAxisLabels = response.showXAxisLabels;
+            /* SDA CUSTOM */ this.panel.content.query.output.config.xAxisLabelCount = response.xAxisLabelCount;
+            /* SDA CUSTOM */ // SDA CUSTOM - KPI chart label settings
+            /* SDA CUSTOM */ this.panel.content.query.output.config.labelColor = response.labelColor;
+            /* SDA CUSTOM */ this.panel.content.query.output.config.labelBackgroundColor = response.labelBackgroundColor;
+            /* SDA CUSTOM */ this.panel.content.query.output.config.showLabels = response.showLabels;
+            /* SDA CUSTOM */ this.panel.content.query.output.config.showLabelsPercent = response.showLabelsPercent;
+            /* SDA CUSTOM */ // END SDA CUSTOM
 
             let layout: any;
             if (response.edaChart) {
@@ -1450,7 +1473,24 @@ export class EdaBlankPanelComponent implements OnInit {
                 );
             }
 
-            const config = new ChartConfig(new KpiConfig({ sufix: response.sufix, alertLimits: response.alerts, edaChart: layout }));
+            /* SDA CUSTOM */ const config = new ChartConfig(new KpiConfig({
+                /* SDA CUSTOM */ sufix: response.sufix,
+                /* SDA CUSTOM */ fontScale: response.fontScale,
+                /* SDA CUSTOM */ alertLimits: response.alerts,
+                /* SDA CUSTOM */ edaChart: layout,
+                /* SDA CUSTOM */ color: response.color,
+                /* SDA CUSTOM */ lineWidth: response.lineWidth,
+                /* SDA CUSTOM */ lineStyle: response.lineStyle,
+                /* SDA CUSTOM */ showXAxis: response.showXAxis,
+                /* SDA CUSTOM */ showXAxisLabels: response.showXAxisLabels,
+                /* SDA CUSTOM */ xAxisLabelCount: response.xAxisLabelCount,
+                /* SDA CUSTOM */ // SDA CUSTOM - KPI chart label settings
+                /* SDA CUSTOM */ labelColor: response.labelColor,
+                /* SDA CUSTOM */ labelBackgroundColor: response.labelBackgroundColor,
+                /* SDA CUSTOM */ showLabels: response.showLabels,
+                /* SDA CUSTOM */ showLabelsPercent: response.showLabelsPercent,
+                /* SDA CUSTOM */ // END SDA CUSTOM
+            /* SDA CUSTOM */ }));
             this.renderChart(this.currentQuery, this.chartLabels, this.chartData, response.chartType, response.chartSubType, config);
             this.dashboardService._notSaved.next(true);
         }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.css
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.css
@@ -64,6 +64,7 @@ ul li:hover {
   padding: 2px 6px;
 }
 
+/* SDA CUSTOM - Responsive chart color row with container query */
 .chart-color-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(110px, 160px);
@@ -72,17 +73,30 @@ ul li:hover {
   min-height: 24px;
 }
 
+@container (max-width: 320px) {
+  .chart-color-row {
+    grid-template-columns: 1fr;
+  }
+
+  .chart-color-controls {
+    justify-content: flex-start;
+  }
+}
+/* END SDA CUSTOM */
+
 .chart-color-row--spaced {
   margin-top: 2px;
 }
 
+/* SDA CUSTOM - Label with wrap support for small containers */
 .chart-color-label {
-  white-space: nowrap;
+  white-space: normal;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  line-height: 1.1;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  line-height: 1.2;
 }
+/* END SDA CUSTOM */
 
 .chart-color-controls {
   display: flex;
@@ -166,6 +180,7 @@ ul li:hover {
   position: relative;
 }
 
+/* SDA CUSTOM - Container query context for responsive grid layout */
 .kpi-config-panel {
   max-height: 34vh;
   overflow-y: auto;
@@ -174,7 +189,9 @@ ul li:hover {
   flex-direction: column;
   gap: 4px;
   font-size: 12px;
+  container-type: inline-size;
 }
+/* END SDA CUSTOM */
 
 .kpi-config-section {
   padding: 6px 8px 8px 8px;

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.css
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.css
@@ -54,3 +54,133 @@ ul li:hover {
 .wrap-alert i:last-child {
   margin-left: auto;
 }
+
+.chart-color-input {
+  width: 76px !important;
+  min-width: 76px;
+  flex: 0 0 76px;
+  height: 26px;
+  font-size: 12px;
+  padding: 2px 6px;
+}
+
+.chart-color-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(110px, 160px);
+  align-items: center;
+  gap: 4px;
+  min-height: 24px;
+}
+
+.chart-color-row--spaced {
+  margin-top: 2px;
+}
+
+.chart-color-label {
+  white-space: nowrap;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.1;
+}
+
+.chart-color-controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.chart-color-picker .p-colorpicker-preview {
+  width: 26px;
+  height: 26px;
+  border-radius: 4px;
+}
+
+.chart-color-picker .p-colorpicker {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.line-style-dropdown {
+  width: 108px;
+}
+
+.line-style-dropdown .p-dropdown {
+  width: 100%;
+  height: 26px;
+  font-size: 12px;
+}
+
+.kpi-preview {
+  background-color: var(--panel-color);
+  width: 100%;
+  max-height: 24vh;
+  min-height: 150px;
+  border-radius: 6px;
+  overflow: hidden;
+  display: flex;
+}
+
+.kpi-preview .component,
+.kpi-preview panel-chart {
+  width: 100%;
+  height: 100%;
+}
+
+/* SDA CUSTOM - Compact KPI options panel with own scroll */
+.kpi-config-panel-wrapper {
+  position: relative;
+}
+
+.kpi-config-panel {
+  max-height: 34vh;
+  overflow-y: auto;
+  padding-right: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.kpi-config-section {
+  padding-bottom: 2px;
+  overflow: visible;
+}
+
+.kpi-config-section .custom-border-b1 {
+  margin-bottom: 2px;
+  font-size: 12px;
+  line-height: 1.1;
+  font-weight: bold;
+}
+
+.chart-color-selection {
+  row-gap: 2px;
+  overflow: visible;
+}
+
+.kpi-config-scroll-indicator {
+  position: sticky;
+  bottom: 0;
+  width: 100%;
+  height: 14px;
+  margin-top: -14px;
+  pointer-events: none;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.95));
+}
+/* END SDA CUSTOM */
+
+.kpi-config-panel .p-inputswitch {
+  height: 18px;
+  width: 34px;
+}
+
+.kpi-config-panel .p-inputswitch .p-inputswitch-slider::before {
+  width: 14px;
+  height: 14px;
+  margin-top: -7px;
+  margin-left: -7px;
+}

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.css
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.css
@@ -124,6 +124,37 @@ ul li:hover {
   display: flex;
 }
 
+.kpi-preview-sticky {
+  position: sticky;
+  top: 0.5rem;
+}
+
+.kpi-options-shell {
+  border: 1px solid #d7dde6;
+  border-radius: 10px;
+  background: #f7f9fc;
+  padding: 10px 10px 8px 10px;
+}
+
+.kpi-options-shell__header {
+  border-bottom: 1px solid #e3e8ef;
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+}
+
+.kpi-options-title {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.2;
+}
+
+.kpi-options-subtitle {
+  margin: 3px 0 0 0;
+  font-size: 11px;
+  line-height: 1.25;
+  color: #5f6b7a;
+}
+
 .kpi-preview .component,
 .kpi-preview panel-chart {
   width: 100%;
@@ -146,12 +177,56 @@ ul li:hover {
 }
 
 .kpi-config-section {
-  padding-bottom: 2px;
+  padding: 6px 8px 8px 8px;
+  border: 1px solid #d9e0ea;
+  border-radius: 8px;
+  background: #ffffff;
   overflow: visible;
 }
 
+.kpi-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 4px;
+  padding: 6px 8px;
+  border: 1px solid #dfe6f1;
+  border-radius: 6px;
+  background: #f4f7fb;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.kpi-section-head:hover {
+  background: #eef3fb;
+  border-color: #cfd9e8;
+}
+
+.kpi-config-section.is-expanded .kpi-section-head {
+  background: #eef3fb;
+  border-color: #c7d4e8;
+}
+
+.kpi-section-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.kpi-section-actions .pi {
+  font-size: 13px;
+  color: #43546a;
+}
+
+.kpi-section-head .p-button {
+  font-size: 11px;
+  padding: 0;
+}
+
 .kpi-config-section .custom-border-b1 {
-  margin-bottom: 2px;
+  margin: 0;
+  border-bottom: none !important;
   font-size: 12px;
   line-height: 1.1;
   font-weight: bold;
@@ -183,4 +258,10 @@ ul li:hover {
   height: 14px;
   margin-top: -7px;
   margin-left: -7px;
+}
+
+@media (max-width: 1200px) {
+  .kpi-preview-sticky {
+    position: static;
+  }
 }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
@@ -13,12 +13,12 @@
       <div class="kpi-config-panel-wrapper">
       <div class="kpi-config-panel">
           <div class="kpi-config-section">
-              <h6 i18n="@@colorsChartH6" class="custom-border-b1">
-                  Colores
+              <h6 i18n="@@kpiAppearanceH6" class="custom-border-b1">
+                Apariencia
               </h6>
               <div class="grid chart-color-selection">
                 <div class="col-12 chart-color-row">
-                  <span i18n="@@colorKpiLabel" class="chart-color-label">Color del KPI</span>
+                  <span i18n="@@kpiIndicatorColorLabel" class="chart-color-label">Color del indicador</span>
                   <span class="chart-color-controls">
                     <input type="text" [(ngModel)]="kpiColor" pInputText class="chart-color-input" (input)="applyKpiColor(120)" />
                     <span class="chart-color-picker">
@@ -28,7 +28,7 @@
                 </div>
                 <ng-container *ngFor="let serie of series; let i = index">
                   <div class="col-12 chart-color-row chart-color-row--spaced">
-                    <span *ngIf="i === 0 && !showChartFillColor" i18n="@@colorChartLabel" class="chart-color-label">Color del gráfico</span>
+                    <span *ngIf="i === 0 && !showChartFillColor" i18n="@@kpiSeriesColorLabel" class="chart-color-label">Color de la serie</span>
                     <span *ngIf="i === 0 && showChartFillColor" i18n="@@colorChartBorderLabel" class="chart-color-label">Color del borde</span>
                     <span class="chart-color-controls">
                       <input type="text" pInputText [(ngModel)]="serie.bg" class="chart-color-input" (input)="handleInputColor(serie, 120)" minlength="7" >
@@ -40,7 +40,7 @@
                 </ng-container>
                 <!-- SDA CUSTOM - KPI chart line color -->
                 <div class="col-12 chart-color-row chart-color-row--spaced" *ngIf="showChartLineColor">
-                  <span i18n="@@colorChartLineLabel" class="chart-color-label">Color de la línea</span>
+                  <span i18n="@@kpiLineColorLabel" class="chart-color-label">Color de línea</span>
                   <span class="chart-color-controls">
                     <input type="text" pInputText [(ngModel)]="chartLineColor" class="chart-color-input" (input)="applyChartLineColor(120)" minlength="7" >
                     <span class="chart-color-picker">
@@ -51,7 +51,7 @@
                 <!-- END SDA CUSTOM -->
                 <!-- SDA CUSTOM - KPI area fill color -->
                 <div class="col-12 chart-color-row chart-color-row--spaced" *ngIf="showChartFillColor">
-                  <span i18n="@@colorChartFillLabel" class="chart-color-label">Color de relleno</span>
+                  <span i18n="@@kpiAreaColorLabel" class="chart-color-label">Color de área</span>
                   <span class="chart-color-controls">
                     <input type="text" pInputText [(ngModel)]="chartFillColor" class="chart-color-input" (input)="applyChartFillColor(120)" minlength="7" >
                     <span class="chart-color-picker">
@@ -60,22 +60,14 @@
                   </span>
                 </div>
                 <!-- END SDA CUSTOM -->
-              </div>
-          </div>
-
-          <div class="kpi-config-section" *ngIf="showLineSettings">
-              <h6 i18n="@@kpiLineH6" class="custom-border-b1">
-                  Línea
-              </h6>
-              <div class="grid chart-color-selection">
-                <div class="col-12 chart-color-row">
-                  <span i18n="@@kpiLineWidthLabel" class="chart-color-label">Ancho de línea</span>
+                <div class="col-12 chart-color-row chart-color-row--spaced" *ngIf="showLineSettings">
+                  <span i18n="@@kpiLineWidthLabel" class="chart-color-label">Grosor de línea</span>
                   <span class="chart-color-controls">
                     <input type="number" min="1" max="10" step="1" [(ngModel)]="lineWidth" pInputText class="chart-color-input" (input)="applyLineStyle(120)" />
                   </span>
                 </div>
-                <div class="col-12 chart-color-row chart-color-row--spaced">
-                  <span i18n="@@kpiLineStyleLabel" class="chart-color-label">Estilo de línea</span>
+                <div class="col-12 chart-color-row chart-color-row--spaced" *ngIf="showLineSettings">
+                  <span i18n="@@kpiLineStyleLabel" class="chart-color-label">Tipo de línea</span>
                   <span class="chart-color-controls">
                     <p-dropdown class="line-style-dropdown" [options]="lineStyleOptions" optionLabel="label" optionValue="value" [(ngModel)]="lineStyle" (onChange)="applyLineStyle()" appendTo="body"></p-dropdown>
                   </span>
@@ -84,30 +76,30 @@
           </div>
 
           <div class="kpi-config-section" *ngIf="showAxisSettings">
-              <h6 i18n="@@kpiXAxisH6" class="custom-border-b1">
-                  Eje horizontal
+              <h6 i18n="@@kpiAxisScaleH6" class="custom-border-b1">
+                  Ejes y escala
               </h6>
               <div class="grid chart-color-selection">
                 <div class="col-12 chart-color-row">
-                  <span i18n="@@kpiXAxisShowLabel" class="chart-color-label">Mostrar eje</span>
+                  <span i18n="@@kpiXAxisShowLabel" class="chart-color-label">Mostrar eje X</span>
                   <span class="chart-color-controls">
                     <p-inputSwitch [(ngModel)]="showXAxis" (onChange)="applyXAxisSettings()"></p-inputSwitch>
                   </span>
                 </div>
                 <div class="col-12 chart-color-row chart-color-row--spaced">
-                  <span i18n="@@kpiXAxisLabelsLabel" class="chart-color-label">Mostrar etiquetas del eje</span>
+                  <span i18n="@@kpiXAxisLabelsLabel" class="chart-color-label">Mostrar etiquetas del eje X</span>
                   <span class="chart-color-controls">
                     <p-inputSwitch [(ngModel)]="showXAxisLabels" (onChange)="applyXAxisSettings()" [disabled]="!showXAxis"></p-inputSwitch>
                   </span>
                 </div>
                 <div class="col-12 chart-color-row chart-color-row--spaced">
-                  <span i18n="@@kpiXAxisAllLabelsLabel" class="chart-color-label">Todas las etiquetas</span>
+                  <span i18n="@@kpiXAxisAllLabelsLabel" class="chart-color-label">Mostrar todas las etiquetas</span>
                   <span class="chart-color-controls">
                     <p-inputSwitch [(ngModel)]="showAllXAxisLabels" (onChange)="toggleAllXAxisLabels()" [disabled]="!showXAxis || !showXAxisLabels"></p-inputSwitch>
                   </span>
                 </div>
                 <div class="col-12 chart-color-row chart-color-row--spaced">
-                  <span i18n="@@kpiXAxisLabelCountLabel" class="chart-color-label">Número de etiquetas</span>
+                  <span i18n="@@kpiXAxisLabelCountLabel" class="chart-color-label">Máximo de etiquetas</span>
                   <span class="chart-color-controls">
                     <input type="number" min="1" max="200" step="1" [(ngModel)]="xAxisLabelCount" pInputText class="chart-color-input" (input)="handleXAxisLabelCountInput(120)" [disabled]="!showXAxis || !showXAxisLabels || showAllXAxisLabels" />
                   </span>
@@ -117,25 +109,25 @@
 
           <!-- SDA CUSTOM - KPI chart label options -->
           <div class="kpi-config-section" *ngIf="showLabelSettings">
-              <h6 i18n="@@showValueLabels" class="custom-border-b1">
-                  Valores del gráfico
+              <h6 i18n="@@kpiLabelsValuesH6" class="custom-border-b1">
+                Etiquetas y valores
               </h6>
               <div class="grid chart-color-selection">
                 <div class="col-12 chart-color-row">
-                  <span i18n="@@showLabels" class="chart-color-label">Mostrar etiquetas del gráfico</span>
-                  <span class="chart-color-controls" [pTooltip]="showLablesTooltip" tooltipPosition="left">
+                  <span i18n="@@kpiShowValueLabelsLabel" class="chart-color-label">Mostrar valores en el gráfico</span>
+                  <span class="chart-color-controls" [pTooltip]="valueLabelsTooltip" tooltipPosition="left">
                     <p-inputSwitch [(ngModel)]="showLabels" (onChange)="setShowLabels()"></p-inputSwitch>
                   </span>
                 </div>
                 <div class="col-12 chart-color-row chart-color-row--spaced">
-                  <span i18n="@@showLabelsPercent" class="chart-color-label">Mostrar Etiquetas en Porcentajes</span>
-                  <span class="chart-color-controls" [pTooltip]="showLablesPercentTooltip" tooltipPosition="left">
+                  <span i18n="@@kpiShowValuePercentLabel" class="chart-color-label">Mostrar valores en porcentaje</span>
+                  <span class="chart-color-controls" [pTooltip]="valueLabelsPercentTooltip" tooltipPosition="left">
                     <p-inputSwitch [(ngModel)]="showLabelsPercent" (onChange)="setShowLabelsPercent()"></p-inputSwitch>
                   </span>
                 </div>
                 <!-- SDA CUSTOM - KPI label color option -->
                 <div class="col-12 chart-color-row chart-color-row--spaced">
-                  <span i18n="@@kpiLabelColorLabel" class="chart-color-label">Color de las etiquetas</span>
+                  <span i18n="@@kpiLabelColorLabel" class="chart-color-label">Color del texto de etiquetas</span>
                   <span class="chart-color-controls">
                     <input type="text" pInputText [(ngModel)]="labelColor" class="chart-color-input" (input)="setLabelColor(120)" minlength="7" >
                     <span class="chart-color-picker">
@@ -144,7 +136,7 @@
                   </span>
                 </div>
                 <div class="col-12 chart-color-row chart-color-row--spaced">
-                  <span i18n="@@kpiLabelBackgroundColorLabel" class="chart-color-label">Color de fondo de las etiquetas</span>
+                  <span i18n="@@kpiLabelBackgroundColorLabel" class="chart-color-label">Fondo de etiquetas</span>
                   <span class="chart-color-controls">
                     <input type="text" pInputText [(ngModel)]="labelBackgroundColor" class="chart-color-input" (input)="setLabelBackgroundColor(120)" minlength="7" >
                     <span class="chart-color-picker">

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
@@ -13,7 +13,7 @@
     <div class="col-4 col-offset-1">
       <div class="kpi-options-shell">
         <div class="kpi-options-shell__header">
-          <h5 i18n="@@kpiOptionsPanelTitle" class="kpi-options-title">Opciones de visualización</h5>
+          <h5 i18n="@@panelTitleOptions" class="kpi-options-title">Opciones de visualización</h5>
         </div>
       <!-- SDA CUSTOM - Compact options panel wrapper with internal scroll indicator -->
       <div class="kpi-config-panel-wrapper">
@@ -23,19 +23,19 @@
                 (click)="toggleSection('appearance')"
                 (keydown.enter)="toggleSection('appearance')"
                 (keydown.space)="toggleSection('appearance')">
-                <h6 i18n="@@kpiAppearanceH6" class="custom-border-b1">
+                <h6 i18n="@@appearanceSection" class="custom-border-b1">
                   Apariencia
                 </h6>
                 <div class="kpi-section-actions">
                   <i class="pi" [ngClass]="isAppearanceExpanded ? 'pi-chevron-up' : 'pi-chevron-down'"></i>
                   <button pButton type="button" class="p-button-text p-button-sm"
-                    (click)="$event.stopPropagation(); resetAppearanceSection()" i18n-label="@@kpiResetSectionButton" label="Restaurar">
+                    (click)="$event.stopPropagation(); resetAppearanceSection()" i18n-label="@@resetSectionButton" label="Restaurar">
                   </button>
                 </div>
               </div>
               <div class="grid chart-color-selection" *ngIf="isAppearanceExpanded">
                 <div class="col-12 chart-color-row">
-                  <span i18n="@@kpiIndicatorColorLabel" class="chart-color-label">Color del indicador</span>
+                  <span i18n="@@colorLabelIndicator" class="chart-color-label">Color del indicador</span>
                   <span class="chart-color-controls">
                     <input type="text" [(ngModel)]="kpiColor" pInputText class="chart-color-input" (input)="applyKpiColor(120)" />
                     <span class="chart-color-picker">
@@ -45,7 +45,7 @@
                 </div>
                 <ng-container *ngFor="let serie of series; let i = index">
                   <div class="col-12 chart-color-row chart-color-row--spaced">
-                    <span *ngIf="i === 0 && !showChartFillColor" i18n="@@kpiSeriesColorLabel" class="chart-color-label">Color de la serie</span>
+                    <span *ngIf="i === 0 && !showChartFillColor" i18n="@@colorLabelSeries" class="chart-color-label">Color de la serie</span>
                     <span *ngIf="i === 0 && showChartFillColor" i18n="@@colorChartBorderLabel" class="chart-color-label">Color del borde</span>
                     <span class="chart-color-controls">
                       <input type="text" pInputText [(ngModel)]="serie.bg" class="chart-color-input" (input)="handleInputColor(serie, 120)" minlength="7" >
@@ -57,7 +57,7 @@
                 </ng-container>
                 <!-- SDA CUSTOM - KPI chart line color -->
                 <div class="col-12 chart-color-row chart-color-row--spaced" *ngIf="showChartLineColor">
-                  <span i18n="@@kpiLineColorLabel" class="chart-color-label">Color de línea</span>
+                  <span i18n="@@colorLabelLine" class="chart-color-label">Color de línea</span>
                   <span class="chart-color-controls">
                     <input type="text" pInputText [(ngModel)]="chartLineColor" class="chart-color-input" (input)="applyChartLineColor(120)" minlength="7" >
                     <span class="chart-color-picker">
@@ -68,7 +68,7 @@
                 <!-- END SDA CUSTOM -->
                 <!-- SDA CUSTOM - KPI area fill color -->
                 <div class="col-12 chart-color-row chart-color-row--spaced" *ngIf="showChartFillColor">
-                  <span i18n="@@kpiAreaColorLabel" class="chart-color-label">Color de área</span>
+                  <span i18n="@@colorLabelArea" class="chart-color-label">Color de área</span>
                   <span class="chart-color-controls">
                     <input type="text" pInputText [(ngModel)]="chartFillColor" class="chart-color-input" (input)="applyChartFillColor(120)" minlength="7" >
                     <span class="chart-color-picker">
@@ -78,13 +78,13 @@
                 </div>
                 <!-- END SDA CUSTOM -->
                 <div class="col-12 chart-color-row chart-color-row--spaced" *ngIf="showLineSettings">
-                  <span i18n="@@kpiLineWidthLabel" class="chart-color-label">Grosor de línea</span>
+                  <span i18n="@@widthLabelLine" class="chart-color-label">Grosor de línea</span>
                   <span class="chart-color-controls">
                     <input type="number" min="1" max="10" step="1" [(ngModel)]="lineWidth" pInputText class="chart-color-input" (input)="applyLineStyle(120)" />
                   </span>
                 </div>
                 <div class="col-12 chart-color-row chart-color-row--spaced" *ngIf="showLineSettings">
-                  <span i18n="@@kpiLineStyleLabel" class="chart-color-label">Tipo de línea</span>
+                  <span i18n="@@lineStyleLabel" class="chart-color-label">Tipo de línea</span>
                   <span class="chart-color-controls">
                     <p-dropdown class="line-style-dropdown" [options]="lineStyleOptions" optionLabel="label" optionValue="value" [(ngModel)]="lineStyle" (onChange)="applyLineStyle()" appendTo="body"></p-dropdown>
                   </span>
@@ -97,37 +97,37 @@
                 (click)="toggleSection('axisScale')"
                 (keydown.enter)="toggleSection('axisScale')"
                 (keydown.space)="toggleSection('axisScale')">
-                <h6 i18n="@@kpiAxisScaleH6" class="custom-border-b1">
+                <h6 i18n="@@axisScaleH6" class="custom-border-b1">
                     Ejes y escala
                 </h6>
                 <div class="kpi-section-actions">
                   <i class="pi" [ngClass]="isAxisScaleExpanded ? 'pi-chevron-up' : 'pi-chevron-down'"></i>
                   <button pButton type="button" class="p-button-text p-button-sm"
-                    (click)="$event.stopPropagation(); resetAxisScaleSection()" i18n-label="@@kpiResetSectionButton" label="Restaurar">
+                    (click)="$event.stopPropagation(); resetAxisScaleSection()" i18n-label="@@resetSectionButton" label="Restaurar">
                   </button>
                 </div>
               </div>
               <div class="grid chart-color-selection" *ngIf="isAxisScaleExpanded">
                 <div class="col-12 chart-color-row">
-                  <span i18n="@@kpiXAxisShowLabel" class="chart-color-label">Mostrar eje X</span>
+                  <span i18n="@@xAxisShowLabel" class="chart-color-label">Mostrar eje X</span>
                   <span class="chart-color-controls">
                     <p-inputSwitch [(ngModel)]="showXAxis" (onChange)="applyXAxisSettings()"></p-inputSwitch>
                   </span>
                 </div>
                 <div class="col-12 chart-color-row chart-color-row--spaced">
-                  <span i18n="@@kpiXAxisLabelsLabel" class="chart-color-label">Mostrar etiquetas del eje X</span>
+                  <span i18n="@@xAxisLabelsLabel" class="chart-color-label">Mostrar etiquetas del eje X</span>
                   <span class="chart-color-controls">
                     <p-inputSwitch [(ngModel)]="showXAxisLabels" (onChange)="applyXAxisSettings()" [disabled]="!showXAxis"></p-inputSwitch>
                   </span>
                 </div>
                 <div class="col-12 chart-color-row chart-color-row--spaced">
-                  <span i18n="@@kpiXAxisAllLabelsLabel" class="chart-color-label">Mostrar todas las etiquetas</span>
+                  <span i18n="@@xAxisAllLabelsLabel" class="chart-color-label">Mostrar todas las etiquetas</span>
                   <span class="chart-color-controls">
                     <p-inputSwitch [(ngModel)]="showAllXAxisLabels" (onChange)="toggleAllXAxisLabels()" [disabled]="!showXAxis || !showXAxisLabels"></p-inputSwitch>
                   </span>
                 </div>
                 <div class="col-12 chart-color-row chart-color-row--spaced">
-                  <span i18n="@@kpiXAxisLabelCountLabel" class="chart-color-label">Máximo de etiquetas</span>
+                  <span i18n="@@xAxisLabelCountLabel" class="chart-color-label">Máximo de etiquetas</span>
                   <span class="chart-color-controls">
                     <input type="number" min="1" max="200" step="1" [(ngModel)]="xAxisLabelCount" pInputText class="chart-color-input" (input)="handleXAxisLabelCountInput(120)" [disabled]="!showXAxis || !showXAxisLabels || showAllXAxisLabels" />
                   </span>
@@ -141,32 +141,32 @@
                 (click)="toggleSection('labelsValues')"
                 (keydown.enter)="toggleSection('labelsValues')"
                 (keydown.space)="toggleSection('labelsValues')">
-                <h6 i18n="@@kpiLabelsValuesH6" class="custom-border-b1">
+                <h6 i18n="@@labelsValuesH6" class="custom-border-b1">
                   Etiquetas y valores
                 </h6>
                 <div class="kpi-section-actions">
                   <i class="pi" [ngClass]="isLabelsValuesExpanded ? 'pi-chevron-up' : 'pi-chevron-down'"></i>
                   <button pButton type="button" class="p-button-text p-button-sm"
-                    (click)="$event.stopPropagation(); resetLabelsValuesSection()" i18n-label="@@kpiResetSectionButton" label="Restaurar">
+                    (click)="$event.stopPropagation(); resetLabelsValuesSection()" i18n-label="@@resetSectionButton" label="Restaurar">
                   </button>
                 </div>
               </div>
               <div class="grid chart-color-selection" *ngIf="isLabelsValuesExpanded">
                 <div class="col-12 chart-color-row">
-                  <span i18n="@@kpiShowValueLabelsLabel" class="chart-color-label">Mostrar valores en el gráfico</span>
+                  <span i18n="@@showValueLabelsLabel" class="chart-color-label">Mostrar valores en el gráfico</span>
                   <span class="chart-color-controls" [pTooltip]="valueLabelsTooltip" tooltipPosition="left">
                     <p-inputSwitch [(ngModel)]="showLabels" (onChange)="setShowLabels()"></p-inputSwitch>
                   </span>
                 </div>
                 <div class="col-12 chart-color-row chart-color-row--spaced">
-                  <span i18n="@@kpiShowValuePercentLabel" class="chart-color-label">Mostrar valores en porcentaje</span>
+                  <span i18n="@@showValuePercentLabel" class="chart-color-label">Mostrar valores en porcentaje</span>
                   <span class="chart-color-controls" [pTooltip]="valueLabelsPercentTooltip" tooltipPosition="left">
                     <p-inputSwitch [(ngModel)]="showLabelsPercent" (onChange)="setShowLabelsPercent()"></p-inputSwitch>
                   </span>
                 </div>
                 <!-- SDA CUSTOM - KPI label color option -->
                 <div class="col-12 chart-color-row chart-color-row--spaced">
-                  <span i18n="@@kpiLabelColorLabel" class="chart-color-label">Color del texto de etiquetas</span>
+                  <span i18n="@@labelColorLabel" class="chart-color-label">Color del texto de etiquetas</span>
                   <span class="chart-color-controls">
                     <input type="text" pInputText [(ngModel)]="labelColor" class="chart-color-input" (input)="setLabelColor(120)" minlength="7" >
                     <span class="chart-color-picker">
@@ -175,7 +175,7 @@
                   </span>
                 </div>
                 <div class="col-12 chart-color-row chart-color-row--spaced">
-                  <span i18n="@@kpiLabelBackgroundColorLabel" class="chart-color-label">Fondo de etiquetas</span>
+                  <span i18n="@@labelBackgroundColorLabel" class="chart-color-label">Fondo de etiquetas</span>
                   <span class="chart-color-controls">
                     <input type="text" pInputText [(ngModel)]="labelBackgroundColor" class="chart-color-input" (input)="setLabelBackgroundColor(120)" minlength="7" >
                     <span class="chart-color-picker">

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
@@ -117,19 +117,19 @@
                 <div class="col-12 chart-color-row chart-color-row--spaced">
                   <span i18n="@@xAxisLabelsLabel" class="chart-color-label">Mostrar etiquetas del eje X</span>
                   <span class="chart-color-controls">
-                    <p-inputSwitch [(ngModel)]="showXAxisLabels" (onChange)="applyXAxisSettings()" [disabled]="!showXAxis"></p-inputSwitch>
+                    <p-inputSwitch [(ngModel)]="showXAxisLabels" (onChange)="applyXAxisSettings()"></p-inputSwitch>
                   </span>
                 </div>
                 <div class="col-12 chart-color-row chart-color-row--spaced">
                   <span i18n="@@xAxisAllLabelsLabel" class="chart-color-label">Mostrar todas las etiquetas</span>
                   <span class="chart-color-controls">
-                    <p-inputSwitch [(ngModel)]="showAllXAxisLabels" (onChange)="toggleAllXAxisLabels()" [disabled]="!showXAxis || !showXAxisLabels"></p-inputSwitch>
+                    <p-inputSwitch [(ngModel)]="showAllXAxisLabels" (onChange)="toggleAllXAxisLabels()" [disabled]="!showXAxisLabels"></p-inputSwitch>
                   </span>
                 </div>
                 <div class="col-12 chart-color-row chart-color-row--spaced">
                   <span i18n="@@xAxisLabelCountLabel" class="chart-color-label">Máximo de etiquetas</span>
                   <span class="chart-color-controls">
-                    <input type="number" min="1" max="200" step="1" [(ngModel)]="xAxisLabelCount" pInputText class="chart-color-input" (input)="handleXAxisLabelCountInput(120)" [disabled]="!showXAxis || !showXAxisLabels || showAllXAxisLabels" />
+                    <input type="number" min="1" max="200" step="1" [(ngModel)]="xAxisLabelCount" pInputText class="chart-color-input" (input)="handleXAxisLabelCountInput(120)" [disabled]="!showXAxisLabels || showAllXAxisLabels" />
                   </span>
                 </div>
               </div>

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
@@ -2,21 +2,38 @@
 
   <div body class="grid h-100 p-5">
 
-    <div class="col-7">
-      <div class="kpi-preview" [style.aspect-ratio]="previewAspectRatio">
-        <panel-chart *ngIf="display" #PanelChartComponent [props]="panelChartConfig" class="component"></panel-chart>
+    <div class="col-7 kpi-preview-column">
+      <div class="kpi-preview-sticky">
+        <div class="kpi-preview" [style.aspect-ratio]="previewAspectRatio">
+          <panel-chart *ngIf="display" #PanelChartComponent [props]="panelChartConfig" class="component"></panel-chart>
+        </div>
       </div>
     </div>
 
     <div class="col-4 col-offset-1">
+      <div class="kpi-options-shell">
+        <div class="kpi-options-shell__header">
+          <h5 i18n="@@kpiOptionsPanelTitle" class="kpi-options-title">Opciones de visualización</h5>
+        </div>
       <!-- SDA CUSTOM - Compact options panel wrapper with internal scroll indicator -->
       <div class="kpi-config-panel-wrapper">
       <div class="kpi-config-panel">
-          <div class="kpi-config-section">
-              <h6 i18n="@@kpiAppearanceH6" class="custom-border-b1">
-                Apariencia
-              </h6>
-              <div class="grid chart-color-selection">
+          <div class="kpi-config-section" [class.is-expanded]="isAppearanceExpanded">
+              <div class="kpi-section-head" role="button" tabindex="0"
+                (click)="toggleSection('appearance')"
+                (keydown.enter)="toggleSection('appearance')"
+                (keydown.space)="toggleSection('appearance')">
+                <h6 i18n="@@kpiAppearanceH6" class="custom-border-b1">
+                  Apariencia
+                </h6>
+                <div class="kpi-section-actions">
+                  <i class="pi" [ngClass]="isAppearanceExpanded ? 'pi-chevron-up' : 'pi-chevron-down'"></i>
+                  <button pButton type="button" class="p-button-text p-button-sm"
+                    (click)="$event.stopPropagation(); resetAppearanceSection()" i18n-label="@@kpiResetSectionButton" label="Restaurar">
+                  </button>
+                </div>
+              </div>
+              <div class="grid chart-color-selection" *ngIf="isAppearanceExpanded">
                 <div class="col-12 chart-color-row">
                   <span i18n="@@kpiIndicatorColorLabel" class="chart-color-label">Color del indicador</span>
                   <span class="chart-color-controls">
@@ -75,11 +92,22 @@
               </div>
           </div>
 
-          <div class="kpi-config-section" *ngIf="showAxisSettings">
-              <h6 i18n="@@kpiAxisScaleH6" class="custom-border-b1">
-                  Ejes y escala
-              </h6>
-              <div class="grid chart-color-selection">
+          <div class="kpi-config-section" *ngIf="showAxisSettings" [class.is-expanded]="isAxisScaleExpanded">
+              <div class="kpi-section-head" role="button" tabindex="0"
+                (click)="toggleSection('axisScale')"
+                (keydown.enter)="toggleSection('axisScale')"
+                (keydown.space)="toggleSection('axisScale')">
+                <h6 i18n="@@kpiAxisScaleH6" class="custom-border-b1">
+                    Ejes y escala
+                </h6>
+                <div class="kpi-section-actions">
+                  <i class="pi" [ngClass]="isAxisScaleExpanded ? 'pi-chevron-up' : 'pi-chevron-down'"></i>
+                  <button pButton type="button" class="p-button-text p-button-sm"
+                    (click)="$event.stopPropagation(); resetAxisScaleSection()" i18n-label="@@kpiResetSectionButton" label="Restaurar">
+                  </button>
+                </div>
+              </div>
+              <div class="grid chart-color-selection" *ngIf="isAxisScaleExpanded">
                 <div class="col-12 chart-color-row">
                   <span i18n="@@kpiXAxisShowLabel" class="chart-color-label">Mostrar eje X</span>
                   <span class="chart-color-controls">
@@ -108,11 +136,22 @@
           </div>
 
           <!-- SDA CUSTOM - KPI chart label options -->
-          <div class="kpi-config-section" *ngIf="showLabelSettings">
-              <h6 i18n="@@kpiLabelsValuesH6" class="custom-border-b1">
-                Etiquetas y valores
-              </h6>
-              <div class="grid chart-color-selection">
+          <div class="kpi-config-section" *ngIf="showLabelSettings" [class.is-expanded]="isLabelsValuesExpanded">
+              <div class="kpi-section-head" role="button" tabindex="0"
+                (click)="toggleSection('labelsValues')"
+                (keydown.enter)="toggleSection('labelsValues')"
+                (keydown.space)="toggleSection('labelsValues')">
+                <h6 i18n="@@kpiLabelsValuesH6" class="custom-border-b1">
+                  Etiquetas y valores
+                </h6>
+                <div class="kpi-section-actions">
+                  <i class="pi" [ngClass]="isLabelsValuesExpanded ? 'pi-chevron-up' : 'pi-chevron-down'"></i>
+                  <button pButton type="button" class="p-button-text p-button-sm"
+                    (click)="$event.stopPropagation(); resetLabelsValuesSection()" i18n-label="@@kpiResetSectionButton" label="Restaurar">
+                  </button>
+                </div>
+              </div>
+              <div class="grid chart-color-selection" *ngIf="isLabelsValuesExpanded">
                 <div class="col-12 chart-color-row">
                   <span i18n="@@kpiShowValueLabelsLabel" class="chart-color-label">Mostrar valores en el gráfico</span>
                   <span class="chart-color-controls" [pTooltip]="valueLabelsTooltip" tooltipPosition="left">
@@ -152,6 +191,7 @@
         <div class="kpi-config-scroll-indicator" aria-hidden="true"></div>
         </div>
         <!-- END SDA CUSTOM -->
+      </div>
     </div>
 
     <div class="col-12 mt-2">

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
@@ -39,7 +39,7 @@
                   <span class="chart-color-controls">
                     <input type="text" [(ngModel)]="kpiColor" pInputText class="chart-color-input" (input)="applyKpiColor(120)" />
                     <span class="chart-color-picker">
-                      <p-colorPicker [(ngModel)]="kpiColor" appendTo="body" (onChange)="applyKpiColor()"></p-colorPicker>
+                      <p-colorPicker [(ngModel)]="kpiColor" appendTo="body" (onChange)="applyKpiColor(0, true)"></p-colorPicker>
                     </span>
                   </span>
                 </div>
@@ -50,7 +50,7 @@
                     <span class="chart-color-controls">
                       <input type="text" pInputText [(ngModel)]="serie.bg" class="chart-color-input" (input)="handleInputColor(serie, 120)" minlength="7" >
                       <span class="chart-color-picker">
-                        <p-colorPicker [(ngModel)]="serie.bg" (onChange)="handleInputColor(serie)" format="hex" appendTo="body"></p-colorPicker>
+                        <p-colorPicker [(ngModel)]="serie.bg" (onChange)="handleInputColor(serie, 0, true)" format="hex" appendTo="body"></p-colorPicker>
                       </span>
                     </span>
                   </div>
@@ -61,7 +61,7 @@
                   <span class="chart-color-controls">
                     <input type="text" pInputText [(ngModel)]="chartLineColor" class="chart-color-input" (input)="applyChartLineColor(120)" minlength="7" >
                     <span class="chart-color-picker">
-                      <p-colorPicker [(ngModel)]="chartLineColor" (onChange)="applyChartLineColor()" format="hex" appendTo="body"></p-colorPicker>
+                      <p-colorPicker [(ngModel)]="chartLineColor" (onChange)="applyChartLineColor(0, true)" format="hex" appendTo="body"></p-colorPicker>
                     </span>
                   </span>
                 </div>
@@ -72,7 +72,7 @@
                   <span class="chart-color-controls">
                     <input type="text" pInputText [(ngModel)]="chartFillColor" class="chart-color-input" (input)="applyChartFillColor(120)" minlength="7" >
                     <span class="chart-color-picker">
-                      <p-colorPicker [(ngModel)]="chartFillColor" (onChange)="applyChartFillColor()" format="hex" appendTo="body"></p-colorPicker>
+                      <p-colorPicker [(ngModel)]="chartFillColor" (onChange)="applyChartFillColor(0, true)" format="hex" appendTo="body"></p-colorPicker>
                     </span>
                   </span>
                 </div>
@@ -170,7 +170,7 @@
                   <span class="chart-color-controls">
                     <input type="text" pInputText [(ngModel)]="labelColor" class="chart-color-input" (input)="setLabelColor(120)" minlength="7" >
                     <span class="chart-color-picker">
-                      <p-colorPicker [(ngModel)]="labelColor" (onChange)="setLabelColor()" format="hex" appendTo="body"></p-colorPicker>
+                      <p-colorPicker [(ngModel)]="labelColor" (onChange)="setLabelColor(0, true)" format="hex" appendTo="body"></p-colorPicker>
                     </span>
                   </span>
                 </div>
@@ -179,7 +179,7 @@
                   <span class="chart-color-controls">
                     <input type="text" pInputText [(ngModel)]="labelBackgroundColor" class="chart-color-input" (input)="setLabelBackgroundColor(120)" minlength="7" >
                     <span class="chart-color-picker">
-                      <p-colorPicker [(ngModel)]="labelBackgroundColor" (onChange)="setLabelBackgroundColor()" format="hex" appendTo="body"></p-colorPicker>
+                      <p-colorPicker [(ngModel)]="labelBackgroundColor" (onChange)="setLabelBackgroundColor(0, true)" format="hex" appendTo="body"></p-colorPicker>
                     </span>
                   </span>
                 </div>

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.html
@@ -1,31 +1,168 @@
 <eda-dialog [inject]="dialog">
-  
+
   <div body class="grid h-100 p-5">
 
-    <div class="col-7" style="background-color: var(--panel-color); width: 90%; height: 15vh;">
-      <panel-chart *ngIf="display" #PanelChartComponent [props]="panelChartConfig" class="component"></panel-chart>
+    <div class="col-7">
+      <div class="kpi-preview" [style.aspect-ratio]="previewAspectRatio">
+        <panel-chart *ngIf="display" #PanelChartComponent [props]="panelChartConfig" class="component"></panel-chart>
+      </div>
     </div>
 
     <div class="col-4 col-offset-1">
-
-        <div class="col-12">
-            <h6 i18n="@@colorsChartH6" class="custom-border-b1">
-                Colores
-            </h6>
-            <div class="grid chart-color-selection">
+      <!-- SDA CUSTOM - Compact options panel wrapper with internal scroll indicator -->
+      <div class="kpi-config-panel-wrapper">
+      <div class="kpi-config-panel">
+          <div class="kpi-config-section">
+              <h6 i18n="@@colorsChartH6" class="custom-border-b1">
+                  Colores
+              </h6>
+              <div class="grid chart-color-selection">
+                <div class="col-12 chart-color-row">
+                  <span i18n="@@colorKpiLabel" class="chart-color-label">Color del KPI</span>
+                  <span class="chart-color-controls">
+                    <input type="text" [(ngModel)]="kpiColor" pInputText class="chart-color-input" (input)="applyKpiColor(120)" />
+                    <span class="chart-color-picker">
+                      <p-colorPicker [(ngModel)]="kpiColor" appendTo="body" (onChange)="applyKpiColor()"></p-colorPicker>
+                    </span>
+                  </span>
+                </div>
                 <ng-container *ngFor="let serie of series; let i = index">
-                    <div class=" col-6 ">
-                        <input type="text" pInputText style="width: 40%" [value]="serie.label" disabled="true" [style.border-color]="serie.border" />
+                  <div class="col-12 chart-color-row chart-color-row--spaced">
+                    <span *ngIf="i === 0 && !showChartFillColor" i18n="@@colorChartLabel" class="chart-color-label">Color del gráfico</span>
+                    <span *ngIf="i === 0 && showChartFillColor" i18n="@@colorChartBorderLabel" class="chart-color-label">Color del borde</span>
+                    <span class="chart-color-controls">
+                      <input type="text" pInputText [(ngModel)]="serie.bg" class="chart-color-input" (input)="handleInputColor(serie, 120)" minlength="7" >
+                      <span class="chart-color-picker">
                         <p-colorPicker [(ngModel)]="serie.bg" (onChange)="handleInputColor(serie)" format="hex" appendTo="body"></p-colorPicker>
-                        <input type="text" pInputText class="eda-color-pick" [(ngModel)]="serie.bg" (input)="handleInputColor(serie)" minlength="7" >
-                    </div>
+                      </span>
+                    </span>
+                  </div>
                 </ng-container>
-            </div>
-        </div>
+                <!-- SDA CUSTOM - KPI chart line color -->
+                <div class="col-12 chart-color-row chart-color-row--spaced" *ngIf="showChartLineColor">
+                  <span i18n="@@colorChartLineLabel" class="chart-color-label">Color de la línea</span>
+                  <span class="chart-color-controls">
+                    <input type="text" pInputText [(ngModel)]="chartLineColor" class="chart-color-input" (input)="applyChartLineColor(120)" minlength="7" >
+                    <span class="chart-color-picker">
+                      <p-colorPicker [(ngModel)]="chartLineColor" (onChange)="applyChartLineColor()" format="hex" appendTo="body"></p-colorPicker>
+                    </span>
+                  </span>
+                </div>
+                <!-- END SDA CUSTOM -->
+                <!-- SDA CUSTOM - KPI area fill color -->
+                <div class="col-12 chart-color-row chart-color-row--spaced" *ngIf="showChartFillColor">
+                  <span i18n="@@colorChartFillLabel" class="chart-color-label">Color de relleno</span>
+                  <span class="chart-color-controls">
+                    <input type="text" pInputText [(ngModel)]="chartFillColor" class="chart-color-input" (input)="applyChartFillColor(120)" minlength="7" >
+                    <span class="chart-color-picker">
+                      <p-colorPicker [(ngModel)]="chartFillColor" (onChange)="applyChartFillColor()" format="hex" appendTo="body"></p-colorPicker>
+                    </span>
+                  </span>
+                </div>
+                <!-- END SDA CUSTOM -->
+              </div>
+          </div>
 
+          <div class="kpi-config-section" *ngIf="showLineSettings">
+              <h6 i18n="@@kpiLineH6" class="custom-border-b1">
+                  Línea
+              </h6>
+              <div class="grid chart-color-selection">
+                <div class="col-12 chart-color-row">
+                  <span i18n="@@kpiLineWidthLabel" class="chart-color-label">Ancho de línea</span>
+                  <span class="chart-color-controls">
+                    <input type="number" min="1" max="10" step="1" [(ngModel)]="lineWidth" pInputText class="chart-color-input" (input)="applyLineStyle(120)" />
+                  </span>
+                </div>
+                <div class="col-12 chart-color-row chart-color-row--spaced">
+                  <span i18n="@@kpiLineStyleLabel" class="chart-color-label">Estilo de línea</span>
+                  <span class="chart-color-controls">
+                    <p-dropdown class="line-style-dropdown" [options]="lineStyleOptions" optionLabel="label" optionValue="value" [(ngModel)]="lineStyle" (onChange)="applyLineStyle()" appendTo="body"></p-dropdown>
+                  </span>
+                </div>
+              </div>
+          </div>
+
+          <div class="kpi-config-section" *ngIf="showAxisSettings">
+              <h6 i18n="@@kpiXAxisH6" class="custom-border-b1">
+                  Eje horizontal
+              </h6>
+              <div class="grid chart-color-selection">
+                <div class="col-12 chart-color-row">
+                  <span i18n="@@kpiXAxisShowLabel" class="chart-color-label">Mostrar eje</span>
+                  <span class="chart-color-controls">
+                    <p-inputSwitch [(ngModel)]="showXAxis" (onChange)="applyXAxisSettings()"></p-inputSwitch>
+                  </span>
+                </div>
+                <div class="col-12 chart-color-row chart-color-row--spaced">
+                  <span i18n="@@kpiXAxisLabelsLabel" class="chart-color-label">Mostrar etiquetas del eje</span>
+                  <span class="chart-color-controls">
+                    <p-inputSwitch [(ngModel)]="showXAxisLabels" (onChange)="applyXAxisSettings()" [disabled]="!showXAxis"></p-inputSwitch>
+                  </span>
+                </div>
+                <div class="col-12 chart-color-row chart-color-row--spaced">
+                  <span i18n="@@kpiXAxisAllLabelsLabel" class="chart-color-label">Todas las etiquetas</span>
+                  <span class="chart-color-controls">
+                    <p-inputSwitch [(ngModel)]="showAllXAxisLabels" (onChange)="toggleAllXAxisLabels()" [disabled]="!showXAxis || !showXAxisLabels"></p-inputSwitch>
+                  </span>
+                </div>
+                <div class="col-12 chart-color-row chart-color-row--spaced">
+                  <span i18n="@@kpiXAxisLabelCountLabel" class="chart-color-label">Número de etiquetas</span>
+                  <span class="chart-color-controls">
+                    <input type="number" min="1" max="200" step="1" [(ngModel)]="xAxisLabelCount" pInputText class="chart-color-input" (input)="handleXAxisLabelCountInput(120)" [disabled]="!showXAxis || !showXAxisLabels || showAllXAxisLabels" />
+                  </span>
+                </div>
+              </div>
+          </div>
+
+          <!-- SDA CUSTOM - KPI chart label options -->
+          <div class="kpi-config-section" *ngIf="showLabelSettings">
+              <h6 i18n="@@showValueLabels" class="custom-border-b1">
+                  Valores del gráfico
+              </h6>
+              <div class="grid chart-color-selection">
+                <div class="col-12 chart-color-row">
+                  <span i18n="@@showLabels" class="chart-color-label">Mostrar etiquetas del gráfico</span>
+                  <span class="chart-color-controls" [pTooltip]="showLablesTooltip" tooltipPosition="left">
+                    <p-inputSwitch [(ngModel)]="showLabels" (onChange)="setShowLabels()"></p-inputSwitch>
+                  </span>
+                </div>
+                <div class="col-12 chart-color-row chart-color-row--spaced">
+                  <span i18n="@@showLabelsPercent" class="chart-color-label">Mostrar Etiquetas en Porcentajes</span>
+                  <span class="chart-color-controls" [pTooltip]="showLablesPercentTooltip" tooltipPosition="left">
+                    <p-inputSwitch [(ngModel)]="showLabelsPercent" (onChange)="setShowLabelsPercent()"></p-inputSwitch>
+                  </span>
+                </div>
+                <!-- SDA CUSTOM - KPI label color option -->
+                <div class="col-12 chart-color-row chart-color-row--spaced">
+                  <span i18n="@@kpiLabelColorLabel" class="chart-color-label">Color de las etiquetas</span>
+                  <span class="chart-color-controls">
+                    <input type="text" pInputText [(ngModel)]="labelColor" class="chart-color-input" (input)="setLabelColor(120)" minlength="7" >
+                    <span class="chart-color-picker">
+                      <p-colorPicker [(ngModel)]="labelColor" (onChange)="setLabelColor()" format="hex" appendTo="body"></p-colorPicker>
+                    </span>
+                  </span>
+                </div>
+                <div class="col-12 chart-color-row chart-color-row--spaced">
+                  <span i18n="@@kpiLabelBackgroundColorLabel" class="chart-color-label">Color de fondo de las etiquetas</span>
+                  <span class="chart-color-controls">
+                    <input type="text" pInputText [(ngModel)]="labelBackgroundColor" class="chart-color-input" (input)="setLabelBackgroundColor(120)" minlength="7" >
+                    <span class="chart-color-picker">
+                      <p-colorPicker [(ngModel)]="labelBackgroundColor" (onChange)="setLabelBackgroundColor()" format="hex" appendTo="body"></p-colorPicker>
+                    </span>
+                  </span>
+                </div>
+                <!-- END SDA CUSTOM -->
+              </div>
+          </div>
+          <!-- END SDA CUSTOM -->
+        </div>
+        <div class="kpi-config-scroll-indicator" aria-hidden="true"></div>
+        </div>
+        <!-- END SDA CUSTOM -->
     </div>
 
-    <div class="col-12 mt-5">
+    <div class="col-12 mt-2">
       <h6 i18n="@@kpiAlertH6" class="custom-border-b1">
         Generar alerta
       </h6>
@@ -91,6 +228,7 @@
               </div>
             </li>
           </ul>
+
         </div>
       </div>
     </div>
@@ -161,7 +299,7 @@
 
       </div>
 
-      <div class="col-12"> 
+      <div class="col-12">
         <h6 *ngIf="!enabled" i18n="@@noMail">Sin alertas de correo</h6>
         <h6 *ngIf="enabled" i18n="@@opcionMail">Enviar per email</h6>
         <p-inputSwitch id="switchCache" class="col-1" [(ngModel)]="enabled" tooltipPosition="left">

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
@@ -42,8 +42,8 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     /* SDA CUSTOM */ public showLabelsPercent: boolean = false;
     /* SDA CUSTOM */ public labelColor: string = '#000000';
     /* SDA CUSTOM */ public labelBackgroundColor: string = '';
-    /* SDA CUSTOM */ public showLablesTooltip: string = $localize`:@@showLablesTooltip:Mostrar o ocultar las etiquetas sobre los gráficos`;
-    /* SDA CUSTOM */ public showLablesPercentTooltip: string = $localize`:@@showLablesPercentTooltip:Mostrar o ocultar las etiquetas en porcentaje sobre los gráficos`;
+    /* SDA CUSTOM */ public valueLabelsTooltip: string = $localize`:@@kpiValueLabelsTooltip:Mostrar u ocultar los valores en el gráfico`;
+    /* SDA CUSTOM */ public valueLabelsPercentTooltip: string = $localize`:@@kpiValueLabelsPercentTooltip:Mostrar u ocultar los valores en porcentaje en el gráfico`;
     /* SDA CUSTOM */ // END SDA CUSTOM
     /* SDA CUSTOM */ public lineStyleOptions = [
         /* SDA CUSTOM */ { label: $localize`:@@kpiLineStyleSolid:Sólida`, value: 'solid' },

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
@@ -535,6 +535,9 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     /* SDA CUSTOM */     this.labelBackgroundColor = this.normalizeHexColor(this.labelBackgroundColor, '');
     /* SDA CUSTOM */     this.edaChart.chartOptions.plugins.datalabels.color = this.labelColor;
     /* SDA CUSTOM */     this.edaChart.chartOptions.plugins.datalabels.backgroundColor = this.labelBackgroundColor || null;
+    /* SDA CUSTOM */     if (this.panelChartConfig?.chartType === 'kpibar') {
+    /* SDA CUSTOM */         this.edaChart.chartOptions.plugins.datalabels.borderRadius = 4;
+    /* SDA CUSTOM */     }
     /* SDA CUSTOM */     this.syncKpiLiveConfig();
     /* SDA CUSTOM */     if (softPreview) {
     /* SDA CUSTOM */         this.schedulePreviewUpdate(debounceMs);
@@ -570,7 +573,7 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
         /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.display = this.showXAxis;
         /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.display = this.showXAxis && this.showXAxisLabels;
         /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.maxTicksLimit = maxTicksLimit || undefined;
-        /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.autoSkip = useAll;
+        /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.autoSkip = !useAll;
         /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.callback = this.buildXAxisTickCallback(
             /* SDA CUSTOM */ useAll,
             /* SDA CUSTOM */ labelsLength,
@@ -588,8 +591,16 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
         /* SDA CUSTOM */ labelCount: number,
         /* SDA CUSTOM */ chartLabels: any[]
     /* SDA CUSTOM */ ): ((value: any, index: number) => string) | undefined {
-        /* SDA CUSTOM */ if (useAll || labelsLength === 0 || !labelCount || labelCount <= 0) {
+        /* SDA CUSTOM */ if (labelsLength === 0) {
             /* SDA CUSTOM */ return undefined;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ if (useAll || !labelCount || labelCount <= 0) {
+            /* SDA CUSTOM */ return (value, index) => {
+                /* SDA CUSTOM */ const label = Array.isArray(chartLabels)
+                    /* SDA CUSTOM */ ? (chartLabels[index] ?? chartLabels[value])
+                    /* SDA CUSTOM */ : value;
+                /* SDA CUSTOM */ return `${label ?? ''}`;
+            /* SDA CUSTOM */ };
         /* SDA CUSTOM */ }
         /* SDA CUSTOM */ const maxCount = Math.min(labelCount, labelsLength);
         /* SDA CUSTOM */ if (maxCount <= 1) {

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
@@ -569,9 +569,16 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
         /* SDA CUSTOM */ if (!this.edaChart.chartOptions.scales.x.ticks) {
             /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks = {};
         /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ if (!this.edaChart.chartOptions.scales.x.grid) {
+            /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.grid = {};
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ if (!this.edaChart.chartOptions.scales.x.border) {
+            /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.border = {};
+        /* SDA CUSTOM */ }
 
-        /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.display = this.showXAxis;
-        /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.display = this.showXAxis && this.showXAxisLabels;
+        /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.display = this.showXAxis || this.showXAxisLabels;
+        /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.grid.drawBorder = this.showXAxis;
+        /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.display = this.showXAxisLabels;
         /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.maxTicksLimit = maxTicksLimit || undefined;
         /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.autoSkip = !useAll;
         /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.callback = this.buildXAxisTickCallback(
@@ -580,9 +587,6 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
             /* SDA CUSTOM */ this.xAxisLabelCount,
             /* SDA CUSTOM */ this.edaChart.chartLabels
         /* SDA CUSTOM */ );
-        /* SDA CUSTOM */ if (this.edaChart.chartOptions.scales.x.grid) {
-            /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.grid.display = this.showXAxis ? this.edaChart.chartOptions.scales.x.grid.display : false;
-        /* SDA CUSTOM */ }
     /* SDA CUSTOM */ }
 
     /* SDA CUSTOM */ private buildXAxisTickCallback(

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
@@ -44,13 +44,13 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     /* SDA CUSTOM */ public showLabelsPercent: boolean = false;
     /* SDA CUSTOM */ public labelColor: string = '#000000';
     /* SDA CUSTOM */ public labelBackgroundColor: string = '';
-    /* SDA CUSTOM */ public valueLabelsTooltip: string = $localize`:@@kpiValueLabelsTooltip:Mostrar u ocultar los valores en el gráfico`;
-    /* SDA CUSTOM */ public valueLabelsPercentTooltip: string = $localize`:@@kpiValueLabelsPercentTooltip:Mostrar u ocultar los valores en porcentaje en el gráfico`;
+    /* SDA CUSTOM */ public valueLabelsTooltip: string = $localize`:@@valueLabelsTooltip:Mostrar u ocultar los valores en el gráfico`;
+    /* SDA CUSTOM */ public valueLabelsPercentTooltip: string = $localize`:@@valueLabelsPercentTooltip:Mostrar u ocultar los valores en porcentaje en el gráfico`;
     /* SDA CUSTOM */ // END SDA CUSTOM
     /* SDA CUSTOM */ public lineStyleOptions = [
-        /* SDA CUSTOM */ { label: $localize`:@@kpiLineStyleSolid:Sólida`, value: 'solid' },
-        /* SDA CUSTOM */ { label: $localize`:@@kpiLineStyleDashed:Discontinua`, value: 'dashed' },
-        /* SDA CUSTOM */ { label: $localize`:@@kpiLineStyleDotted:Punteada`, value: 'dotted' }
+        /* SDA CUSTOM */ { label: $localize`:@@lineStyleSolid:Sólida`, value: 'solid' },
+        /* SDA CUSTOM */ { label: $localize`:@@lineStyleDashed:Discontinua`, value: 'dashed' },
+        /* SDA CUSTOM */ { label: $localize`:@@lineStyleDotted:Punteada`, value: 'dotted' }
     /* SDA CUSTOM */ ];
 
     public units: string;

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
@@ -19,6 +19,7 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
 
     public dialog: EdaDialog;
     public panelChartConfig: PanelChart = new PanelChart();
+    /* SDA CUSTOM */ public previewAspectRatio: string = '16 / 9';
 
     public value: number;
     public operand: string;
@@ -26,6 +27,29 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     public alerts: Array<any> = [];
     public alertInfo: string = $localize`:@@alertsInfo: Cuando el valor del kpi sea (=, <,>) que el valor definido cambiará el color del texto`;
     public ptooltipViewAlerts: string = $localize`:@@ptooltipViewAlerts:Configurar alertas`;
+    /* SDA CUSTOM */ public kpiColor: string = '';
+    /* SDA CUSTOM */ public lineWidth: number = 2;
+    /* SDA CUSTOM */ public lineStyle: string = 'solid';
+    /* SDA CUSTOM */ public showLineSettings: boolean = false;
+    /* SDA CUSTOM */ public showAxisSettings: boolean = false;
+    /* SDA CUSTOM */ public showXAxis: boolean = true;
+    /* SDA CUSTOM */ public showXAxisLabels: boolean = true;
+    /* SDA CUSTOM */ public showAllXAxisLabels: boolean = true;
+    /* SDA CUSTOM */ public xAxisLabelCount: number = 0;
+    /* SDA CUSTOM */ // SDA CUSTOM - KPI chart label settings
+    /* SDA CUSTOM */ public showLabelSettings: boolean = false;
+    /* SDA CUSTOM */ public showLabels: boolean = false;
+    /* SDA CUSTOM */ public showLabelsPercent: boolean = false;
+    /* SDA CUSTOM */ public labelColor: string = '#000000';
+    /* SDA CUSTOM */ public labelBackgroundColor: string = '';
+    /* SDA CUSTOM */ public showLablesTooltip: string = $localize`:@@showLablesTooltip:Mostrar o ocultar las etiquetas sobre los gráficos`;
+    /* SDA CUSTOM */ public showLablesPercentTooltip: string = $localize`:@@showLablesPercentTooltip:Mostrar o ocultar las etiquetas en porcentaje sobre los gráficos`;
+    /* SDA CUSTOM */ // END SDA CUSTOM
+    /* SDA CUSTOM */ public lineStyleOptions = [
+        /* SDA CUSTOM */ { label: $localize`:@@kpiLineStyleSolid:Sólida`, value: 'solid' },
+        /* SDA CUSTOM */ { label: $localize`:@@kpiLineStyleDashed:Discontinua`, value: 'dashed' },
+        /* SDA CUSTOM */ { label: $localize`:@@kpiLineStyleDotted:Punteada`, value: 'dotted' }
+    /* SDA CUSTOM */ ];
 
     public units: string;
     public quantity: number;
@@ -41,6 +65,15 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     public series: any[] = [];
     public edaChart: any;
     public display: boolean = false;
+    /* SDA CUSTOM */ private previewRefreshTimer: any = null;
+    /* SDA CUSTOM */ // SDA CUSTOM - KPI chart line color settings
+    /* SDA CUSTOM */ public showChartLineColor: boolean = false;
+    /* SDA CUSTOM */ public chartLineColor: string = '';
+    /* SDA CUSTOM */ // END SDA CUSTOM
+    /* SDA CUSTOM */ // SDA CUSTOM - KPI area fill color settings
+    /* SDA CUSTOM */ public showChartFillColor: boolean = false;
+    /* SDA CUSTOM */ public chartFillColor: string = '';
+    /* SDA CUSTOM */ // END SDA CUSTOM
 
     constructor(private userService: UserService,) {
 
@@ -63,13 +96,33 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     }
 
     saveChartConfig() {
+        /* SDA CUSTOM */ const kpiInject = this.panelChartComponent?.componentRef?.instance?.inject;
+        /* SDA CUSTOM */ const config: any = this.panelChartConfig?.config?.getConfig?.() || {};
+        /* SDA CUSTOM */ const sufix = kpiInject?.sufix ?? config.sufix ?? '';
+        /* SDA CUSTOM */ const fontScale = kpiInject?.fontScale ?? config.fontScale ?? 1;
+        /* SDA CUSTOM */ const chartType = this.panelChartConfig?.chartType || 'kpi';
+        /* SDA CUSTOM */ const chartSubType = this.panelChartConfig?.edaChart;
+
         this.onClose(EdaDialogCloseEvent.UPDATE,
             {
                 alerts: this.alerts,
-                sufix: this.panelChartComponent.componentRef.instance.inject.sufix,
+                /* SDA CUSTOM */ sufix,
+                /* SDA CUSTOM */ fontScale,
+                /* SDA CUSTOM */ color: this.kpiColor,
+                /* SDA CUSTOM */ lineWidth: this.lineWidth,
+                /* SDA CUSTOM */ lineStyle: this.lineStyle,
+                /* SDA CUSTOM */ showXAxis: this.showXAxis,
+                /* SDA CUSTOM */ showXAxisLabels: this.showXAxisLabels,
+                /* SDA CUSTOM */ xAxisLabelCount: this.xAxisLabelCount,
+                /* SDA CUSTOM */ // SDA CUSTOM - KPI chart label settings
+                /* SDA CUSTOM */ labelColor: this.labelColor,
+                /* SDA CUSTOM */ labelBackgroundColor: this.labelBackgroundColor,
+                /* SDA CUSTOM */ showLabels: this.showLabels,
+                /* SDA CUSTOM */ showLabelsPercent: this.showLabelsPercent,
+                /* SDA CUSTOM */ // END SDA CUSTOM
                 edaChart: this.edaChart,
-                chartType: this.panelChartConfig.chartType,
-                chartSubType: this.panelChartConfig.edaChart
+                /* SDA CUSTOM */ chartType,
+                /* SDA CUSTOM */ chartSubType
             });
     }
 
@@ -78,30 +131,84 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     }
 
     onShow(): void {
-        this.panelChartConfig = this.controller.params.panelChart;
+        /* SDA CUSTOM*/ this.panelChartConfig = _.cloneDeep(this.controller.params.panelChart);
+        /* SDA CUSTOM*/ this.panelChartConfig.canEdit = false;
+        /* SDA CUSTOM*/ this.panelChartConfig.canSave = false;
+        /* SDA CUSTOM*/ this.panelChartConfig.locked = true;
         this.edaChart = this.controller.params.edaChart;
+        /* SDA CUSTOM */ this.setPreviewAspectRatio();
 
         const config: any = this.panelChartConfig.config.getConfig();
 
         this.loadChartColors();
         this.alerts = config.alertLimits || []; //deepcopy
+        /* SDA CUSTOM */ this.kpiColor = this.normalizeHexColor(config.color || this.panelChartComponent?.componentRef?.instance?.color || '', '#67757c');
+        /* SDA CUSTOM */ this.lineWidth = config.lineWidth ?? 2;
+        /* SDA CUSTOM */ this.lineStyle = config.lineStyle ?? 'solid';
+        /* SDA CUSTOM */ this.showLineSettings = ['kpiline', 'kpiarea'].includes(this.panelChartConfig?.chartType);
+        /* SDA CUSTOM */ this.showAxisSettings = this.panelChartConfig?.chartType !== 'kpi';
+        /* SDA CUSTOM */ this.showXAxis = config.showXAxis ?? true;
+        /* SDA CUSTOM */ this.showXAxisLabels = config.showXAxisLabels ?? true;
+        /* SDA CUSTOM */ this.xAxisLabelCount = config.xAxisLabelCount ?? 0;
+        /* SDA CUSTOM */ this.showAllXAxisLabels = !this.xAxisLabelCount || this.xAxisLabelCount <= 0;
+        /* SDA CUSTOM */ // SDA CUSTOM - KPI chart label settings
+        /* SDA CUSTOM */ this.showLabelSettings = this.panelChartConfig?.chartType !== 'kpi';
+        /* SDA CUSTOM */ this.showLabels = config.showLabels ?? config?.edaChart?.showLabels ?? false;
+        /* SDA CUSTOM */ this.showLabelsPercent = config.showLabelsPercent ?? config?.edaChart?.showLabelsPercent ?? false;
+        /* SDA CUSTOM */ this.labelColor = config.labelColor ?? this.getKpiLabelColor();
+        /* SDA CUSTOM */ this.labelBackgroundColor = config.labelBackgroundColor ?? this.getKpiLabelBackgroundColor();
+        /* SDA CUSTOM */ // END SDA CUSTOM
+        /* SDA CUSTOM */ // SDA CUSTOM - KPI chart line color settings
+        /* SDA CUSTOM */ this.showChartLineColor = ['kpibar', 'kpiarea'].includes(this.panelChartConfig?.chartType);
+        /* SDA CUSTOM */ this.chartLineColor = this.getKpiChartLineColor();
+        /* SDA CUSTOM */ // END SDA CUSTOM
+        /* SDA CUSTOM */ // SDA CUSTOM - KPI area fill color settings
+        /* SDA CUSTOM */ this.showChartFillColor = this.isKpiAreaChart();
+        /* SDA CUSTOM */ this.chartFillColor = this.getKpiChartFillColor();
+        /* SDA CUSTOM */ // END SDA CUSTOM
+        /* SDA CUSTOM */ this.applyKpiColor();
+        /* SDA CUSTOM */ this.applyLineStyle();
+        /* SDA CUSTOM */ this.applyXAxisSettings();
+        /* SDA CUSTOM */ this.applyKpiLabelColor();
         this.display = true;
     }
+
+    /* SDA CUSTOM */ private setPreviewAspectRatio(): void {
+        /* SDA CUSTOM */ const sizeX = this.panelChartConfig?.size?.x;
+        /* SDA CUSTOM */ const sizeY = this.panelChartConfig?.size?.y;
+        /* SDA CUSTOM */ if (sizeX && sizeY && sizeX > 0 && sizeY > 0) {
+            /* SDA CUSTOM */ this.previewAspectRatio = `${sizeX} / ${sizeY}`;
+        /* SDA CUSTOM */ } else {
+            /* SDA CUSTOM */ this.previewAspectRatio = '16 / 9';
+        /* SDA CUSTOM */ }
+    /* SDA CUSTOM */ }
 
     loadChartColors() {
         if (this.edaChart) {
 
-            this.series = this.edaChart.chartDataset.map(dataset => ({
-                label: dataset.label,
-                bg: this.rgb2hex(dataset.backgroundColor),
-                border: dataset.borderColor
-            }));
-            
-            this.edaChart.chartColors = this.series.map(s => ({ backgroundColor: this.hex2rgb(s.bg, 90), borderColor: s.border }));
+            /* SDA CUSTOM */ this.series = this.edaChart.chartDataset.map((dataset, index) => {
+            /* SDA CUSTOM */     const chartColor = this.edaChart?.chartColors?.[index] || {};
+            /* SDA CUSTOM */     const bg = this.normalizeHexColor(dataset.backgroundColor, this.normalizeHexColor(chartColor.backgroundColor, '#67757c'));
+            /* SDA CUSTOM */     const border = this.normalizeHexColor(dataset.borderColor, this.normalizeHexColor(chartColor.borderColor, bg));
+            /* SDA CUSTOM */     return {
+            /* SDA CUSTOM */         label: dataset.label,
+            /* SDA CUSTOM */         bg,
+            /* SDA CUSTOM */         border
+            /* SDA CUSTOM */     };
+            /* SDA CUSTOM */ });
+
+            /* SDA CUSTOM */ this.edaChart.chartColors = this.series.map(s => ({
+            /* SDA CUSTOM */     backgroundColor: this.hex2rgb(s.bg, 90),
+            /* SDA CUSTOM */     borderColor: this.hex2rgb(s.border || s.bg, 100)
+            /* SDA CUSTOM */ }));
         }
     }
 
     onClose(event: EdaDialogCloseEvent, response?: any): void {
+        /* SDA CUSTOM */ if (this.previewRefreshTimer) {
+            /* SDA CUSTOM */ clearTimeout(this.previewRefreshTimer);
+            /* SDA CUSTOM */ this.previewRefreshTimer = null;
+        /* SDA CUSTOM */ }
         return this.controller.close(event, response);
     }
 
@@ -137,26 +244,29 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
             const r = parseInt(hex.substring(0, 2), 16);
             const g = parseInt(hex.substring(2, 4), 16);
             const b = parseInt(hex.substring(4, 6), 16);
-            
+
             return 'rgba(' + r + ',' + g + ',' + b + ',' + opacity / 100 + ')';
         }
     }
 
-    handleInputColor(event) {
+    /* SDA CUSTOM */ handleInputColor(event, debounceMs: number = 0) {
+        /* SDA CUSTOM */ const isAreaBorderMode = this.showChartFillColor;
         if (this.edaChart.chartDataset) {
             const newDatasets = [];
             const dataset = this.edaChart.chartDataset;
-            
+
 
             for (let i = 0, n = dataset.length; i < n; i += 1) {
                 if (dataset[i].label === event.label) {
-                    dataset[i].backgroundColor = this.hex2rgb(event.bg, 90);
+                    /* SDA CUSTOM */ if (!isAreaBorderMode) {
+                        /* SDA CUSTOM */ dataset[i].backgroundColor = this.hex2rgb(event.bg, 90);
+                    /* SDA CUSTOM */ }
                     dataset[i].borderColor = this.hex2rgb(event.bg, 100);
                     this.edaChart.chartColors[i] = _.pick(dataset[i], [ 'backgroundColor', 'borderColor']);
                 } else {
                     if (!_.isArray(dataset[i].backgroundColor)) {
                         dataset[i].backgroundColor = this.edaChart.chartColors[i].backgroundColor;
-                        dataset[i].borderColor = this.edaChart.chartColors[i].backgroundColor;
+                        /* SDA CUSTOM */ dataset[i].borderColor = this.edaChart.chartColors[i].borderColor || this.edaChart.chartColors[i].backgroundColor;
                         this.edaChart.chartColors[i] = _.pick(dataset[i], [  'backgroundColor', 'borderColor']);
                     } else {
                         if (this.edaChart.chartLabels) {
@@ -186,8 +296,400 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
             }
         }
 
+        /* SDA CUSTOM */ this.syncKpiLiveConfig();
+        /* SDA CUSTOM */ this.schedulePreviewRefresh(false, debounceMs);
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ applyKpiColor(debounceMs: number = 0) {
+        /* SDA CUSTOM */ if (!this.panelChartComponent?.componentRef?.instance?.inject) {
+            /* SDA CUSTOM */ return;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ this.kpiColor = this.normalizeHexColor(this.kpiColor, this.kpiColor);
+        /* SDA CUSTOM */ this.panelChartComponent.componentRef.instance.inject.color = this.kpiColor;
+        /* SDA CUSTOM */ if (typeof this.panelChartComponent.componentRef.instance.setBaseColor === 'function') {
+            /* SDA CUSTOM */ this.panelChartComponent.componentRef.instance.setBaseColor(this.kpiColor);
+            /* SDA CUSTOM */ this.panelChartComponent.componentRef.instance.applyAlertColors?.();
+        /* SDA CUSTOM */ }
         this.panelChartComponent.componentRef.instance.inject.edaChart = this.edaChart;
-        this.panelChartComponent.componentRef.instance.updateChart();
+        /* SDA CUSTOM */ this.syncKpiLiveConfig();
+        /* SDA CUSTOM */ this.schedulePreviewRefresh(false, debounceMs);
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ applyLineStyle(debounceMs: number = 0) {
+        /* SDA CUSTOM */ if (!this.showLineSettings || !this.edaChart?.chartDataset) {
+            /* SDA CUSTOM */ return;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ if (this.panelChartComponent?.componentRef?.instance?.inject) {
+            /* SDA CUSTOM */ this.panelChartComponent.componentRef.instance.inject.lineWidth = this.lineWidth;
+            /* SDA CUSTOM */ this.panelChartComponent.componentRef.instance.inject.lineStyle = this.lineStyle;
+            /* SDA CUSTOM */ this.panelChartComponent.componentRef.instance.inject.edaChart = this.edaChart;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ this.updateLineDatasets(this.edaChart.chartDataset);
+        /* SDA CUSTOM */ this.syncKpiLiveConfig();
+        /* SDA CUSTOM */ this.schedulePreviewRefresh(false, debounceMs);
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ toggleAllXAxisLabels() {
+        /* SDA CUSTOM */ if (this.showAllXAxisLabels) {
+            /* SDA CUSTOM */ this.xAxisLabelCount = 0;
+        /* SDA CUSTOM */ } else if (!this.xAxisLabelCount || this.xAxisLabelCount <= 0) {
+            /* SDA CUSTOM */ this.xAxisLabelCount = this.getDefaultXAxisLabelCount();
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ this.applyXAxisSettings();
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ handleXAxisLabelCountInput(debounceMs: number = 0) {
+        /* SDA CUSTOM */ if (this.xAxisLabelCount && this.xAxisLabelCount > 0) {
+            /* SDA CUSTOM */ this.showAllXAxisLabels = false;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ this.applyXAxisSettings(debounceMs);
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ applyXAxisSettings(debounceMs: number = 0) {
+        /* SDA CUSTOM */ if (!this.showAxisSettings || !this.edaChart?.chartOptions) {
+            /* SDA CUSTOM */ return;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ if (this.panelChartComponent?.componentRef?.instance?.inject) {
+            /* SDA CUSTOM */ this.panelChartComponent.componentRef.instance.inject.showXAxis = this.showXAxis;
+            /* SDA CUSTOM */ this.panelChartComponent.componentRef.instance.inject.showXAxisLabels = this.showXAxisLabels;
+            /* SDA CUSTOM */ this.panelChartComponent.componentRef.instance.inject.xAxisLabelCount = this.xAxisLabelCount;
+            /* SDA CUSTOM */ this.panelChartComponent.componentRef.instance.inject.edaChart = this.edaChart;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ this.updateXAxisOptions();
+        /* SDA CUSTOM */ this.syncKpiLiveConfig();
+        /* SDA CUSTOM */ this.schedulePreviewRefresh(false, debounceMs);
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ // SDA CUSTOM - KPI chart label handlers
+    /* SDA CUSTOM */ setShowLabels() {
+    /* SDA CUSTOM */     this.updateKpiChartLabels();
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ setShowLabelsPercent() {
+    /* SDA CUSTOM */     this.updateKpiChartLabels();
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ setLabelColor(debounceMs: number = 0) {
+    /* SDA CUSTOM */     this.applyKpiLabelColor(debounceMs);
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ setLabelBackgroundColor(debounceMs: number = 0) {
+    /* SDA CUSTOM */     this.applyKpiLabelColor(debounceMs);
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private updateKpiChartLabels() {
+    /* SDA CUSTOM */     if (!this.panelChartConfig?.config) {
+    /* SDA CUSTOM */         return;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     const config: any = this.panelChartConfig.config.getConfig();
+    /* SDA CUSTOM */     config.showLabels = this.showLabels;
+    /* SDA CUSTOM */     config.showLabelsPercent = this.showLabelsPercent;
+    /* SDA CUSTOM */     if (config?.edaChart) {
+    /* SDA CUSTOM */         config.edaChart.showLabels = this.showLabels;
+    /* SDA CUSTOM */         config.edaChart.showLabelsPercent = this.showLabelsPercent;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     if (this.edaChart) {
+    /* SDA CUSTOM */         this.edaChart.showLabels = this.showLabels;
+    /* SDA CUSTOM */         this.edaChart.showLabelsPercent = this.showLabelsPercent;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     this.syncKpiLiveConfig();
+    /* SDA CUSTOM */     this.refreshKpiPreview(true);
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private applyKpiLabelColor(debounceMs: number = 0): void {
+    /* SDA CUSTOM */     if (!this.edaChart?.chartOptions) {
+    /* SDA CUSTOM */         return;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     if (!this.edaChart.chartOptions.plugins) {
+    /* SDA CUSTOM */         this.edaChart.chartOptions.plugins = {};
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     if (!this.edaChart.chartOptions.plugins.datalabels) {
+    /* SDA CUSTOM */         this.edaChart.chartOptions.plugins.datalabels = {};
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     this.labelBackgroundColor = this.normalizeHexColor(this.labelBackgroundColor, '');
+    /* SDA CUSTOM */     this.edaChart.chartOptions.plugins.datalabels.color = this.labelColor;
+    /* SDA CUSTOM */     this.edaChart.chartOptions.plugins.datalabels.backgroundColor = this.labelBackgroundColor || null;
+    /* SDA CUSTOM */     this.syncKpiLiveConfig();
+    /* SDA CUSTOM */     this.schedulePreviewRefresh(false, debounceMs);
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private getKpiLabelColor(): string {
+    /* SDA CUSTOM */     return this.normalizeHexColor(this.edaChart?.chartOptions?.plugins?.datalabels?.color, '#000000');
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private getKpiLabelBackgroundColor(): string {
+    /* SDA CUSTOM */     return this.normalizeHexColor(this.edaChart?.chartOptions?.plugins?.datalabels?.backgroundColor, '');
+    /* SDA CUSTOM */ }
+    /* SDA CUSTOM */ // END SDA CUSTOM
+
+    /* SDA CUSTOM */ private updateXAxisOptions(): void {
+        /* SDA CUSTOM */ const labelsLength = this.edaChart?.chartLabels?.length || 0;
+        /* SDA CUSTOM */ const useAll = !this.xAxisLabelCount || this.xAxisLabelCount <= 0 || this.showAllXAxisLabels;
+        /* SDA CUSTOM */ const maxTicksLimit = useAll ? labelsLength : this.xAxisLabelCount;
+
+        /* SDA CUSTOM */ if (!this.edaChart.chartOptions.scales) {
+            /* SDA CUSTOM */ this.edaChart.chartOptions.scales = {};
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ if (!this.edaChart.chartOptions.scales.x) {
+            /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x = {};
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ if (!this.edaChart.chartOptions.scales.x.ticks) {
+            /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks = {};
+        /* SDA CUSTOM */ }
+
+        /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.display = this.showXAxis;
+        /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.display = this.showXAxis && this.showXAxisLabels;
+        /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.maxTicksLimit = maxTicksLimit || undefined;
+        /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.autoSkip = useAll;
+        /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.callback = this.buildXAxisTickCallback(
+            /* SDA CUSTOM */ useAll,
+            /* SDA CUSTOM */ labelsLength,
+            /* SDA CUSTOM */ this.xAxisLabelCount,
+            /* SDA CUSTOM */ this.edaChart.chartLabels
+        /* SDA CUSTOM */ );
+        /* SDA CUSTOM */ if (this.edaChart.chartOptions.scales.x.grid) {
+            /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.grid.display = this.showXAxis ? this.edaChart.chartOptions.scales.x.grid.display : false;
+        /* SDA CUSTOM */ }
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private buildXAxisTickCallback(
+        /* SDA CUSTOM */ useAll: boolean,
+        /* SDA CUSTOM */ labelsLength: number,
+        /* SDA CUSTOM */ labelCount: number,
+        /* SDA CUSTOM */ chartLabels: any[]
+    /* SDA CUSTOM */ ): ((value: any, index: number) => string) | undefined {
+        /* SDA CUSTOM */ if (useAll || labelsLength === 0 || !labelCount || labelCount <= 0) {
+            /* SDA CUSTOM */ return undefined;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ const maxCount = Math.min(labelCount, labelsLength);
+        /* SDA CUSTOM */ if (maxCount <= 1) {
+            /* SDA CUSTOM */ return (value, index) => {
+                /* SDA CUSTOM */ if (index !== 0) {
+                    /* SDA CUSTOM */ return '';
+                /* SDA CUSTOM */ }
+                /* SDA CUSTOM */ const label = Array.isArray(chartLabels)
+                    /* SDA CUSTOM */ ? (chartLabels[index] ?? chartLabels[value])
+                    /* SDA CUSTOM */ : value;
+                /* SDA CUSTOM */ return `${label ?? ''}`;
+            /* SDA CUSTOM */ };
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ const indices = this.getAxisLabelIndices(labelsLength, maxCount);
+        /* SDA CUSTOM */ return (value, index) => {
+            /* SDA CUSTOM */ if (!indices.has(index)) {
+                /* SDA CUSTOM */ return '';
+            /* SDA CUSTOM */ }
+            /* SDA CUSTOM */ const label = Array.isArray(chartLabels)
+                /* SDA CUSTOM */ ? (chartLabels[index] ?? chartLabels[value])
+                /* SDA CUSTOM */ : value;
+            /* SDA CUSTOM */ return `${label ?? ''}`;
+        /* SDA CUSTOM */ };
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private getAxisLabelIndices(labelsLength: number, labelCount: number): Set<number> {
+        /* SDA CUSTOM */ const indices = new Set<number>();
+        /* SDA CUSTOM */ if (labelsLength <= 0) {
+            /* SDA CUSTOM */ return indices;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ if (labelCount <= 1) {
+            /* SDA CUSTOM */ indices.add(0);
+            /* SDA CUSTOM */ return indices;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ const steps = labelCount - 1;
+        /* SDA CUSTOM */ for (let i = 0; i < labelCount; i += 1) {
+            /* SDA CUSTOM */ const index = Math.round((i * (labelsLength - 1)) / steps);
+            /* SDA CUSTOM */ indices.add(index);
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ indices.add(0);
+        /* SDA CUSTOM */ indices.add(labelsLength - 1);
+        /* SDA CUSTOM */ return indices;
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private getDefaultXAxisLabelCount(): number {
+        /* SDA CUSTOM */ const labelsLength = this.edaChart?.chartLabels?.length || 0;
+        /* SDA CUSTOM */ if (labelsLength === 0) {
+            /* SDA CUSTOM */ return 5;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ return Math.min(5, labelsLength);
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private updateLineDatasets(datasets: any[]): void {
+        /* SDA CUSTOM */ const dash = this.getLineDash(this.lineStyle);
+        /* SDA CUSTOM */ datasets.forEach(dataset => {
+            /* SDA CUSTOM */ dataset.borderWidth = this.lineWidth;
+            /* SDA CUSTOM */ dataset.borderDash = dash;
+        /* SDA CUSTOM */ });
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ // SDA CUSTOM - KPI chart line color handlers
+    /* SDA CUSTOM */ applyChartLineColor(debounceMs: number = 0) {
+    /* SDA CUSTOM */     if (!this.showChartLineColor || !this.edaChart?.chartDataset) {
+    /* SDA CUSTOM */         return;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     const borderColor = this.hex2rgb(this.chartLineColor, 100);
+    /* SDA CUSTOM */     const borderWidth = 2;
+    /* SDA CUSTOM */     this.edaChart.chartDataset.forEach(dataset => {
+    /* SDA CUSTOM */         dataset.borderColor = borderColor;
+    /* SDA CUSTOM */         dataset.borderWidth = dataset.borderWidth ?? borderWidth;
+    /* SDA CUSTOM */     });
+    /* SDA CUSTOM */     if (Array.isArray(this.edaChart.chartColors)) {
+    /* SDA CUSTOM */         this.edaChart.chartColors = this.edaChart.chartColors.map(color => ({
+    /* SDA CUSTOM */             backgroundColor: color.backgroundColor,
+    /* SDA CUSTOM */             borderColor
+    /* SDA CUSTOM */         }));
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     if (this.panelChartComponent?.componentRef?.instance?.inject) {
+    /* SDA CUSTOM */         this.panelChartComponent.componentRef.instance.inject.edaChart = this.edaChart;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     this.syncKpiLiveConfig();
+    /* SDA CUSTOM */     this.schedulePreviewRefresh(false, debounceMs);
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private getKpiChartLineColor(): string {
+    /* SDA CUSTOM */     const chartColors = this.edaChart?.chartColors || [];
+    /* SDA CUSTOM */     const border = chartColors[0]?.borderColor || this.edaChart?.chartDataset?.[0]?.borderColor;
+    /* SDA CUSTOM */     return this.normalizeHexColor(border, '');
+    /* SDA CUSTOM */ }
+    /* SDA CUSTOM */ // END SDA CUSTOM
+
+    /* SDA CUSTOM */ // SDA CUSTOM - KPI area fill color handlers
+    /* SDA CUSTOM */ applyChartFillColor(debounceMs: number = 0) {
+    /* SDA CUSTOM */     if (!this.showChartFillColor || !this.edaChart?.chartDataset) {
+    /* SDA CUSTOM */         return;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     const fillColor = this.hex2rgb(this.chartFillColor, 90);
+    /* SDA CUSTOM */     this.edaChart.chartDataset.forEach(dataset => {
+    /* SDA CUSTOM */         dataset.backgroundColor = fillColor;
+    /* SDA CUSTOM */         dataset.fill = true;
+    /* SDA CUSTOM */     });
+    /* SDA CUSTOM */     if (Array.isArray(this.edaChart.chartColors)) {
+    /* SDA CUSTOM */         this.edaChart.chartColors = this.edaChart.chartColors.map(color => ({
+    /* SDA CUSTOM */             backgroundColor: fillColor,
+    /* SDA CUSTOM */             borderColor: color.borderColor
+    /* SDA CUSTOM */         }));
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     if (this.panelChartComponent?.componentRef?.instance?.inject) {
+    /* SDA CUSTOM */         this.panelChartComponent.componentRef.instance.inject.edaChart = this.edaChart;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     this.syncKpiLiveConfig();
+    /* SDA CUSTOM */     this.schedulePreviewRefresh(false, debounceMs);
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private getKpiChartFillColor(): string {
+    /* SDA CUSTOM */     const chartColors = this.edaChart?.chartColors || [];
+    /* SDA CUSTOM */     const background = chartColors[0]?.backgroundColor || this.edaChart?.chartDataset?.[0]?.backgroundColor;
+    /* SDA CUSTOM */     return this.normalizeHexColor(background, '');
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private isKpiAreaChart(): boolean {
+    /* SDA CUSTOM */     const panelType = this.panelChartConfig?.chartType;
+    /* SDA CUSTOM */     const panelSubType = this.panelChartConfig?.edaChart;
+    /* SDA CUSTOM */     const edaChartType = this.edaChart?.chartType;
+    /* SDA CUSTOM */     const kpiType = this.edaChart?.kpiChart;
+    /* SDA CUSTOM */     return panelType === 'kpiarea' || panelSubType === 'kpiarea' || edaChartType === 'area' || kpiType === 'kpiarea';
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private syncKpiLiveConfig(): void {
+    /* SDA CUSTOM */     if (!this.panelChartConfig?.config) {
+    /* SDA CUSTOM */         return;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     const config: any = this.panelChartConfig.config.getConfig();
+    /* SDA CUSTOM */     config.lineWidth = this.lineWidth;
+    /* SDA CUSTOM */     config.lineStyle = this.lineStyle;
+    /* SDA CUSTOM */     config.color = this.kpiColor;
+    /* SDA CUSTOM */     config.showXAxis = this.showXAxis;
+    /* SDA CUSTOM */     config.showXAxisLabels = this.showXAxisLabels;
+    /* SDA CUSTOM */     config.xAxisLabelCount = this.xAxisLabelCount;
+    /* SDA CUSTOM */     config.labelColor = this.labelColor;
+    /* SDA CUSTOM */     config.labelBackgroundColor = this.labelBackgroundColor;
+    /* SDA CUSTOM */     config.showLabels = this.showLabels;
+    /* SDA CUSTOM */     config.showLabelsPercent = this.showLabelsPercent;
+    /* SDA CUSTOM */     if (this.edaChart?.chartColors) {
+    /* SDA CUSTOM */         config.colors = this.edaChart.chartColors;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     if (config?.edaChart) {
+    /* SDA CUSTOM */         config.edaChart.showLabels = this.showLabels;
+    /* SDA CUSTOM */         config.edaChart.showLabelsPercent = this.showLabelsPercent;
+    /* SDA CUSTOM */         config.edaChart.labelBackgroundColor = this.labelBackgroundColor;
+    /* SDA CUSTOM */         if (this.edaChart?.chartColors) {
+    /* SDA CUSTOM */             config.edaChart.colors = this.edaChart.chartColors;
+    /* SDA CUSTOM */         }
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private refreshKpiPreview(forceRebuild: boolean = false): void {
+    /* SDA CUSTOM */     const refreshFromPanel = () => {
+    /* SDA CUSTOM */         if (!this.panelChartComponent) {
+    /* SDA CUSTOM */             return;
+    /* SDA CUSTOM */         }
+    /* SDA CUSTOM */         // Rebuild current chart in preview so every option change is reflected immediately.
+    /* SDA CUSTOM */         this.panelChartComponent.changeChartType();
+    /* SDA CUSTOM */         const nextEdaChart = this.panelChartComponent?.componentRef?.instance?.inject?.edaChart;
+    /* SDA CUSTOM */         if (nextEdaChart) {
+    /* SDA CUSTOM */             this.edaChart = nextEdaChart;
+    /* SDA CUSTOM */             if (Array.isArray(this.edaChart?.chartDataset)) {
+    /* SDA CUSTOM */                 this.loadChartColors();
+    /* SDA CUSTOM */             }
+    /* SDA CUSTOM */         }
+    /* SDA CUSTOM */         this.panelChartComponent.updateComponent?.();
+    /* SDA CUSTOM */     };
+
+    /* SDA CUSTOM */     if (forceRebuild) {
+    /* SDA CUSTOM */         this.panelChartConfig = new PanelChart(this.panelChartConfig);
+    /* SDA CUSTOM */         setTimeout(_ => {
+    /* SDA CUSTOM */             refreshFromPanel();
+    /* SDA CUSTOM */         });
+    /* SDA CUSTOM */         return;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     refreshFromPanel();
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private schedulePreviewRefresh(forceRebuild: boolean = false, debounceMs: number = 0): void {
+    /* SDA CUSTOM */     if (debounceMs <= 0) {
+    /* SDA CUSTOM */         this.refreshKpiPreview(forceRebuild);
+    /* SDA CUSTOM */         return;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     if (this.previewRefreshTimer) {
+    /* SDA CUSTOM */         clearTimeout(this.previewRefreshTimer);
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     this.previewRefreshTimer = setTimeout(() => {
+    /* SDA CUSTOM */         this.previewRefreshTimer = null;
+    /* SDA CUSTOM */         this.refreshKpiPreview(forceRebuild);
+    /* SDA CUSTOM */     }, debounceMs);
+    /* SDA CUSTOM */ }
+    /* SDA CUSTOM */ // END SDA CUSTOM
+
+    /* SDA CUSTOM */ // SDA CUSTOM - Normalize color values for dialog inputs
+    /* SDA CUSTOM */ private normalizeHexColor(color: any, fallback: string = ''): string {
+    /* SDA CUSTOM */     const resolvedColor = Array.isArray(color) ? color[0] : color;
+    /* SDA CUSTOM */     if (typeof resolvedColor !== 'string') {
+    /* SDA CUSTOM */         return fallback;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     const trimmed = resolvedColor.trim();
+    /* SDA CUSTOM */     const shortHexMatch = /^#([0-9a-fA-F]{3})$/.exec(trimmed);
+    /* SDA CUSTOM */     if (shortHexMatch) {
+    /* SDA CUSTOM */         const [r, g, b] = shortHexMatch[1].split('');
+    /* SDA CUSTOM */         return `#${r}${r}${g}${g}${b}${b}`;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     if (/^#([0-9a-fA-F]{6})$/.test(trimmed)) {
+    /* SDA CUSTOM */         return trimmed;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     if (/^rgba?\(/i.test(trimmed)) {
+    /* SDA CUSTOM */         return this.rgb2hex(trimmed) || fallback;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     return fallback;
+    /* SDA CUSTOM */ }
+    /* SDA CUSTOM */ // END SDA CUSTOM
+
+    /* SDA CUSTOM */ private getLineDash(style: string): number[] {
+        /* SDA CUSTOM */ switch (style) {
+            /* SDA CUSTOM */ case 'dashed':
+                /* SDA CUSTOM */ return [8, 4];
+            /* SDA CUSTOM */ case 'dotted':
+                /* SDA CUSTOM */ return [2, 4];
+            /* SDA CUSTOM */ case 'solid':
+            /* SDA CUSTOM */ default:
+                /* SDA CUSTOM */ return [];
+        /* SDA CUSTOM */ }
     }
 
     openConfigDialog($event, alert) {

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
@@ -14,6 +14,8 @@ import * as _ from 'lodash';
 
 export class KpiEditDialogComponent extends EdaDialogAbstract {
 
+    /* SDA CUSTOM */private static persistedSectionState: { appearance: boolean; axisScale: boolean; labelsValues: boolean } | null = null;
+
     @ViewChild('PanelChartComponent', { static: false }) panelChartComponent: PanelChartComponent;
     @ViewChild('mailConfig', { static: false }) mailConfig: any;
 
@@ -65,6 +67,9 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     public series: any[] = [];
     public edaChart: any;
     public display: boolean = false;
+    /* SDA CUSTOM */ public isAppearanceExpanded: boolean = true;
+    /* SDA CUSTOM */ public isAxisScaleExpanded: boolean = false;
+    /* SDA CUSTOM */ public isLabelsValuesExpanded: boolean = false;
     /* SDA CUSTOM */ private previewRefreshTimer: any = null;
     /* SDA CUSTOM */ // SDA CUSTOM - KPI chart line color settings
     /* SDA CUSTOM */ public showChartLineColor: boolean = false;
@@ -74,6 +79,10 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     /* SDA CUSTOM */ public showChartFillColor: boolean = false;
     /* SDA CUSTOM */ public chartFillColor: string = '';
     /* SDA CUSTOM */ // END SDA CUSTOM
+    /* SDA CUSTOM */ private initialAppearanceState: any = null;
+    /* SDA CUSTOM */ private initialAxisScaleState: any = null;
+    /* SDA CUSTOM */ private initialLabelsValuesState: any = null;
+    /* SDA CUSTOM */ private initialChartStyleState: any = null;
 
     constructor(private userService: UserService,) {
 
@@ -170,8 +179,117 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
         /* SDA CUSTOM */ this.applyLineStyle();
         /* SDA CUSTOM */ this.applyXAxisSettings();
         /* SDA CUSTOM */ this.applyKpiLabelColor();
+        /* SDA CUSTOM */ this.captureInitialSectionState();
+        /* SDA CUSTOM */ const persistedState = KpiEditDialogComponent.persistedSectionState;
+        /* SDA CUSTOM */ if (persistedState) {
+        /* SDA CUSTOM */     this.isAppearanceExpanded = persistedState.appearance;
+        /* SDA CUSTOM */     this.isAxisScaleExpanded = persistedState.axisScale;
+        /* SDA CUSTOM */     this.isLabelsValuesExpanded = persistedState.labelsValues;
+        /* SDA CUSTOM */ } else {
+        /* SDA CUSTOM */     this.isAppearanceExpanded = true;
+        /* SDA CUSTOM */     this.isAxisScaleExpanded = false;
+        /* SDA CUSTOM */     this.isLabelsValuesExpanded = false;
+        /* SDA CUSTOM */ }
         this.display = true;
     }
+
+    /* SDA CUSTOM */ toggleSection(section: 'appearance' | 'axisScale' | 'labelsValues'): void {
+    /* SDA CUSTOM */     switch (section) {
+    /* SDA CUSTOM */         case 'appearance':
+    /* SDA CUSTOM */             this.isAppearanceExpanded = !this.isAppearanceExpanded;
+    /* SDA CUSTOM */             break;
+    /* SDA CUSTOM */         case 'axisScale':
+    /* SDA CUSTOM */             this.isAxisScaleExpanded = !this.isAxisScaleExpanded;
+    /* SDA CUSTOM */             break;
+    /* SDA CUSTOM */         case 'labelsValues':
+    /* SDA CUSTOM */             this.isLabelsValuesExpanded = !this.isLabelsValuesExpanded;
+    /* SDA CUSTOM */             break;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     KpiEditDialogComponent.persistedSectionState = {
+    /* SDA CUSTOM */         appearance: this.isAppearanceExpanded,
+    /* SDA CUSTOM */         axisScale: this.isAxisScaleExpanded,
+    /* SDA CUSTOM */         labelsValues: this.isLabelsValuesExpanded
+    /* SDA CUSTOM */     };
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private captureInitialSectionState(): void {
+        /* SDA CUSTOM */ this.initialAppearanceState = {
+            /* SDA CUSTOM */ kpiColor: this.kpiColor,
+            /* SDA CUSTOM */ lineWidth: this.lineWidth,
+            /* SDA CUSTOM */ lineStyle: this.lineStyle,
+            /* SDA CUSTOM */ chartLineColor: this.chartLineColor,
+            /* SDA CUSTOM */ chartFillColor: this.chartFillColor
+        /* SDA CUSTOM */ };
+        /* SDA CUSTOM */ this.initialAxisScaleState = {
+            /* SDA CUSTOM */ showXAxis: this.showXAxis,
+            /* SDA CUSTOM */ showXAxisLabels: this.showXAxisLabels,
+            /* SDA CUSTOM */ showAllXAxisLabels: this.showAllXAxisLabels,
+            /* SDA CUSTOM */ xAxisLabelCount: this.xAxisLabelCount
+        /* SDA CUSTOM */ };
+        /* SDA CUSTOM */ this.initialLabelsValuesState = {
+            /* SDA CUSTOM */ showLabels: this.showLabels,
+            /* SDA CUSTOM */ showLabelsPercent: this.showLabelsPercent,
+            /* SDA CUSTOM */ labelColor: this.labelColor,
+            /* SDA CUSTOM */ labelBackgroundColor: this.labelBackgroundColor
+        /* SDA CUSTOM */ };
+        /* SDA CUSTOM */ this.initialChartStyleState = {
+            /* SDA CUSTOM */ chartDataset: _.cloneDeep(this.edaChart?.chartDataset || []),
+            /* SDA CUSTOM */ chartColors: _.cloneDeep(this.edaChart?.chartColors || [])
+        /* SDA CUSTOM */ };
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ resetAppearanceSection(): void {
+        /* SDA CUSTOM */ if (!this.initialAppearanceState) {
+            /* SDA CUSTOM */ return;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ this.kpiColor = this.initialAppearanceState.kpiColor;
+        /* SDA CUSTOM */ this.lineWidth = this.initialAppearanceState.lineWidth;
+        /* SDA CUSTOM */ this.lineStyle = this.initialAppearanceState.lineStyle;
+        /* SDA CUSTOM */ this.chartLineColor = this.initialAppearanceState.chartLineColor;
+        /* SDA CUSTOM */ this.chartFillColor = this.initialAppearanceState.chartFillColor;
+
+        /* SDA CUSTOM */ if (this.initialChartStyleState) {
+            /* SDA CUSTOM */ this.edaChart.chartDataset = _.cloneDeep(this.initialChartStyleState.chartDataset);
+            /* SDA CUSTOM */ this.edaChart.chartColors = _.cloneDeep(this.initialChartStyleState.chartColors);
+            /* SDA CUSTOM */ this.loadChartColors();
+        /* SDA CUSTOM */ }
+
+        /* SDA CUSTOM */ this.applyKpiColor();
+        /* SDA CUSTOM */ if (this.showLineSettings) {
+            /* SDA CUSTOM */ this.applyLineStyle();
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ if (this.showChartLineColor) {
+            /* SDA CUSTOM */ this.applyChartLineColor();
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ if (this.showChartFillColor) {
+            /* SDA CUSTOM */ this.applyChartFillColor();
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ this.syncKpiLiveConfig();
+        /* SDA CUSTOM */ this.schedulePreviewRefresh(false, 0);
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ resetAxisScaleSection(): void {
+        /* SDA CUSTOM */ if (!this.initialAxisScaleState) {
+            /* SDA CUSTOM */ return;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ this.showXAxis = this.initialAxisScaleState.showXAxis;
+        /* SDA CUSTOM */ this.showXAxisLabels = this.initialAxisScaleState.showXAxisLabels;
+        /* SDA CUSTOM */ this.showAllXAxisLabels = this.initialAxisScaleState.showAllXAxisLabels;
+        /* SDA CUSTOM */ this.xAxisLabelCount = this.initialAxisScaleState.xAxisLabelCount;
+        /* SDA CUSTOM */ this.applyXAxisSettings();
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ resetLabelsValuesSection(): void {
+        /* SDA CUSTOM */ if (!this.initialLabelsValuesState) {
+            /* SDA CUSTOM */ return;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ this.showLabels = this.initialLabelsValuesState.showLabels;
+        /* SDA CUSTOM */ this.showLabelsPercent = this.initialLabelsValuesState.showLabelsPercent;
+        /* SDA CUSTOM */ this.labelColor = this.initialLabelsValuesState.labelColor;
+        /* SDA CUSTOM */ this.labelBackgroundColor = this.initialLabelsValuesState.labelBackgroundColor;
+        /* SDA CUSTOM */ this.updateKpiChartLabels();
+        /* SDA CUSTOM */ this.applyKpiLabelColor();
+    /* SDA CUSTOM */ }
 
     /* SDA CUSTOM */ private setPreviewAspectRatio(): void {
         /* SDA CUSTOM */ const sizeX = this.panelChartConfig?.size?.x;

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
@@ -367,7 +367,7 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
         }
     }
 
-    /* SDA CUSTOM */ handleInputColor(event, debounceMs: number = 0) {
+    /* SDA CUSTOM */ handleInputColor(event, debounceMs: number = 0, softPreview: boolean = false) {
         /* SDA CUSTOM */ const isAreaBorderMode = this.showChartFillColor;
         if (this.edaChart.chartDataset) {
             const newDatasets = [];
@@ -415,10 +415,14 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
         }
 
         /* SDA CUSTOM */ this.syncKpiLiveConfig();
-        /* SDA CUSTOM */ this.schedulePreviewRefresh(false, debounceMs);
+        /* SDA CUSTOM */ if (softPreview) {
+            /* SDA CUSTOM */ this.schedulePreviewUpdate(debounceMs);
+        /* SDA CUSTOM */ } else {
+            /* SDA CUSTOM */ this.schedulePreviewRefresh(false, debounceMs);
+        /* SDA CUSTOM */ }
     /* SDA CUSTOM */ }
 
-    /* SDA CUSTOM */ applyKpiColor(debounceMs: number = 0) {
+    /* SDA CUSTOM */ applyKpiColor(debounceMs: number = 0, softPreview: boolean = false) {
         /* SDA CUSTOM */ if (!this.panelChartComponent?.componentRef?.instance?.inject) {
             /* SDA CUSTOM */ return;
         /* SDA CUSTOM */ }
@@ -430,7 +434,11 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
         /* SDA CUSTOM */ }
         this.panelChartComponent.componentRef.instance.inject.edaChart = this.edaChart;
         /* SDA CUSTOM */ this.syncKpiLiveConfig();
-        /* SDA CUSTOM */ this.schedulePreviewRefresh(false, debounceMs);
+        /* SDA CUSTOM */ if (softPreview) {
+            /* SDA CUSTOM */ this.schedulePreviewUpdate(debounceMs);
+        /* SDA CUSTOM */ } else {
+            /* SDA CUSTOM */ this.schedulePreviewRefresh(false, debounceMs);
+        /* SDA CUSTOM */ }
     /* SDA CUSTOM */ }
 
     /* SDA CUSTOM */ applyLineStyle(debounceMs: number = 0) {
@@ -487,12 +495,12 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     /* SDA CUSTOM */     this.updateKpiChartLabels();
     /* SDA CUSTOM */ }
 
-    /* SDA CUSTOM */ setLabelColor(debounceMs: number = 0) {
-    /* SDA CUSTOM */     this.applyKpiLabelColor(debounceMs);
+    /* SDA CUSTOM */ setLabelColor(debounceMs: number = 0, softPreview: boolean = false) {
+    /* SDA CUSTOM */     this.applyKpiLabelColor(debounceMs, softPreview);
     /* SDA CUSTOM */ }
 
-    /* SDA CUSTOM */ setLabelBackgroundColor(debounceMs: number = 0) {
-    /* SDA CUSTOM */     this.applyKpiLabelColor(debounceMs);
+    /* SDA CUSTOM */ setLabelBackgroundColor(debounceMs: number = 0, softPreview: boolean = false) {
+    /* SDA CUSTOM */     this.applyKpiLabelColor(debounceMs, softPreview);
     /* SDA CUSTOM */ }
 
     /* SDA CUSTOM */ private updateKpiChartLabels() {
@@ -514,7 +522,7 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     /* SDA CUSTOM */     this.refreshKpiPreview(true);
     /* SDA CUSTOM */ }
 
-    /* SDA CUSTOM */ private applyKpiLabelColor(debounceMs: number = 0): void {
+    /* SDA CUSTOM */ private applyKpiLabelColor(debounceMs: number = 0, softPreview: boolean = false): void {
     /* SDA CUSTOM */     if (!this.edaChart?.chartOptions) {
     /* SDA CUSTOM */         return;
     /* SDA CUSTOM */     }
@@ -528,7 +536,11 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     /* SDA CUSTOM */     this.edaChart.chartOptions.plugins.datalabels.color = this.labelColor;
     /* SDA CUSTOM */     this.edaChart.chartOptions.plugins.datalabels.backgroundColor = this.labelBackgroundColor || null;
     /* SDA CUSTOM */     this.syncKpiLiveConfig();
-    /* SDA CUSTOM */     this.schedulePreviewRefresh(false, debounceMs);
+    /* SDA CUSTOM */     if (softPreview) {
+    /* SDA CUSTOM */         this.schedulePreviewUpdate(debounceMs);
+    /* SDA CUSTOM */     } else {
+    /* SDA CUSTOM */         this.schedulePreviewRefresh(false, debounceMs);
+    /* SDA CUSTOM */     }
     /* SDA CUSTOM */ }
 
     /* SDA CUSTOM */ private getKpiLabelColor(): string {
@@ -639,7 +651,7 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     /* SDA CUSTOM */ }
 
     /* SDA CUSTOM */ // SDA CUSTOM - KPI chart line color handlers
-    /* SDA CUSTOM */ applyChartLineColor(debounceMs: number = 0) {
+    /* SDA CUSTOM */ applyChartLineColor(debounceMs: number = 0, softPreview: boolean = false) {
     /* SDA CUSTOM */     if (!this.showChartLineColor || !this.edaChart?.chartDataset) {
     /* SDA CUSTOM */         return;
     /* SDA CUSTOM */     }
@@ -659,7 +671,11 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     /* SDA CUSTOM */         this.panelChartComponent.componentRef.instance.inject.edaChart = this.edaChart;
     /* SDA CUSTOM */     }
     /* SDA CUSTOM */     this.syncKpiLiveConfig();
-    /* SDA CUSTOM */     this.schedulePreviewRefresh(false, debounceMs);
+    /* SDA CUSTOM */     if (softPreview) {
+    /* SDA CUSTOM */         this.schedulePreviewUpdate(debounceMs);
+    /* SDA CUSTOM */     } else {
+    /* SDA CUSTOM */         this.schedulePreviewRefresh(false, debounceMs);
+    /* SDA CUSTOM */     }
     /* SDA CUSTOM */ }
 
     /* SDA CUSTOM */ private getKpiChartLineColor(): string {
@@ -670,7 +686,7 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     /* SDA CUSTOM */ // END SDA CUSTOM
 
     /* SDA CUSTOM */ // SDA CUSTOM - KPI area fill color handlers
-    /* SDA CUSTOM */ applyChartFillColor(debounceMs: number = 0) {
+    /* SDA CUSTOM */ applyChartFillColor(debounceMs: number = 0, softPreview: boolean = false) {
     /* SDA CUSTOM */     if (!this.showChartFillColor || !this.edaChart?.chartDataset) {
     /* SDA CUSTOM */         return;
     /* SDA CUSTOM */     }
@@ -689,7 +705,11 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     /* SDA CUSTOM */         this.panelChartComponent.componentRef.instance.inject.edaChart = this.edaChart;
     /* SDA CUSTOM */     }
     /* SDA CUSTOM */     this.syncKpiLiveConfig();
-    /* SDA CUSTOM */     this.schedulePreviewRefresh(false, debounceMs);
+    /* SDA CUSTOM */     if (softPreview) {
+    /* SDA CUSTOM */         this.schedulePreviewUpdate(debounceMs);
+    /* SDA CUSTOM */     } else {
+    /* SDA CUSTOM */         this.schedulePreviewRefresh(false, debounceMs);
+    /* SDA CUSTOM */     }
     /* SDA CUSTOM */ }
 
     /* SDA CUSTOM */ private getKpiChartFillColor(): string {
@@ -774,6 +794,30 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
     /* SDA CUSTOM */         this.refreshKpiPreview(forceRebuild);
     /* SDA CUSTOM */     }, debounceMs);
     /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ // SDA CUSTOM - Soft preview update to keep color pickers opened while selecting
+    /* SDA CUSTOM */ private schedulePreviewUpdate(debounceMs: number = 0): void {
+    /* SDA CUSTOM */     const updateFromPanel = () => {
+    /* SDA CUSTOM */         if (!this.panelChartComponent?.componentRef?.instance) {
+    /* SDA CUSTOM */             return;
+    /* SDA CUSTOM */         }
+    /* SDA CUSTOM */         this.panelChartComponent.componentRef.instance.inject.edaChart = this.edaChart;
+    /* SDA CUSTOM */         this.panelChartComponent.updateComponent?.();
+    /* SDA CUSTOM */     };
+
+    /* SDA CUSTOM */     if (debounceMs <= 0) {
+    /* SDA CUSTOM */         updateFromPanel();
+    /* SDA CUSTOM */         return;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     if (this.previewRefreshTimer) {
+    /* SDA CUSTOM */         clearTimeout(this.previewRefreshTimer);
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     this.previewRefreshTimer = setTimeout(() => {
+    /* SDA CUSTOM */         this.previewRefreshTimer = null;
+    /* SDA CUSTOM */         updateFromPanel();
+    /* SDA CUSTOM */     }, debounceMs);
+    /* SDA CUSTOM */ }
+    /* SDA CUSTOM */ // END SDA CUSTOM
     /* SDA CUSTOM */ // END SDA CUSTOM
 
     /* SDA CUSTOM */ // SDA CUSTOM - Normalize color values for dialog inputs

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/kpi-dialog/kpi-dialog.component.ts
@@ -580,7 +580,7 @@ export class KpiEditDialogComponent extends EdaDialogAbstract {
         /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.grid.drawBorder = this.showXAxis;
         /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.display = this.showXAxisLabels;
         /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.maxTicksLimit = maxTicksLimit || undefined;
-        /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.autoSkip = !useAll;
+        /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.autoSkip = false;
         /* SDA CUSTOM */ this.edaChart.chartOptions.scales.x.ticks.callback = this.buildXAxisTickCallback(
             /* SDA CUSTOM */ useAll,
             /* SDA CUSTOM */ labelsLength,

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/chart-configuration-models/kpi-config.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/chart-configuration-models/kpi-config.ts
@@ -4,6 +4,21 @@ export class KpiConfig {
     sufix: string = '';
     alertLimits: any[] = [];
     edaChart: ChartJsConfig;
+    /* SDA CUSTOM */ fontScale: number = 1;
+    /* SDA CUSTOM */ color: string;
+    /* SDA CUSTOM */ lineWidth: number = 2;
+    /* SDA CUSTOM */ lineStyle: string = 'solid';
+    /* SDA CUSTOM */ showXAxis: boolean = true;
+    /* SDA CUSTOM */ showXAxisLabels: boolean = true;
+    /* SDA CUSTOM */ xAxisLabelCount: number = 0;
+  /* SDA CUSTOM */ // SDA CUSTOM - KPI datalabel color setting
+  /* SDA CUSTOM */ labelColor: string = '#000000';
+  /* SDA CUSTOM */ // END SDA CUSTOM
+  /* SDA CUSTOM */ // SDA CUSTOM - KPI chart label settings
+  /* SDA CUSTOM */ showLabels: boolean = false;
+  /* SDA CUSTOM */ showLabelsPercent: boolean = false;
+  /* SDA CUSTOM */ labelBackgroundColor: string = '';
+  /* SDA CUSTOM */ // END SDA CUSTOM
     constructor(init?: Partial<KpiConfig>) {
         this.edaChart = new ChartJsConfig(
           init?.edaChart?.colors || [],
@@ -15,7 +30,16 @@ export class KpiConfig {
           init?.edaChart?.numberOfColumns || 0,
           init?.edaChart?.assignedColors || []
         );
-        
+        /* SDA CUSTOM */ this.lineWidth = init?.lineWidth ?? this.lineWidth;
+        /* SDA CUSTOM */ this.lineStyle = init?.lineStyle ?? this.lineStyle;
+        /* SDA CUSTOM */ this.showXAxis = init?.showXAxis ?? this.showXAxis;
+        /* SDA CUSTOM */ this.showXAxisLabels = init?.showXAxisLabels ?? this.showXAxisLabels;
+        /* SDA CUSTOM */ this.xAxisLabelCount = init?.xAxisLabelCount ?? this.xAxisLabelCount;
+        /* SDA CUSTOM */ this.labelColor = init?.labelColor ?? this.labelColor;
+        /* SDA CUSTOM */ this.showLabels = init?.showLabels ?? init?.edaChart?.showLabels ?? this.showLabels;
+        /* SDA CUSTOM */ this.showLabelsPercent = init?.showLabelsPercent ?? init?.edaChart?.showLabelsPercent ?? this.showLabelsPercent;
+        /* SDA CUSTOM */ this.labelBackgroundColor = init?.labelBackgroundColor ?? this.labelBackgroundColor;
+
         Object.assign(this, init);
 
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.ts
@@ -825,15 +825,15 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         /* SDA CUSTOM */ if (!chartOptions.scales.x.ticks) {
             /* SDA CUSTOM */ chartOptions.scales.x.ticks = {};
         /* SDA CUSTOM */ }
-
-        /* SDA CUSTOM */ chartOptions.scales.x.display = showAxis;
-        /* SDA CUSTOM */ chartOptions.scales.x.ticks.display = showAxis && showLabels;
+        /* SDA CUSTOM */ if (!chartOptions.scales.x.grid) {
+            /* SDA CUSTOM */ chartOptions.scales.x.grid = {};
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ chartOptions.scales.x.display = showAxis || showLabels;
+        /* SDA CUSTOM */ chartOptions.scales.x.grid.drawBorder = showAxis;
+        /* SDA CUSTOM */ chartOptions.scales.x.ticks.display = showLabels;
         /* SDA CUSTOM */ chartOptions.scales.x.ticks.maxTicksLimit = maxTicksLimit || undefined;
         /* SDA CUSTOM */ chartOptions.scales.x.ticks.autoSkip = !useAll;
         /* SDA CUSTOM */ chartOptions.scales.x.ticks.callback = this.buildKpiXAxisTickCallback(useAll, labelsLength, labelCount, chartLabels);
-        /* SDA CUSTOM */ if (chartOptions.scales.x.grid) {
-            /* SDA CUSTOM */ chartOptions.scales.x.grid.display = showAxis ? chartOptions.scales.x.grid.display : false;
-        /* SDA CUSTOM */ }
     /* SDA CUSTOM */ }
 
     /* SDA CUSTOM */ private buildKpiXAxisTickCallback(

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.ts
@@ -487,17 +487,32 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         chartConfig.value = this.props.data.values[0][0];
         chartConfig.header = this.props.query[0]?.display_name?.default;
         chartConfig.showChart = false;
+        /* SDA CUSTOM */ chartConfig.showResizeControls = !!this.props?.canEdit && !!this.props?.canSave && !this.props?.locked;
 
         const config: any = this.props.config;
         const alertLimits = config?.config?.alertLimits || [];
 
         if (config) {
             chartConfig.sufix = (<KpiConfig>config.getConfig())?.sufix || '';
+            /* SDA CUSTOM */ chartConfig.fontScale = (<KpiConfig>config.getConfig())?.fontScale || 1;
+            /* SDA CUSTOM */ chartConfig.color = (<KpiConfig>config.getConfig())?.color || null;
+            /* SDA CUSTOM */ chartConfig.lineWidth = (<KpiConfig>config.getConfig())?.lineWidth ?? 2;
+            /* SDA CUSTOM */ chartConfig.lineStyle = (<KpiConfig>config.getConfig())?.lineStyle ?? 'solid';
+            /* SDA CUSTOM */ chartConfig.showXAxis = (<KpiConfig>config.getConfig())?.showXAxis ?? true;
+            /* SDA CUSTOM */ chartConfig.showXAxisLabels = (<KpiConfig>config.getConfig())?.showXAxisLabels ?? true;
+            /* SDA CUSTOM */ chartConfig.xAxisLabelCount = (<KpiConfig>config.getConfig())?.xAxisLabelCount ?? 0;
             chartConfig.alertLimits = alertLimits;
             chartConfig.edaChart =  (<KpiConfig>config.getConfig())?.edaChart;
         } else {
             chartConfig.sufix = '';
             chartConfig.alertLimits = [];
+            /* SDA CUSTOM */ chartConfig.fontScale = 1;
+            /* SDA CUSTOM */ chartConfig.color = null;
+            /* SDA CUSTOM */ chartConfig.lineWidth = 2;
+            /* SDA CUSTOM */ chartConfig.lineStyle = 'solid';
+            /* SDA CUSTOM */ chartConfig.showXAxis = true;
+            /* SDA CUSTOM */ chartConfig.showXAxisLabels = true;
+            /* SDA CUSTOM */ chartConfig.xAxisLabelCount = 0;
         }
 
         this.createEdaKpiComponent(chartConfig);
@@ -513,7 +528,23 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         this.componentRef = this.entry.createComponent(factory);
         this.componentRef.instance.inject = inject;
         this.componentRef.instance.onNotify.subscribe(data => {
-            const kpiConfig = new KpiConfig({ sufix: data.sufix, alertLimits: inject.alertLimits });
+            /* SDA CUSTOM */ const currentConfig = <KpiConfig>this.props.config.getConfig();
+            /* SDA CUSTOM */ const kpiConfig = new KpiConfig({
+                /* SDA CUSTOM */ sufix: data.sufix,
+                /* SDA CUSTOM */ alertLimits: inject.alertLimits,
+                /* SDA CUSTOM */ color: inject.color ?? currentConfig?.color ?? null,
+                /* SDA CUSTOM */ fontScale: data.fontScale,
+                /* SDA CUSTOM */ lineWidth: inject.lineWidth,
+                /* SDA CUSTOM */ lineStyle: inject.lineStyle,
+                /* SDA CUSTOM */ showXAxis: inject.showXAxis,
+                /* SDA CUSTOM */ showXAxisLabels: inject.showXAxisLabels,
+                /* SDA CUSTOM */ xAxisLabelCount: inject.xAxisLabelCount,
+                /* SDA CUSTOM */ showLabels: currentConfig?.showLabels ?? false,
+                /* SDA CUSTOM */ showLabelsPercent: currentConfig?.showLabelsPercent ?? false,
+                /* SDA CUSTOM */ labelColor: currentConfig?.labelColor ?? '#000000',
+                /* SDA CUSTOM */ labelBackgroundColor: currentConfig?.labelBackgroundColor ?? '',
+                /* SDA CUSTOM */ edaChart: currentConfig?.edaChart
+            /* SDA CUSTOM */ });
             (<KpiConfig><unknown>this.props.config.setConfig(kpiConfig));
         })
     }
@@ -599,17 +630,30 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
   /*SDA CUSTOM*/          chartOptions.chartOptions.layout = {};
   /*SDA CUSTOM*/      }
 
+    /* SDA CUSTOM */ /*SDA CUSTOM*/      const showValueLabels = !!(cfg?.showLabels || cfg?.showLabelsPercent);
+    /* SDA CUSTOM */ /*SDA CUSTOM*/      const topPadding = showValueLabels ? 24 : 15;
+
   /*SDA CUSTOM*/      chartOptions.chartOptions.layout.padding = {
-  /*SDA CUSTOM*/          top: 15,
+    /* SDA CUSTOM */ /*SDA CUSTOM*/          top: topPadding,
   /*SDA CUSTOM*/          right: 15,
   /*SDA CUSTOM*/          bottom: 25,
   /*SDA CUSTOM*/          left: 20
   /*SDA CUSTOM*/      };
+
+    /* SDA CUSTOM */ /*SDA CUSTOM*/      if (!chartOptions.chartOptions.plugins) {
+    /* SDA CUSTOM */ /*SDA CUSTOM*/          chartOptions.chartOptions.plugins = {};
+    /* SDA CUSTOM */ /*SDA CUSTOM*/      }
+    /* SDA CUSTOM */ /*SDA CUSTOM*/      if (!chartOptions.chartOptions.plugins.datalabels) {
+    /* SDA CUSTOM */ /*SDA CUSTOM*/          chartOptions.chartOptions.plugins.datalabels = {};
+    /* SDA CUSTOM */ /*SDA CUSTOM*/      }
+    /* SDA CUSTOM */ /*SDA CUSTOM*/      chartOptions.chartOptions.plugins.datalabels.clamp = true;
+    /* SDA CUSTOM */ /*SDA CUSTOM*/      chartOptions.chartOptions.plugins.datalabels.clip = false;
   /*SDA CUSTOM*/
 
         // let chartConfig: any = {};
         chartConfig.edaChart = {}
         chartConfig.showChart = true;
+        /* SDA CUSTOM */ chartConfig.showResizeControls = !!this.props?.canEdit && !!this.props?.canSave && !this.props?.locked;
         chartConfig.edaChart.edaChart = chartSubType;
         chartConfig.edaChart.chartType = chartType;
         chartConfig.edaChart.chartLabels = chartData[0];
@@ -622,6 +666,45 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
             chartConfig.edaChart.chartDataset[0].backgroundColor = chartConfig.edaChart.chartColors[0].backgroundColor;
             chartConfig.edaChart.chartDataset[0].borderColor = chartConfig.edaChart.chartColors[0].borderColor;
         }
+
+        /* SDA CUSTOM */ // SDA CUSTOM - KPI bar border visibility
+        /* SDA CUSTOM */ if (chartType === 'bar' && chartConfig.edaChart?.chartDataset?.length) {
+        /* SDA CUSTOM */     const borderWidth = cfg?.lineWidth ?? 2;
+        /* SDA CUSTOM */     chartConfig.edaChart.chartDataset.forEach(dataset => {
+        /* SDA CUSTOM */         dataset.borderWidth = dataset.borderWidth ?? borderWidth;
+        /* SDA CUSTOM */     });
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ // END SDA CUSTOM
+
+        /* SDA CUSTOM */ const lineWidth = cfg?.lineWidth ?? 2;
+        /* SDA CUSTOM */ const lineStyle = cfg?.lineStyle ?? 'solid';
+        /* SDA CUSTOM */ chartConfig.lineWidth = lineWidth;
+        /* SDA CUSTOM */ chartConfig.lineStyle = lineStyle;
+        /* SDA CUSTOM */ if (['line', 'area'].includes(chartType)) {
+            /* SDA CUSTOM */ this.applyKpiLineStyle(chartConfig.edaChart.chartDataset, lineWidth, lineStyle);
+        /* SDA CUSTOM */ }
+
+        /* SDA CUSTOM */ const showXAxis = cfg?.showXAxis ?? true;
+        /* SDA CUSTOM */ const showXAxisLabels = cfg?.showXAxisLabels ?? true;
+        /* SDA CUSTOM */ const xAxisLabelCount = cfg?.xAxisLabelCount ?? 0;
+        /* SDA CUSTOM */ const labelColor = cfg?.labelColor ?? chartOptions.chartOptions?.plugins?.datalabels?.color ?? '#000000';
+        /* SDA CUSTOM */ const labelBackgroundColor = cfg?.labelBackgroundColor ?? chartOptions.chartOptions?.plugins?.datalabels?.backgroundColor ?? '';
+        /* SDA CUSTOM */ chartConfig.showXAxis = showXAxis;
+        /* SDA CUSTOM */ chartConfig.showXAxisLabels = showXAxisLabels;
+        /* SDA CUSTOM */ chartConfig.xAxisLabelCount = xAxisLabelCount;
+        /* SDA CUSTOM */ chartConfig.showLabels = cfg?.showLabels ?? false;
+        /* SDA CUSTOM */ chartConfig.showLabelsPercent = cfg?.showLabelsPercent ?? false;
+        /* SDA CUSTOM */ chartConfig.labelColor = labelColor;
+        /* SDA CUSTOM */ chartConfig.labelBackgroundColor = labelBackgroundColor;
+        /* SDA CUSTOM */ if (!chartConfig.edaChart.chartOptions.plugins) {
+        /* SDA CUSTOM */     chartConfig.edaChart.chartOptions.plugins = {};
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ if (!chartConfig.edaChart.chartOptions.plugins.datalabels) {
+        /* SDA CUSTOM */     chartConfig.edaChart.chartOptions.plugins.datalabels = {};
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ chartConfig.edaChart.chartOptions.plugins.datalabels.color = labelColor;
+        /* SDA CUSTOM */ chartConfig.edaChart.chartOptions.plugins.datalabels.backgroundColor = labelBackgroundColor || null;
+        /* SDA CUSTOM */ this.applyKpiXAxisOptions(chartConfig.edaChart.chartOptions, showXAxis, showXAxisLabels, xAxisLabelCount, chartConfig.edaChart.chartLabels);
 
 
         // KPI Config
@@ -656,9 +739,31 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         if (propsConfig) {
             chartConfig.sufix = (<KpiConfig>propsConfig.getConfig())?.sufix || '';
             chartConfig.alertLimits = alertLimits;
+            /* SDA CUSTOM */ chartConfig.fontScale = (<KpiConfig>propsConfig.getConfig())?.fontScale || 1;
+            /* SDA CUSTOM */ chartConfig.color = (<KpiConfig>propsConfig.getConfig())?.color || null;
+            /* SDA CUSTOM */ chartConfig.lineWidth = (<KpiConfig>propsConfig.getConfig())?.lineWidth ?? lineWidth;
+            /* SDA CUSTOM */ chartConfig.lineStyle = (<KpiConfig>propsConfig.getConfig())?.lineStyle ?? lineStyle;
+            /* SDA CUSTOM */ chartConfig.showXAxis = (<KpiConfig>propsConfig.getConfig())?.showXAxis ?? showXAxis;
+            /* SDA CUSTOM */ chartConfig.showXAxisLabels = (<KpiConfig>propsConfig.getConfig())?.showXAxisLabels ?? showXAxisLabels;
+            /* SDA CUSTOM */ chartConfig.xAxisLabelCount = (<KpiConfig>propsConfig.getConfig())?.xAxisLabelCount ?? xAxisLabelCount;
+            /* SDA CUSTOM */ chartConfig.showLabels = (<KpiConfig>propsConfig.getConfig())?.showLabels ?? chartConfig.showLabels;
+            /* SDA CUSTOM */ chartConfig.showLabelsPercent = (<KpiConfig>propsConfig.getConfig())?.showLabelsPercent ?? chartConfig.showLabelsPercent;
+            /* SDA CUSTOM */ chartConfig.labelColor = (<KpiConfig>propsConfig.getConfig())?.labelColor ?? labelColor;
+            /* SDA CUSTOM */ chartConfig.labelBackgroundColor = (<KpiConfig>propsConfig.getConfig())?.labelBackgroundColor ?? labelBackgroundColor;
         } else {
             chartConfig.sufix = '';
             chartConfig.alertLimits = [];
+            /* SDA CUSTOM */ chartConfig.fontScale = 1;
+            /* SDA CUSTOM */ chartConfig.color = null;
+            /* SDA CUSTOM */ chartConfig.lineWidth = lineWidth;
+            /* SDA CUSTOM */ chartConfig.lineStyle = lineStyle;
+            /* SDA CUSTOM */ chartConfig.showXAxis = showXAxis;
+            /* SDA CUSTOM */ chartConfig.showXAxisLabels = showXAxisLabels;
+            /* SDA CUSTOM */ chartConfig.xAxisLabelCount = xAxisLabelCount;
+            /* SDA CUSTOM */ chartConfig.showLabels = chartConfig.showLabels ?? false;
+            /* SDA CUSTOM */ chartConfig.showLabelsPercent = chartConfig.showLabelsPercent ?? false;
+            /* SDA CUSTOM */ chartConfig.labelColor = labelColor;
+            /* SDA CUSTOM */ chartConfig.labelBackgroundColor = labelBackgroundColor;
         }
 
         this.createEdaKpiChartComponent(chartConfig);
@@ -670,6 +775,115 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         if(Math.floor(value) === value) return 0;
         return value.toString().split(".")[1].length || 0;
     }
+
+    /* SDA CUSTOM */ private applyKpiLineStyle(datasets: any[], lineWidth: number, lineStyle: string): void {
+        /* SDA CUSTOM */ if (!Array.isArray(datasets)) {
+            /* SDA CUSTOM */ return;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ const dash = this.getKpiLineDash(lineStyle);
+        /* SDA CUSTOM */ datasets.forEach(dataset => {
+            /* SDA CUSTOM */ dataset.borderWidth = lineWidth;
+            /* SDA CUSTOM */ dataset.borderDash = dash;
+        /* SDA CUSTOM */ });
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private getKpiLineDash(style: string): number[] {
+        /* SDA CUSTOM */ switch (style) {
+            /* SDA CUSTOM */ case 'dashed':
+                /* SDA CUSTOM */ return [8, 4];
+            /* SDA CUSTOM */ case 'dotted':
+                /* SDA CUSTOM */ return [2, 4];
+            /* SDA CUSTOM */ case 'solid':
+            /* SDA CUSTOM */ default:
+                /* SDA CUSTOM */ return [];
+        /* SDA CUSTOM */ }
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private applyKpiXAxisOptions(
+        /* SDA CUSTOM */ chartOptions: any,
+        /* SDA CUSTOM */ showAxis: boolean,
+        /* SDA CUSTOM */ showLabels: boolean,
+        /* SDA CUSTOM */ labelCount: number,
+        /* SDA CUSTOM */ chartLabels: any[]
+    /* SDA CUSTOM */ ): void {
+        /* SDA CUSTOM */ if (!chartOptions) {
+            /* SDA CUSTOM */ return;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ const labelsLength = Array.isArray(chartLabels) ? chartLabels.length : 0;
+        /* SDA CUSTOM */ const useAll = !labelCount || labelCount <= 0;
+        /* SDA CUSTOM */ const maxTicksLimit = useAll ? labelsLength : labelCount;
+
+        /* SDA CUSTOM */ if (!chartOptions.scales) {
+            /* SDA CUSTOM */ chartOptions.scales = {};
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ if (!chartOptions.scales.x) {
+            /* SDA CUSTOM */ chartOptions.scales.x = {};
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ if (!chartOptions.scales.x.ticks) {
+            /* SDA CUSTOM */ chartOptions.scales.x.ticks = {};
+        /* SDA CUSTOM */ }
+
+        /* SDA CUSTOM */ chartOptions.scales.x.display = showAxis;
+        /* SDA CUSTOM */ chartOptions.scales.x.ticks.display = showAxis && showLabels;
+        /* SDA CUSTOM */ chartOptions.scales.x.ticks.maxTicksLimit = maxTicksLimit || undefined;
+        /* SDA CUSTOM */ chartOptions.scales.x.ticks.autoSkip = useAll;
+        /* SDA CUSTOM */ chartOptions.scales.x.ticks.callback = this.buildKpiXAxisTickCallback(useAll, labelsLength, labelCount, chartLabels);
+        /* SDA CUSTOM */ if (chartOptions.scales.x.grid) {
+            /* SDA CUSTOM */ chartOptions.scales.x.grid.display = showAxis ? chartOptions.scales.x.grid.display : false;
+        /* SDA CUSTOM */ }
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private buildKpiXAxisTickCallback(
+        /* SDA CUSTOM */ useAll: boolean,
+        /* SDA CUSTOM */ labelsLength: number,
+        /* SDA CUSTOM */ labelCount: number,
+        /* SDA CUSTOM */ chartLabels: any[]
+    /* SDA CUSTOM */ ): ((value: any, index: number) => string) | undefined {
+        /* SDA CUSTOM */ if (useAll || labelsLength === 0 || !labelCount || labelCount <= 0) {
+            /* SDA CUSTOM */ return undefined;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ const maxCount = Math.min(labelCount, labelsLength);
+        /* SDA CUSTOM */ if (maxCount <= 1) {
+            /* SDA CUSTOM */ return (value, index) => {
+                /* SDA CUSTOM */ if (index !== 0) {
+                    /* SDA CUSTOM */ return '';
+                /* SDA CUSTOM */ }
+                /* SDA CUSTOM */ const label = Array.isArray(chartLabels)
+                    /* SDA CUSTOM */ ? (chartLabels[index] ?? chartLabels[value])
+                    /* SDA CUSTOM */ : value;
+                /* SDA CUSTOM */ return `${label ?? ''}`;
+            /* SDA CUSTOM */ };
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ const indices = this.getKpiXAxisLabelIndices(labelsLength, maxCount);
+        /* SDA CUSTOM */ return (value, index) => {
+            /* SDA CUSTOM */ if (!indices.has(index)) {
+                /* SDA CUSTOM */ return '';
+            /* SDA CUSTOM */ }
+            /* SDA CUSTOM */ const label = Array.isArray(chartLabels)
+                /* SDA CUSTOM */ ? (chartLabels[index] ?? chartLabels[value])
+                /* SDA CUSTOM */ : value;
+            /* SDA CUSTOM */ return `${label ?? ''}`;
+        /* SDA CUSTOM */ };
+    /* SDA CUSTOM */ }
+
+    /* SDA CUSTOM */ private getKpiXAxisLabelIndices(labelsLength: number, labelCount: number): Set<number> {
+        /* SDA CUSTOM */ const indices = new Set<number>();
+        /* SDA CUSTOM */ if (labelsLength <= 0) {
+            /* SDA CUSTOM */ return indices;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ if (labelCount <= 1) {
+            /* SDA CUSTOM */ indices.add(0);
+            /* SDA CUSTOM */ return indices;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ const steps = labelCount - 1;
+        /* SDA CUSTOM */ for (let i = 0; i < labelCount; i += 1) {
+            /* SDA CUSTOM */ const index = Math.round((i * (labelsLength - 1)) / steps);
+            /* SDA CUSTOM */ indices.add(index);
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ indices.add(0);
+        /* SDA CUSTOM */ indices.add(labelsLength - 1);
+        /* SDA CUSTOM */ return indices;
+    /* SDA CUSTOM */ }
 
 
     /**
@@ -683,7 +897,24 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         this.componentRef.instance.inject = inject;
 
         this.componentRef.instance.onNotify.subscribe(data => {
-            const kpiConfig = new KpiConfig({ sufix: data.sufix, alertLimits: inject.alertLimits||[], edaChart: inject.edaChart });
+            /* SDA CUSTOM */ const currentConfig = <KpiConfig>this.props.config.getConfig();
+            /* SDA CUSTOM */ const kpiConfig = new KpiConfig({
+                /* SDA CUSTOM */ sufix: data.sufix,
+                /* SDA CUSTOM */ alertLimits: inject.alertLimits||[],
+                /* SDA CUSTOM */ edaChart: inject.edaChart,
+                /* SDA CUSTOM */ fontScale: data.fontScale,
+                /* SDA CUSTOM */ lineWidth: inject.lineWidth,
+                /* SDA CUSTOM */ lineStyle: inject.lineStyle,
+                /* SDA CUSTOM */ showXAxis: inject.showXAxis,
+                /* SDA CUSTOM */ showXAxisLabels: inject.showXAxisLabels,
+                /* SDA CUSTOM */ xAxisLabelCount: inject.xAxisLabelCount,
+                /* SDA CUSTOM */ // SDA CUSTOM - Preserve KPI label settings
+                /* SDA CUSTOM */ showLabels: inject.showLabels ?? currentConfig?.showLabels ?? false,
+                /* SDA CUSTOM */ showLabelsPercent: inject.showLabelsPercent ?? currentConfig?.showLabelsPercent ?? false,
+                /* SDA CUSTOM */ labelColor: inject.labelColor ?? currentConfig?.labelColor ?? '#000000',
+                /* SDA CUSTOM */ labelBackgroundColor: inject.labelBackgroundColor ?? currentConfig?.labelBackgroundColor ?? '',
+                /* SDA CUSTOM */ // END SDA CUSTOM
+            /* SDA CUSTOM */ });
             (<KpiConfig><unknown>this.props.config.setConfig(kpiConfig));
         })
         this.configUpdated.emit();

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.ts
@@ -832,7 +832,7 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         /* SDA CUSTOM */ chartOptions.scales.x.grid.drawBorder = showAxis;
         /* SDA CUSTOM */ chartOptions.scales.x.ticks.display = showLabels;
         /* SDA CUSTOM */ chartOptions.scales.x.ticks.maxTicksLimit = maxTicksLimit || undefined;
-        /* SDA CUSTOM */ chartOptions.scales.x.ticks.autoSkip = !useAll;
+        /* SDA CUSTOM */ chartOptions.scales.x.ticks.autoSkip = false;
         /* SDA CUSTOM */ chartOptions.scales.x.ticks.callback = this.buildKpiXAxisTickCallback(useAll, labelsLength, labelCount, chartLabels);
     /* SDA CUSTOM */ }
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.ts
@@ -704,6 +704,9 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         /* SDA CUSTOM */ }
         /* SDA CUSTOM */ chartConfig.edaChart.chartOptions.plugins.datalabels.color = labelColor;
         /* SDA CUSTOM */ chartConfig.edaChart.chartOptions.plugins.datalabels.backgroundColor = labelBackgroundColor || null;
+        /* SDA CUSTOM */ if (chartType === 'bar') {
+        /* SDA CUSTOM */     chartConfig.edaChart.chartOptions.plugins.datalabels.borderRadius = 4;
+        /* SDA CUSTOM */ }
         /* SDA CUSTOM */ this.applyKpiXAxisOptions(chartConfig.edaChart.chartOptions, showXAxis, showXAxisLabels, xAxisLabelCount, chartConfig.edaChart.chartLabels);
 
 
@@ -826,7 +829,7 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         /* SDA CUSTOM */ chartOptions.scales.x.display = showAxis;
         /* SDA CUSTOM */ chartOptions.scales.x.ticks.display = showAxis && showLabels;
         /* SDA CUSTOM */ chartOptions.scales.x.ticks.maxTicksLimit = maxTicksLimit || undefined;
-        /* SDA CUSTOM */ chartOptions.scales.x.ticks.autoSkip = useAll;
+        /* SDA CUSTOM */ chartOptions.scales.x.ticks.autoSkip = !useAll;
         /* SDA CUSTOM */ chartOptions.scales.x.ticks.callback = this.buildKpiXAxisTickCallback(useAll, labelsLength, labelCount, chartLabels);
         /* SDA CUSTOM */ if (chartOptions.scales.x.grid) {
             /* SDA CUSTOM */ chartOptions.scales.x.grid.display = showAxis ? chartOptions.scales.x.grid.display : false;
@@ -839,8 +842,16 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         /* SDA CUSTOM */ labelCount: number,
         /* SDA CUSTOM */ chartLabels: any[]
     /* SDA CUSTOM */ ): ((value: any, index: number) => string) | undefined {
-        /* SDA CUSTOM */ if (useAll || labelsLength === 0 || !labelCount || labelCount <= 0) {
+        /* SDA CUSTOM */ if (labelsLength === 0) {
             /* SDA CUSTOM */ return undefined;
+        /* SDA CUSTOM */ }
+        /* SDA CUSTOM */ if (useAll || !labelCount || labelCount <= 0) {
+            /* SDA CUSTOM */ return (value, index) => {
+                /* SDA CUSTOM */ const label = Array.isArray(chartLabels)
+                    /* SDA CUSTOM */ ? (chartLabels[index] ?? chartLabels[value])
+                    /* SDA CUSTOM */ : value;
+                /* SDA CUSTOM */ return `${label ?? ''}`;
+            /* SDA CUSTOM */ };
         /* SDA CUSTOM */ }
         /* SDA CUSTOM */ const maxCount = Math.min(labelCount, labelsLength);
         /* SDA CUSTOM */ if (maxCount <= 1) {

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.ts
@@ -17,6 +17,9 @@ export class PanelChart {
   public draggable: boolean;
   public coordinates: Array<Array<number>>;
   public zoom: number;
+  /* SDA CUSTOM */ public canEdit: boolean;
+  /* SDA CUSTOM */ public canSave: boolean;
+  /* SDA CUSTOM */ public locked: boolean;
 
   constructor(init?: Partial<PanelChart>) {
     Object.assign(this, init);

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/charts-config-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/charts-config-utils.ts
@@ -46,15 +46,28 @@ export const ChartsConfigUtils = {
       config = {
         sufix: ebp.panelChart.componentRef.instance.inject.sufix,
         alertLimits: ebp.panelChart.componentRef.instance.inject.alertLimits,
+        /* SDA CUSTOM */ fontScale: ebp.panelChart.componentRef.instance.inject.fontScale,
+        /* SDA CUSTOM */ color: ebp.panelChart.componentRef.instance.inject.color,
+        /* SDA CUSTOM */ lineWidth: ebp.panelChart.componentRef.instance.inject.lineWidth,
+        /* SDA CUSTOM */ lineStyle: ebp.panelChart.componentRef.instance.inject.lineStyle,
+        /* SDA CUSTOM */ showXAxis: ebp.panelChart.componentRef.instance.inject.showXAxis,
+        /* SDA CUSTOM */ showXAxisLabels: ebp.panelChart.componentRef.instance.inject.showXAxisLabels,
+        /* SDA CUSTOM */ xAxisLabelCount: ebp.panelChart.componentRef.instance.inject.xAxisLabelCount,
+        /* SDA CUSTOM */ labelColor: ebp.panelChart.componentRef.instance.inject.labelColor,
+        /* SDA CUSTOM */ labelBackgroundColor: ebp.panelChart.componentRef.instance.inject.labelBackgroundColor,
+        /* SDA CUSTOM */ showLabels: ebp.panelChart.componentRef.instance.inject.showLabels,
+        /* SDA CUSTOM */ showLabelsPercent: ebp.panelChart.componentRef.instance.inject.showLabelsPercent,
         edaChart: {}
       }
 
-      if (kpiChart.edaChart) {
+      /* SDA CUSTOM */ if (kpiChart?.edaChart) {
         config.edaChart.colors = kpiChart.chartColors;
         config.edaChart.chartType = ebp.panelChart.props.chartType;
+        /* SDA CUSTOM */ config.edaChart.showLabels = ebp.panelChart.componentRef.instance.inject.showLabels;
+        /* SDA CUSTOM */ config.edaChart.showLabelsPercent = ebp.panelChart.componentRef.instance.inject.showLabelsPercent;
 
-        // colors: ebp.panelChart.props.config && ebp.panelChart.props.config.getConfig() ? ebp.panelChart.props.config.getConfig()['colors'] : [], 
-        // chartType: ebp.panelChart.props.chartType, 
+        // colors: ebp.panelChart.props.config && ebp.panelChart.props.config.getConfig() ? ebp.panelChart.props.config.getConfig()['colors'] : [],
+        // chartType: ebp.panelChart.props.chartType,
       }
 
     } else if (ebp.panelChart.componentRef && ebp.panelChart.props.chartType === 'dynamicText') {
@@ -71,7 +84,7 @@ export const ChartsConfigUtils = {
         legendPosition: ebp.panelChart.componentRef ? ebp.panelChart.componentRef.instance.inject.legendPosition : null,
         color: ebp.panelChart.componentRef ? ebp.panelChart.componentRef.instance.inject.color : null,
         draggable: ebp.panelChart.componentRef ? ebp.panelChart.componentRef.instance.inject.draggable : null,
-        
+
       }
     } else if(ebp.panelChart.props.chartType === 'treetable') {
       config = {
@@ -104,9 +117,9 @@ export const ChartsConfigUtils = {
       };
     } else{
       // Chart.js
-      config = { 
-        colors: ebp.panelChart.props.config && ebp.panelChart.props.config.getConfig() ? ebp.panelChart.props.config.getConfig()['colors'] : [], 
-        chartType: ebp.panelChart.props.chartType, 
+      config = {
+        /* SDA CUSTOM */ colors: ebp.panelChart.props.config && ebp.panelChart.props.config.getConfig() ? ebp.panelChart.props.config.getConfig()['colors'] : [],
+        /* SDA CUSTOM */ chartType: ebp.panelChart.props.chartType,
         addTrend: ebp.panelChart.props.config && ebp.panelChart.props.config.getConfig() ? ebp.panelChart.props.config.getConfig()['addTrend'] : false,
         addComparative: ebp.panelChart.props.config && ebp.panelChart.props.config.getConfig() ? ebp.panelChart.props.config.getConfig()['addComparative'] : false,
         showLabels: ebp.panelChart.props.config && ebp.panelChart.props.config.getConfig() ? ebp.panelChart.props.config.getConfig()['showLabels'] : false,

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -435,17 +435,45 @@
     <source>Color del gráfico</source>
     <target>Color del gràfic</target>
   </trans-unit>
+  <trans-unit id="kpiAppearanceH6">
+    <source>Apariencia</source>
+    <target>Aparença</target>
+  </trans-unit>
+  <trans-unit id="kpiIndicatorColorLabel">
+    <source>Color del indicador</source>
+    <target>Color de l'indicador</target>
+  </trans-unit>
+  <trans-unit id="kpiSeriesColorLabel">
+    <source>Color de la serie</source>
+    <target>Color de la sèrie</target>
+  </trans-unit>
+  <trans-unit id="kpiLineColorLabel">
+    <source>Color de línea</source>
+    <target>Color de línia</target>
+  </trans-unit>
+  <trans-unit id="kpiAreaColorLabel">
+    <source>Color de área</source>
+    <target>Color d'àrea</target>
+  </trans-unit>
+  <trans-unit id="kpiAxisScaleH6">
+    <source>Ejes y escala</source>
+    <target>Eixos i escala</target>
+  </trans-unit>
+  <trans-unit id="kpiLabelsValuesH6">
+    <source>Etiquetas y valores</source>
+    <target>Etiquetes i valors</target>
+  </trans-unit>
   <trans-unit id="kpiLineH6">
     <source>Línea</source>
     <target>Línia</target>
   </trans-unit>
   <trans-unit id="kpiLineWidthLabel">
-    <source>Ancho de línea</source>
-    <target>Ample de línia</target>
+    <source>Grosor de línea</source>
+    <target>Gruix de línia</target>
   </trans-unit>
   <trans-unit id="kpiLineStyleLabel">
-    <source>Estilo de línea</source>
-    <target>Estil de línia</target>
+    <source>Tipo de línea</source>
+    <target>Tipus de línia</target>
   </trans-unit>
   <trans-unit id="kpiLineStyleSolid">
     <source>Sólida</source>
@@ -464,20 +492,20 @@
     <target>Eix horitzontal</target>
   </trans-unit>
   <trans-unit id="kpiXAxisShowLabel">
-    <source>Mostrar eje</source>
-    <target>Mostra l'eix</target>
+    <source>Mostrar eje X</source>
+    <target>Mostra l'eix X</target>
   </trans-unit>
   <trans-unit id="kpiXAxisLabelsLabel">
-    <source>Mostrar etiquetas del eje</source>
-    <target>Mostra les etiquetes de l'eix</target>
+    <source>Mostrar etiquetas del eje X</source>
+    <target>Mostra les etiquetes de l'eix X</target>
   </trans-unit>
   <trans-unit id="kpiXAxisAllLabelsLabel">
-    <source>Todas las etiquetas</source>
-    <target>Totes les etiquetes</target>
+    <source>Mostrar todas las etiquetas</source>
+    <target>Mostra totes les etiquetes</target>
   </trans-unit>
   <trans-unit id="kpiXAxisLabelCountLabel">
-    <source>Número de etiquetas</source>
-    <target>Nombre d'etiquetes</target>
+    <source>Máximo de etiquetas</source>
+    <target>Màxim d'etiquetes</target>
   </trans-unit>
   <trans-unit id="unlockPanel">
     <source>Desbloquear panel</source>
@@ -488,9 +516,25 @@
     <source>Mostrar etiquetas del gráfico</source>
     <target>Mostra les etiquetes del gràfic</target>
   </trans-unit>
+  <trans-unit id="kpiShowValueLabelsLabel">
+    <source>Mostrar valores en el gráfico</source>
+    <target>Mostra els valors al gràfic</target>
+  </trans-unit>
   <trans-unit id="showLabelsPercent">
     <source>Mostrar Etiquetas en Porcentajes</source>
     <target>Mostra les etiquetes en percentatge</target>
+  </trans-unit>
+  <trans-unit id="kpiShowValuePercentLabel">
+    <source>Mostrar valores en porcentaje</source>
+    <target>Mostra els valors en percentatge</target>
+  </trans-unit>
+  <trans-unit id="kpiValueLabelsTooltip">
+    <source>Mostrar u ocultar los valores en el gráfico</source>
+    <target>Mostra o oculta els valors al gràfic</target>
+  </trans-unit>
+  <trans-unit id="kpiValueLabelsPercentTooltip">
+    <source>Mostrar u ocultar los valores en porcentaje en el gráfico</source>
+    <target>Mostra o oculta els valors en percentatge al gràfic</target>
   </trans-unit>
   <trans-unit id="colorChartBorderLabel">
     <source>Color del borde</source>
@@ -505,12 +549,12 @@
     <target>Color d'emplenat</target>
   </trans-unit>
   <trans-unit id="kpiLabelColorLabel">
-    <source>Color de las etiquetas</source>
-    <target>Color de les etiquetes</target>
+    <source>Color del texto de etiquetas</source>
+    <target>Color del text de les etiquetes</target>
   </trans-unit>
   <trans-unit id="kpiLabelBackgroundColorLabel">
-    <source>Color de fondo de las etiquetas</source>
-    <target>Color de fons de les etiquetes</target>
+    <source>Fondo de etiquetas</source>
+    <target>Fons de les etiquetes</target>
   </trans-unit>
   <!-- END SDA CUSTOM -->
 </body>

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -439,6 +439,14 @@
     <source>Apariencia</source>
     <target>Aparença</target>
   </trans-unit>
+  <trans-unit id="kpiOptionsPanelTitle">
+    <source>Opciones de visualización</source>
+    <target>Opcions de visualització</target>
+  </trans-unit>
+  <trans-unit id="kpiResetSectionButton">
+    <source>Restaurar</source>
+    <target>Restablir</target>
+  </trans-unit>
   <trans-unit id="kpiIndicatorColorLabel">
     <source>Color del indicador</source>
     <target>Color de l'indicador</target>

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -427,10 +427,92 @@
     <source>Bloquear panel</source>
     <target>Bloqueja el panell</target>
   </trans-unit>
+  <trans-unit id="colorKpiLabel">
+    <source>Color del KPI</source>
+    <target>Color del KPI</target>
+  </trans-unit>
+  <trans-unit id="colorChartLabel">
+    <source>Color del gráfico</source>
+    <target>Color del gràfic</target>
+  </trans-unit>
+  <trans-unit id="kpiLineH6">
+    <source>Línea</source>
+    <target>Línia</target>
+  </trans-unit>
+  <trans-unit id="kpiLineWidthLabel">
+    <source>Ancho de línea</source>
+    <target>Ample de línia</target>
+  </trans-unit>
+  <trans-unit id="kpiLineStyleLabel">
+    <source>Estilo de línea</source>
+    <target>Estil de línia</target>
+  </trans-unit>
+  <trans-unit id="kpiLineStyleSolid">
+    <source>Sólida</source>
+    <target>Sòlida</target>
+  </trans-unit>
+  <trans-unit id="kpiLineStyleDashed">
+    <source>Discontinua</source>
+    <target>Discontínua</target>
+  </trans-unit>
+  <trans-unit id="kpiLineStyleDotted">
+    <source>Punteada</source>
+    <target>Puntejada</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisH6">
+    <source>Eje horizontal</source>
+    <target>Eix horitzontal</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisShowLabel">
+    <source>Mostrar eje</source>
+    <target>Mostra l'eix</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisLabelsLabel">
+    <source>Mostrar etiquetas del eje</source>
+    <target>Mostra les etiquetes de l'eix</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisAllLabelsLabel">
+    <source>Todas las etiquetas</source>
+    <target>Totes les etiquetes</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisLabelCountLabel">
+    <source>Número de etiquetas</source>
+    <target>Nombre d'etiquetes</target>
+  </trans-unit>
   <trans-unit id="unlockPanel">
     <source>Desbloquear panel</source>
     <target>Desbloqueja el panell</target>
   </trans-unit>
+  <!-- SDA CUSTOM - KPI/chart option labels -->
+  <trans-unit id="showLabels">
+    <source>Mostrar etiquetas del gráfico</source>
+    <target>Mostra les etiquetes del gràfic</target>
+  </trans-unit>
+  <trans-unit id="showLabelsPercent">
+    <source>Mostrar Etiquetas en Porcentajes</source>
+    <target>Mostra les etiquetes en percentatge</target>
+  </trans-unit>
+  <trans-unit id="colorChartBorderLabel">
+    <source>Color del borde</source>
+    <target>Color de la vora</target>
+  </trans-unit>
+  <trans-unit id="colorChartLineLabel">
+    <source>Color de la línea</source>
+    <target>Color de la línia</target>
+  </trans-unit>
+  <trans-unit id="colorChartFillLabel">
+    <source>Color de relleno</source>
+    <target>Color d'emplenat</target>
+  </trans-unit>
+  <trans-unit id="kpiLabelColorLabel">
+    <source>Color de las etiquetas</source>
+    <target>Color de les etiquetes</target>
+  </trans-unit>
+  <trans-unit id="kpiLabelBackgroundColorLabel">
+    <source>Color de fondo de las etiquetas</source>
+    <target>Color de fons de les etiquetes</target>
+  </trans-unit>
+  <!-- END SDA CUSTOM -->
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -427,6 +427,10 @@
     <source>Bloquear panel</source>
     <target>Bloqueja el panell</target>
   </trans-unit>
+  <trans-unit id="unlockPanel">
+    <source>Desbloquear panel</source>
+    <target>Desbloqueja el panell</target>
+  </trans-unit>
   <trans-unit id="colorKpiLabel">
     <source>Color del KPI</source>
     <target>Color del KPI</target>
@@ -445,7 +449,7 @@
   </trans-unit>
   <trans-unit id="resetSectionButton">
     <source>Restaurar</source>
-    <target>Restablir</target>
+    <target>Restableix</target>
   </trans-unit>
   <trans-unit id="colorLabelIndicator">
     <source>Color del indicador</source>
@@ -489,7 +493,7 @@
   </trans-unit>
   <trans-unit id="lineStyleDotted">
     <source>Punteada</source>
-    <target>Puntejada</target>
+    <target>De punts</target>
   </trans-unit>
   <trans-unit id="xAxisShowLabel">
     <source>Mostrar eje X</source>
@@ -506,10 +510,6 @@
   <trans-unit id="xAxisLabelCountLabel">
     <source>Máximo de etiquetas</source>
     <target>Màxim d'etiquetes</target>
-  </trans-unit>
-  <trans-unit id="unlockPanel">
-    <source>Desbloquear panel</source>
-    <target>Desbloqueja el panell</target>
   </trans-unit>
   <!-- SDA CUSTOM - KPI/chart option labels -->
   <trans-unit id="showChartLabels">

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -435,83 +435,75 @@
     <source>Color del gráfico</source>
     <target>Color del gràfic</target>
   </trans-unit>
-  <trans-unit id="kpiAppearanceH6">
+  <trans-unit id="appearanceSection">
     <source>Apariencia</source>
     <target>Aparença</target>
   </trans-unit>
-  <trans-unit id="kpiOptionsPanelTitle">
+  <trans-unit id="panelTitleOptions">
     <source>Opciones de visualización</source>
     <target>Opcions de visualització</target>
   </trans-unit>
-  <trans-unit id="kpiResetSectionButton">
+  <trans-unit id="resetSectionButton">
     <source>Restaurar</source>
     <target>Restablir</target>
   </trans-unit>
-  <trans-unit id="kpiIndicatorColorLabel">
+  <trans-unit id="colorLabelIndicator">
     <source>Color del indicador</source>
     <target>Color de l'indicador</target>
   </trans-unit>
-  <trans-unit id="kpiSeriesColorLabel">
+  <trans-unit id="colorLabelSeries">
     <source>Color de la serie</source>
     <target>Color de la sèrie</target>
   </trans-unit>
-  <trans-unit id="kpiLineColorLabel">
+  <trans-unit id="colorLabelLine">
     <source>Color de línea</source>
     <target>Color de línia</target>
   </trans-unit>
-  <trans-unit id="kpiAreaColorLabel">
+  <trans-unit id="colorLabelArea">
     <source>Color de área</source>
     <target>Color d'àrea</target>
   </trans-unit>
-  <trans-unit id="kpiAxisScaleH6">
+  <trans-unit id="axisScaleH6">
     <source>Ejes y escala</source>
     <target>Eixos i escala</target>
   </trans-unit>
-  <trans-unit id="kpiLabelsValuesH6">
+  <trans-unit id="labelsValuesH6">
     <source>Etiquetas y valores</source>
     <target>Etiquetes i valors</target>
   </trans-unit>
-  <trans-unit id="kpiLineH6">
-    <source>Línea</source>
-    <target>Línia</target>
-  </trans-unit>
-  <trans-unit id="kpiLineWidthLabel">
+  <trans-unit id="widthLabelLine">
     <source>Grosor de línea</source>
     <target>Gruix de línia</target>
   </trans-unit>
-  <trans-unit id="kpiLineStyleLabel">
+  <trans-unit id="lineStyleLabel">
     <source>Tipo de línea</source>
     <target>Tipus de línia</target>
   </trans-unit>
-  <trans-unit id="kpiLineStyleSolid">
+  <trans-unit id="lineStyleSolid">
     <source>Sólida</source>
     <target>Sòlida</target>
   </trans-unit>
-  <trans-unit id="kpiLineStyleDashed">
+  <trans-unit id="lineStyleDashed">
     <source>Discontinua</source>
     <target>Discontínua</target>
   </trans-unit>
-  <trans-unit id="kpiLineStyleDotted">
+  <trans-unit id="lineStyleDotted">
     <source>Punteada</source>
     <target>Puntejada</target>
   </trans-unit>
-  <trans-unit id="kpiXAxisH6">
-    <source>Eje horizontal</source>
-    <target>Eix horitzontal</target>
-  </trans-unit>
-  <trans-unit id="kpiXAxisShowLabel">
+  <trans-unit id="xAxisShowLabel">
     <source>Mostrar eje X</source>
     <target>Mostra l'eix X</target>
   </trans-unit>
-  <trans-unit id="kpiXAxisLabelsLabel">
+  <trans-unit id="xAxisLabelsLabel">
     <source>Mostrar etiquetas del eje X</source>
     <target>Mostra les etiquetes de l'eix X</target>
   </trans-unit>
-  <trans-unit id="kpiXAxisAllLabelsLabel">
+  <trans-unit id="xAxisAllLabelsLabel">
     <source>Mostrar todas las etiquetas</source>
     <target>Mostra totes les etiquetes</target>
   </trans-unit>
-  <trans-unit id="kpiXAxisLabelCountLabel">
+  <trans-unit id="xAxisLabelCountLabel">
     <source>Máximo de etiquetas</source>
     <target>Màxim d'etiquetes</target>
   </trans-unit>
@@ -524,7 +516,7 @@
     <source>Mostrar etiquetas del gráfico</source>
     <target>Mostra les etiquetes del gràfic</target>
   </trans-unit>
-  <trans-unit id="kpiShowValueLabelsLabel">
+  <trans-unit id="showValueLabelsLabel">
     <source>Mostrar valores en el gráfico</source>
     <target>Mostra els valors al gràfic</target>
   </trans-unit>
@@ -532,15 +524,15 @@
     <source>Mostrar Etiquetas en Porcentajes</source>
     <target>Mostra les etiquetes en percentatge</target>
   </trans-unit>
-  <trans-unit id="kpiShowValuePercentLabel">
+  <trans-unit id="showValuePercentLabel">
     <source>Mostrar valores en porcentaje</source>
     <target>Mostra els valors en percentatge</target>
   </trans-unit>
-  <trans-unit id="kpiValueLabelsTooltip">
+  <trans-unit id="valueLabelsTooltip">
     <source>Mostrar u ocultar los valores en el gráfico</source>
     <target>Mostra o oculta els valors al gràfic</target>
   </trans-unit>
-  <trans-unit id="kpiValueLabelsPercentTooltip">
+  <trans-unit id="valueLabelsPercentTooltip">
     <source>Mostrar u ocultar los valores en porcentaje en el gráfico</source>
     <target>Mostra o oculta els valors en percentatge al gràfic</target>
   </trans-unit>
@@ -548,19 +540,15 @@
     <source>Color del borde</source>
     <target>Color de la vora</target>
   </trans-unit>
-  <trans-unit id="colorChartLineLabel">
-    <source>Color de la línea</source>
-    <target>Color de la línia</target>
-  </trans-unit>
   <trans-unit id="colorChartFillLabel">
     <source>Color de relleno</source>
     <target>Color d'emplenat</target>
   </trans-unit>
-  <trans-unit id="kpiLabelColorLabel">
+  <trans-unit id="labelColorLabel">
     <source>Color del texto de etiquetas</source>
     <target>Color del text de les etiquetes</target>
   </trans-unit>
-  <trans-unit id="kpiLabelBackgroundColorLabel">
+  <trans-unit id="labelBackgroundColorLabel">
     <source>Fondo de etiquetas</source>
     <target>Fons de les etiquetes</target>
   </trans-unit>

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -512,7 +512,7 @@
     <target>Desbloqueja el panell</target>
   </trans-unit>
   <!-- SDA CUSTOM - KPI/chart option labels -->
-  <trans-unit id="showLabels">
+  <trans-unit id="showChartLabels">
     <source>Mostrar etiquetas del gráfico</source>
     <target>Mostra les etiquetes del gràfic</target>
   </trans-unit>
@@ -520,7 +520,7 @@
     <source>Mostrar valores en el gráfico</source>
     <target>Mostra els valors al gràfic</target>
   </trans-unit>
-  <trans-unit id="showLabelsPercent">
+  <trans-unit id="showChartLabelsPercent">
     <source>Mostrar Etiquetas en Porcentajes</source>
     <target>Mostra les etiquetes en percentatge</target>
   </trans-unit>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -431,6 +431,88 @@
     <source>Desbloquear panel</source>
     <target>Unlock panel</target>
   </trans-unit>
+  <trans-unit id="colorKpiLabel">
+    <source>Color del KPI</source>
+    <target>KPI color</target>
+  </trans-unit>
+  <trans-unit id="colorChartLabel">
+    <source>Color del gráfico</source>
+    <target>Chart color</target>
+  </trans-unit>
+  <trans-unit id="kpiLineH6">
+    <source>Línea</source>
+    <target>Line</target>
+  </trans-unit>
+  <trans-unit id="kpiLineWidthLabel">
+    <source>Ancho de línea</source>
+    <target>Line width</target>
+  </trans-unit>
+  <trans-unit id="kpiLineStyleLabel">
+    <source>Estilo de línea</source>
+    <target>Line style</target>
+  </trans-unit>
+  <trans-unit id="kpiLineStyleSolid">
+    <source>Sólida</source>
+    <target>Solid</target>
+  </trans-unit>
+  <trans-unit id="kpiLineStyleDashed">
+    <source>Discontinua</source>
+    <target>Dashed</target>
+  </trans-unit>
+  <trans-unit id="kpiLineStyleDotted">
+    <source>Punteada</source>
+    <target>Dotted</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisH6">
+    <source>Eje horizontal</source>
+    <target>Horizontal axis</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisShowLabel">
+    <source>Mostrar eje</source>
+    <target>Show axis</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisLabelsLabel">
+    <source>Mostrar etiquetas del eje</source>
+    <target>Show axis labels</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisAllLabelsLabel">
+    <source>Todas las etiquetas</source>
+    <target>All labels</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisLabelCountLabel">
+    <source>Número de etiquetas</source>
+    <target>Label count</target>
+  </trans-unit>
+  <!-- SDA CUSTOM - KPI/chart option labels -->
+  <trans-unit id="showLabels">
+    <source>Mostrar etiquetas del gráfico</source>
+    <target>Show chart labels</target>
+  </trans-unit>
+  <trans-unit id="showLabelsPercent">
+    <source>Mostrar Etiquetas en Porcentajes</source>
+    <target>Show labels as percentages</target>
+  </trans-unit>
+  <trans-unit id="colorChartBorderLabel">
+    <source>Color del borde</source>
+    <target>Border color</target>
+  </trans-unit>
+  <trans-unit id="colorChartLineLabel">
+    <source>Color de la línea</source>
+    <target>Line color</target>
+  </trans-unit>
+  <trans-unit id="colorChartFillLabel">
+    <source>Color de relleno</source>
+    <target>Fill color</target>
+  </trans-unit>
+  <trans-unit id="kpiLabelColorLabel">
+    <source>Color de las etiquetas</source>
+    <target>Label color</target>
+  </trans-unit>
+  <trans-unit id="kpiLabelBackgroundColorLabel">
+    <source>Color de fondo de las etiquetas</source>
+    <target>Label background color</target>
+  </trans-unit>
+  <!-- END SDA CUSTOM -->
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -443,6 +443,14 @@
     <source>Apariencia</source>
     <target>Appearance</target>
   </trans-unit>
+  <trans-unit id="kpiOptionsPanelTitle">
+    <source>Opciones de visualización</source>
+    <target>Display options</target>
+  </trans-unit>
+  <trans-unit id="kpiResetSectionButton">
+    <source>Restaurar</source>
+    <target>Reset</target>
+  </trans-unit>
   <trans-unit id="kpiIndicatorColorLabel">
     <source>Color del indicador</source>
     <target>Indicator color</target>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -439,17 +439,45 @@
     <source>Color del gráfico</source>
     <target>Chart color</target>
   </trans-unit>
+  <trans-unit id="kpiAppearanceH6">
+    <source>Apariencia</source>
+    <target>Appearance</target>
+  </trans-unit>
+  <trans-unit id="kpiIndicatorColorLabel">
+    <source>Color del indicador</source>
+    <target>Indicator color</target>
+  </trans-unit>
+  <trans-unit id="kpiSeriesColorLabel">
+    <source>Color de la serie</source>
+    <target>Series color</target>
+  </trans-unit>
+  <trans-unit id="kpiLineColorLabel">
+    <source>Color de línea</source>
+    <target>Line color</target>
+  </trans-unit>
+  <trans-unit id="kpiAreaColorLabel">
+    <source>Color de área</source>
+    <target>Area color</target>
+  </trans-unit>
+  <trans-unit id="kpiAxisScaleH6">
+    <source>Ejes y escala</source>
+    <target>Axes and scale</target>
+  </trans-unit>
+  <trans-unit id="kpiLabelsValuesH6">
+    <source>Etiquetas y valores</source>
+    <target>Labels and values</target>
+  </trans-unit>
   <trans-unit id="kpiLineH6">
     <source>Línea</source>
     <target>Line</target>
   </trans-unit>
   <trans-unit id="kpiLineWidthLabel">
-    <source>Ancho de línea</source>
-    <target>Line width</target>
+    <source>Grosor de línea</source>
+    <target>Line thickness</target>
   </trans-unit>
   <trans-unit id="kpiLineStyleLabel">
-    <source>Estilo de línea</source>
-    <target>Line style</target>
+    <source>Tipo de línea</source>
+    <target>Line type</target>
   </trans-unit>
   <trans-unit id="kpiLineStyleSolid">
     <source>Sólida</source>
@@ -468,29 +496,45 @@
     <target>Horizontal axis</target>
   </trans-unit>
   <trans-unit id="kpiXAxisShowLabel">
-    <source>Mostrar eje</source>
-    <target>Show axis</target>
+    <source>Mostrar eje X</source>
+    <target>Show X-axis</target>
   </trans-unit>
   <trans-unit id="kpiXAxisLabelsLabel">
-    <source>Mostrar etiquetas del eje</source>
-    <target>Show axis labels</target>
+    <source>Mostrar etiquetas del eje X</source>
+    <target>Show X-axis labels</target>
   </trans-unit>
   <trans-unit id="kpiXAxisAllLabelsLabel">
-    <source>Todas las etiquetas</source>
-    <target>All labels</target>
+    <source>Mostrar todas las etiquetas</source>
+    <target>Show all labels</target>
   </trans-unit>
   <trans-unit id="kpiXAxisLabelCountLabel">
-    <source>Número de etiquetas</source>
-    <target>Label count</target>
+    <source>Máximo de etiquetas</source>
+    <target>Maximum labels</target>
   </trans-unit>
   <!-- SDA CUSTOM - KPI/chart option labels -->
   <trans-unit id="showLabels">
     <source>Mostrar etiquetas del gráfico</source>
     <target>Show chart labels</target>
   </trans-unit>
+  <trans-unit id="kpiShowValueLabelsLabel">
+    <source>Mostrar valores en el gráfico</source>
+    <target>Show values on chart</target>
+  </trans-unit>
   <trans-unit id="showLabelsPercent">
     <source>Mostrar Etiquetas en Porcentajes</source>
     <target>Show labels as percentages</target>
+  </trans-unit>
+  <trans-unit id="kpiShowValuePercentLabel">
+    <source>Mostrar valores en porcentaje</source>
+    <target>Show values as percentage</target>
+  </trans-unit>
+  <trans-unit id="kpiValueLabelsTooltip">
+    <source>Mostrar u ocultar los valores en el gráfico</source>
+    <target>Show or hide values on chart</target>
+  </trans-unit>
+  <trans-unit id="kpiValueLabelsPercentTooltip">
+    <source>Mostrar u ocultar los valores en porcentaje en el gráfico</source>
+    <target>Show or hide percentage values on chart</target>
   </trans-unit>
   <trans-unit id="colorChartBorderLabel">
     <source>Color del borde</source>
@@ -505,12 +549,12 @@
     <target>Fill color</target>
   </trans-unit>
   <trans-unit id="kpiLabelColorLabel">
-    <source>Color de las etiquetas</source>
-    <target>Label color</target>
+    <source>Color del texto de etiquetas</source>
+    <target>Label text color</target>
   </trans-unit>
   <trans-unit id="kpiLabelBackgroundColorLabel">
-    <source>Color de fondo de las etiquetas</source>
-    <target>Label background color</target>
+    <source>Fondo de etiquetas</source>
+    <target>Label background</target>
   </trans-unit>
   <!-- END SDA CUSTOM -->
 </body>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -439,83 +439,75 @@
     <source>Color del gráfico</source>
     <target>Chart color</target>
   </trans-unit>
-  <trans-unit id="kpiAppearanceH6">
+  <trans-unit id="appearanceSection">
     <source>Apariencia</source>
     <target>Appearance</target>
   </trans-unit>
-  <trans-unit id="kpiOptionsPanelTitle">
+  <trans-unit id="panelTitleOptions">
     <source>Opciones de visualización</source>
     <target>Display options</target>
   </trans-unit>
-  <trans-unit id="kpiResetSectionButton">
+  <trans-unit id="resetSectionButton">
     <source>Restaurar</source>
     <target>Reset</target>
   </trans-unit>
-  <trans-unit id="kpiIndicatorColorLabel">
+  <trans-unit id="colorLabelIndicator">
     <source>Color del indicador</source>
     <target>Indicator color</target>
   </trans-unit>
-  <trans-unit id="kpiSeriesColorLabel">
+  <trans-unit id="colorLabelSeries">
     <source>Color de la serie</source>
     <target>Series color</target>
   </trans-unit>
-  <trans-unit id="kpiLineColorLabel">
+  <trans-unit id="colorLabelLine">
     <source>Color de línea</source>
     <target>Line color</target>
   </trans-unit>
-  <trans-unit id="kpiAreaColorLabel">
+  <trans-unit id="colorLabelArea">
     <source>Color de área</source>
     <target>Area color</target>
   </trans-unit>
-  <trans-unit id="kpiAxisScaleH6">
+  <trans-unit id="axisScaleH6">
     <source>Ejes y escala</source>
     <target>Axes and scale</target>
   </trans-unit>
-  <trans-unit id="kpiLabelsValuesH6">
+  <trans-unit id="labelsValuesH6">
     <source>Etiquetas y valores</source>
     <target>Labels and values</target>
   </trans-unit>
-  <trans-unit id="kpiLineH6">
-    <source>Línea</source>
-    <target>Line</target>
-  </trans-unit>
-  <trans-unit id="kpiLineWidthLabel">
+  <trans-unit id="widthLabelLine">
     <source>Grosor de línea</source>
     <target>Line thickness</target>
   </trans-unit>
-  <trans-unit id="kpiLineStyleLabel">
+  <trans-unit id="lineStyleLabel">
     <source>Tipo de línea</source>
     <target>Line type</target>
   </trans-unit>
-  <trans-unit id="kpiLineStyleSolid">
+  <trans-unit id="lineStyleSolid">
     <source>Sólida</source>
     <target>Solid</target>
   </trans-unit>
-  <trans-unit id="kpiLineStyleDashed">
+  <trans-unit id="lineStyleDashed">
     <source>Discontinua</source>
     <target>Dashed</target>
   </trans-unit>
-  <trans-unit id="kpiLineStyleDotted">
+  <trans-unit id="lineStyleDotted">
     <source>Punteada</source>
     <target>Dotted</target>
   </trans-unit>
-  <trans-unit id="kpiXAxisH6">
-    <source>Eje horizontal</source>
-    <target>Horizontal axis</target>
-  </trans-unit>
-  <trans-unit id="kpiXAxisShowLabel">
+  <trans-unit id="xAxisShowLabel">
     <source>Mostrar eje X</source>
     <target>Show X-axis</target>
   </trans-unit>
-  <trans-unit id="kpiXAxisLabelsLabel">
+  <trans-unit id="xAxisLabelsLabel">
     <source>Mostrar etiquetas del eje X</source>
     <target>Show X-axis labels</target>
   </trans-unit>
-  <trans-unit id="kpiXAxisAllLabelsLabel">
+  <trans-unit id="xAxisAllLabelsLabel">
     <source>Mostrar todas las etiquetas</source>
     <target>Show all labels</target>
   </trans-unit>
-  <trans-unit id="kpiXAxisLabelCountLabel">
+  <trans-unit id="xAxisLabelCountLabel">
     <source>Máximo de etiquetas</source>
     <target>Maximum labels</target>
   </trans-unit>
@@ -524,7 +516,7 @@
     <source>Mostrar etiquetas del gráfico</source>
     <target>Show chart labels</target>
   </trans-unit>
-  <trans-unit id="kpiShowValueLabelsLabel">
+  <trans-unit id="showValueLabelsLabel">
     <source>Mostrar valores en el gráfico</source>
     <target>Show values on chart</target>
   </trans-unit>
@@ -532,15 +524,15 @@
     <source>Mostrar Etiquetas en Porcentajes</source>
     <target>Show labels as percentages</target>
   </trans-unit>
-  <trans-unit id="kpiShowValuePercentLabel">
+  <trans-unit id="showValuePercentLabel">
     <source>Mostrar valores en porcentaje</source>
     <target>Show values as percentage</target>
   </trans-unit>
-  <trans-unit id="kpiValueLabelsTooltip">
+  <trans-unit id="valueLabelsTooltip">
     <source>Mostrar u ocultar los valores en el gráfico</source>
     <target>Show or hide values on chart</target>
   </trans-unit>
-  <trans-unit id="kpiValueLabelsPercentTooltip">
+  <trans-unit id="valueLabelsPercentTooltip">
     <source>Mostrar u ocultar los valores en porcentaje en el gráfico</source>
     <target>Show or hide percentage values on chart</target>
   </trans-unit>
@@ -548,19 +540,15 @@
     <source>Color del borde</source>
     <target>Border color</target>
   </trans-unit>
-  <trans-unit id="colorChartLineLabel">
-    <source>Color de la línea</source>
-    <target>Line color</target>
-  </trans-unit>
   <trans-unit id="colorChartFillLabel">
     <source>Color de relleno</source>
     <target>Fill color</target>
   </trans-unit>
-  <trans-unit id="kpiLabelColorLabel">
+  <trans-unit id="labelColorLabel">
     <source>Color del texto de etiquetas</source>
     <target>Label text color</target>
   </trans-unit>
-  <trans-unit id="kpiLabelBackgroundColorLabel">
+  <trans-unit id="labelBackgroundColorLabel">
     <source>Fondo de etiquetas</source>
     <target>Label background</target>
   </trans-unit>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -512,7 +512,7 @@
     <target>Maximum labels</target>
   </trans-unit>
   <!-- SDA CUSTOM - KPI/chart option labels -->
-  <trans-unit id="showLabels">
+  <trans-unit id="showChartLabels">
     <source>Mostrar etiquetas del gráfico</source>
     <target>Show chart labels</target>
   </trans-unit>
@@ -520,7 +520,7 @@
     <source>Mostrar valores en el gráfico</source>
     <target>Show values on chart</target>
   </trans-unit>
-  <trans-unit id="showLabelsPercent">
+  <trans-unit id="showChartLabelsPercent">
     <source>Mostrar Etiquetas en Porcentajes</source>
     <target>Show labels as percentages</target>
   </trans-unit>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -443,6 +443,14 @@
     <source>Apariencia</source>
     <target>Apariencia</target>
   </trans-unit>
+  <trans-unit id="kpiOptionsPanelTitle">
+    <source>Opciones de visualización</source>
+    <target>Opciones de visualización</target>
+  </trans-unit>
+  <trans-unit id="kpiResetSectionButton">
+    <source>Restaurar</source>
+    <target>Restaurar</target>
+  </trans-unit>
   <trans-unit id="kpiIndicatorColorLabel">
     <source>Color del indicador</source>
     <target>Color del indicador</target>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -514,7 +514,7 @@
     <target>Máximo de etiquetas</target>
   </trans-unit>
   <!-- SDA CUSTOM - KPI/chart option labels -->
-  <trans-unit id="showLabels">
+  <trans-unit id="showChartLabels">
     <source>Mostrar etiquetas del gráfico</source>
     <target>Mostrar etiquetas del gráfico</target>
   </trans-unit>
@@ -522,7 +522,7 @@
     <source>Mostrar valores en el gráfico</source>
     <target>Mostrar valores en el gráfico</target>
   </trans-unit>
-  <trans-unit id="showLabelsPercent">
+  <trans-unit id="showChartLabelsPercent">
     <source>Mostrar Etiquetas en Porcentajes</source>
     <target>Mostrar Etiquetas en Porcentajes</target>
   </trans-unit>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -524,7 +524,7 @@
   </trans-unit>
   <trans-unit id="showChartLabelsPercent">
     <source>Mostrar Etiquetas en Porcentajes</source>
-    <target>Mostrar Etiquetas en Porcentajes</target>
+    <target>Mostrar etiquetas en porcentaje</target>
   </trans-unit>
   <trans-unit id="showValuePercentLabel">
     <source>Mostrar valores en porcentaje</source>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -431,6 +431,88 @@
     <source>Desbloquear panel</source>
     <target>Desbloquear panel</target>
   </trans-unit>
+  <trans-unit id="colorKpiLabel">
+    <source>Color del KPI</source>
+    <target>Color del KPI</target>
+  </trans-unit>
+  <trans-unit id="colorChartLabel">
+    <source>Color del gráfico</source>
+    <target>Color del gráfico</target>
+  </trans-unit>
+  <trans-unit id="kpiLineH6">
+    <source>Línea</source>
+    <target>Línea</target>
+  </trans-unit>
+  <trans-unit id="kpiLineWidthLabel">
+    <source>Ancho de línea</source>
+    <target>Ancho de línea</target>
+  </trans-unit>
+  <trans-unit id="kpiLineStyleLabel">
+    <source>Estilo de línea</source>
+    <target>Estilo de línea</target>
+  </trans-unit>
+  <trans-unit id="kpiLineStyleSolid">
+    <source>Sólida</source>
+    <target>Sólida</target>
+  </trans-unit>
+  <trans-unit id="kpiLineStyleDashed">
+    <source>Discontinua</source>
+    <target>Discontinua</target>
+  </trans-unit>
+  <trans-unit id="kpiLineStyleDotted">
+    <source>Punteada</source>
+    <target>Punteada</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisH6">
+    <source>Eje horizontal</source>
+    <target>Eje horizontal</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisShowLabel">
+    <source>Mostrar eje</source>
+    <target>Mostrar eje</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisLabelsLabel">
+    <source>Mostrar etiquetas del eje</source>
+    <target>Mostrar etiquetas del eje</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisAllLabelsLabel">
+    <source>Todas las etiquetas</source>
+    <target>Todas las etiquetas</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisLabelCountLabel">
+    <source>Número de etiquetas</source>
+    <target>Número de etiquetas</target>
+  </trans-unit>
+  <!-- SDA CUSTOM - KPI/chart option labels -->
+  <trans-unit id="showLabels">
+    <source>Mostrar etiquetas del gráfico</source>
+    <target>Mostrar etiquetas del gráfico</target>
+  </trans-unit>
+  <trans-unit id="showLabelsPercent">
+    <source>Mostrar Etiquetas en Porcentajes</source>
+    <target>Mostrar Etiquetas en Porcentajes</target>
+  </trans-unit>
+  <trans-unit id="colorChartBorderLabel">
+    <source>Color del borde</source>
+    <target>Color del borde</target>
+  </trans-unit>
+  <trans-unit id="colorChartLineLabel">
+    <source>Color de la línea</source>
+    <target>Color de la línea</target>
+  </trans-unit>
+  <trans-unit id="colorChartFillLabel">
+    <source>Color de relleno</source>
+    <target>Color de relleno</target>
+  </trans-unit>
+  <trans-unit id="kpiLabelColorLabel">
+    <source>Color de las etiquetas</source>
+    <target>Color de las etiquetas</target>
+  </trans-unit>
+  <trans-unit id="kpiLabelBackgroundColorLabel">
+    <source>Color de fondo de las etiquetas</source>
+    <target>Color de fondo de las etiquetas</target>
+  </trans-unit>
+  <!-- END SDA CUSTOM -->
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -439,17 +439,45 @@
     <source>Color del gráfico</source>
     <target>Color del gráfico</target>
   </trans-unit>
+  <trans-unit id="kpiAppearanceH6">
+    <source>Apariencia</source>
+    <target>Apariencia</target>
+  </trans-unit>
+  <trans-unit id="kpiIndicatorColorLabel">
+    <source>Color del indicador</source>
+    <target>Color del indicador</target>
+  </trans-unit>
+  <trans-unit id="kpiSeriesColorLabel">
+    <source>Color de la serie</source>
+    <target>Color de la serie</target>
+  </trans-unit>
+  <trans-unit id="kpiLineColorLabel">
+    <source>Color de línea</source>
+    <target>Color de línea</target>
+  </trans-unit>
+  <trans-unit id="kpiAreaColorLabel">
+    <source>Color de área</source>
+    <target>Color de área</target>
+  </trans-unit>
+  <trans-unit id="kpiAxisScaleH6">
+    <source>Ejes y escala</source>
+    <target>Ejes y escala</target>
+  </trans-unit>
+  <trans-unit id="kpiLabelsValuesH6">
+    <source>Etiquetas y valores</source>
+    <target>Etiquetas y valores</target>
+  </trans-unit>
   <trans-unit id="kpiLineH6">
     <source>Línea</source>
     <target>Línea</target>
   </trans-unit>
   <trans-unit id="kpiLineWidthLabel">
-    <source>Ancho de línea</source>
-    <target>Ancho de línea</target>
+    <source>Grosor de línea</source>
+    <target>Grosor de línea</target>
   </trans-unit>
   <trans-unit id="kpiLineStyleLabel">
-    <source>Estilo de línea</source>
-    <target>Estilo de línea</target>
+    <source>Tipo de línea</source>
+    <target>Tipo de línea</target>
   </trans-unit>
   <trans-unit id="kpiLineStyleSolid">
     <source>Sólida</source>
@@ -468,29 +496,45 @@
     <target>Eje horizontal</target>
   </trans-unit>
   <trans-unit id="kpiXAxisShowLabel">
-    <source>Mostrar eje</source>
-    <target>Mostrar eje</target>
+    <source>Mostrar eje X</source>
+    <target>Mostrar eje X</target>
   </trans-unit>
   <trans-unit id="kpiXAxisLabelsLabel">
-    <source>Mostrar etiquetas del eje</source>
-    <target>Mostrar etiquetas del eje</target>
+    <source>Mostrar etiquetas del eje X</source>
+    <target>Mostrar etiquetas del eje X</target>
   </trans-unit>
   <trans-unit id="kpiXAxisAllLabelsLabel">
-    <source>Todas las etiquetas</source>
-    <target>Todas las etiquetas</target>
+    <source>Mostrar todas las etiquetas</source>
+    <target>Mostrar todas las etiquetas</target>
   </trans-unit>
   <trans-unit id="kpiXAxisLabelCountLabel">
-    <source>Número de etiquetas</source>
-    <target>Número de etiquetas</target>
+    <source>Máximo de etiquetas</source>
+    <target>Máximo de etiquetas</target>
   </trans-unit>
   <!-- SDA CUSTOM - KPI/chart option labels -->
   <trans-unit id="showLabels">
     <source>Mostrar etiquetas del gráfico</source>
     <target>Mostrar etiquetas del gráfico</target>
   </trans-unit>
+  <trans-unit id="kpiShowValueLabelsLabel">
+    <source>Mostrar valores en el gráfico</source>
+    <target>Mostrar valores en el gráfico</target>
+  </trans-unit>
   <trans-unit id="showLabelsPercent">
     <source>Mostrar Etiquetas en Porcentajes</source>
     <target>Mostrar Etiquetas en Porcentajes</target>
+  </trans-unit>
+  <trans-unit id="kpiShowValuePercentLabel">
+    <source>Mostrar valores en porcentaje</source>
+    <target>Mostrar valores en porcentaje</target>
+  </trans-unit>
+  <trans-unit id="kpiValueLabelsTooltip">
+    <source>Mostrar u ocultar los valores en el gráfico</source>
+    <target>Mostrar u ocultar los valores en el gráfico</target>
+  </trans-unit>
+  <trans-unit id="kpiValueLabelsPercentTooltip">
+    <source>Mostrar u ocultar los valores en porcentaje en el gráfico</source>
+    <target>Mostrar u ocultar los valores en porcentaje en el gráfico</target>
   </trans-unit>
   <trans-unit id="colorChartBorderLabel">
     <source>Color del borde</source>
@@ -505,12 +549,12 @@
     <target>Color de relleno</target>
   </trans-unit>
   <trans-unit id="kpiLabelColorLabel">
-    <source>Color de las etiquetas</source>
-    <target>Color de las etiquetas</target>
+    <source>Color del texto de etiquetas</source>
+    <target>Color del texto de etiquetas</target>
   </trans-unit>
   <trans-unit id="kpiLabelBackgroundColorLabel">
-    <source>Color de fondo de las etiquetas</source>
-    <target>Color de fondo de las etiquetas</target>
+    <source>Fondo de etiquetas</source>
+    <target>Fondo de etiquetas</target>
   </trans-unit>
   <!-- END SDA CUSTOM -->
 </body>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -356,8 +356,10 @@
     <target>Buscar un tipo</target>
   </trans-unit>
   <trans-unit id="modoEDAAlert" datatype="html">
-    <source>Este panel utiliza el modo EDA, que está obsoleto y dejará de funcionar futuras versiones de SinergiaDA. Por esa misma razón no se pueden hacer cambios sobre este informe. Para garantizar su funcionamiento se recomienda rehacerlo usando el <b>Modo Árbol</b>.</source>
-    <target>Este panel utiliza el modo <b>EDA</b>, que está obsoleto y dejará de funcionar futuras versiones de SinergiaDA. Por esa misma razón no se pueden hacer cambios sobre este informe. Para garantizar su funcionamiento se recomienda rehacerlo usando el <b>Modo Árbol</b>.</target>
+    <source>Este panel utiliza el modo EDA, que está obsoleto y dejará de funcionar futuras versiones de SinergiaDA. Por esa misma razón no se pueden hacer cambios sobre este informe. Para garantizar su funcionamiento se recomienda rehacerlo usando el <b>Modo Árbol</b>.
+    </source>
+    <target>Este panel utiliza el modo <b>EDA</b>, que está obsoleto y dejará de funcionar futuras versiones de SinergiaDA. Por esa misma razón no se pueden hacer cambios sobre este informe. Para garantizar su funcionamiento se recomienda rehacerlo usando el <b>Modo Árbol</b>.
+    </target>
   </trans-unit>
   <trans-unit id="clearAllFilters" datatype="html">
     <source>Eliminar todos los filtros</source>
@@ -439,83 +441,75 @@
     <source>Color del gráfico</source>
     <target>Color del gráfico</target>
   </trans-unit>
-  <trans-unit id="kpiAppearanceH6">
+  <trans-unit id="appearanceSection">
     <source>Apariencia</source>
     <target>Apariencia</target>
   </trans-unit>
-  <trans-unit id="kpiOptionsPanelTitle">
+  <trans-unit id="panelTitleOptions">
     <source>Opciones de visualización</source>
     <target>Opciones de visualización</target>
   </trans-unit>
-  <trans-unit id="kpiResetSectionButton">
+  <trans-unit id="resetSectionButton">
     <source>Restaurar</source>
     <target>Restaurar</target>
   </trans-unit>
-  <trans-unit id="kpiIndicatorColorLabel">
+  <trans-unit id="colorLabelIndicator">
     <source>Color del indicador</source>
     <target>Color del indicador</target>
   </trans-unit>
-  <trans-unit id="kpiSeriesColorLabel">
+  <trans-unit id="colorLabelSeries">
     <source>Color de la serie</source>
     <target>Color de la serie</target>
   </trans-unit>
-  <trans-unit id="kpiLineColorLabel">
+  <trans-unit id="colorLabelLine">
     <source>Color de línea</source>
     <target>Color de línea</target>
   </trans-unit>
-  <trans-unit id="kpiAreaColorLabel">
+  <trans-unit id="colorLabelArea">
     <source>Color de área</source>
     <target>Color de área</target>
   </trans-unit>
-  <trans-unit id="kpiAxisScaleH6">
+  <trans-unit id="axisScaleH6">
     <source>Ejes y escala</source>
     <target>Ejes y escala</target>
   </trans-unit>
-  <trans-unit id="kpiLabelsValuesH6">
+  <trans-unit id="labelsValuesH6">
     <source>Etiquetas y valores</source>
     <target>Etiquetas y valores</target>
   </trans-unit>
-  <trans-unit id="kpiLineH6">
-    <source>Línea</source>
-    <target>Línea</target>
-  </trans-unit>
-  <trans-unit id="kpiLineWidthLabel">
+  <trans-unit id="widthLabelLine">
     <source>Grosor de línea</source>
     <target>Grosor de línea</target>
   </trans-unit>
-  <trans-unit id="kpiLineStyleLabel">
+  <trans-unit id="lineStyleLabel">
     <source>Tipo de línea</source>
     <target>Tipo de línea</target>
   </trans-unit>
-  <trans-unit id="kpiLineStyleSolid">
+  <trans-unit id="lineStyleSolid">
     <source>Sólida</source>
     <target>Sólida</target>
   </trans-unit>
-  <trans-unit id="kpiLineStyleDashed">
+  <trans-unit id="lineStyleDashed">
     <source>Discontinua</source>
     <target>Discontinua</target>
   </trans-unit>
-  <trans-unit id="kpiLineStyleDotted">
+  <trans-unit id="lineStyleDotted">
     <source>Punteada</source>
     <target>Punteada</target>
   </trans-unit>
-  <trans-unit id="kpiXAxisH6">
-    <source>Eje horizontal</source>
-    <target>Eje horizontal</target>
-  </trans-unit>
-  <trans-unit id="kpiXAxisShowLabel">
+  <trans-unit id="xAxisShowLabel">
     <source>Mostrar eje X</source>
     <target>Mostrar eje X</target>
   </trans-unit>
-  <trans-unit id="kpiXAxisLabelsLabel">
+  <trans-unit id="xAxisLabelsLabel">
     <source>Mostrar etiquetas del eje X</source>
     <target>Mostrar etiquetas del eje X</target>
   </trans-unit>
-  <trans-unit id="kpiXAxisAllLabelsLabel">
+  <trans-unit id="xAxisAllLabelsLabel">
     <source>Mostrar todas las etiquetas</source>
     <target>Mostrar todas las etiquetas</target>
   </trans-unit>
-  <trans-unit id="kpiXAxisLabelCountLabel">
+  <trans-unit id="xAxisLabelCountLabel">
     <source>Máximo de etiquetas</source>
     <target>Máximo de etiquetas</target>
   </trans-unit>
@@ -524,7 +518,7 @@
     <source>Mostrar etiquetas del gráfico</source>
     <target>Mostrar etiquetas del gráfico</target>
   </trans-unit>
-  <trans-unit id="kpiShowValueLabelsLabel">
+  <trans-unit id="showValueLabelsLabel">
     <source>Mostrar valores en el gráfico</source>
     <target>Mostrar valores en el gráfico</target>
   </trans-unit>
@@ -532,15 +526,15 @@
     <source>Mostrar Etiquetas en Porcentajes</source>
     <target>Mostrar Etiquetas en Porcentajes</target>
   </trans-unit>
-  <trans-unit id="kpiShowValuePercentLabel">
+  <trans-unit id="showValuePercentLabel">
     <source>Mostrar valores en porcentaje</source>
     <target>Mostrar valores en porcentaje</target>
   </trans-unit>
-  <trans-unit id="kpiValueLabelsTooltip">
+  <trans-unit id="valueLabelsTooltip">
     <source>Mostrar u ocultar los valores en el gráfico</source>
     <target>Mostrar u ocultar los valores en el gráfico</target>
   </trans-unit>
-  <trans-unit id="kpiValueLabelsPercentTooltip">
+  <trans-unit id="valueLabelsPercentTooltip">
     <source>Mostrar u ocultar los valores en porcentaje en el gráfico</source>
     <target>Mostrar u ocultar los valores en porcentaje en el gráfico</target>
   </trans-unit>
@@ -548,23 +542,19 @@
     <source>Color del borde</source>
     <target>Color del borde</target>
   </trans-unit>
-  <trans-unit id="colorChartLineLabel">
-    <source>Color de la línea</source>
-    <target>Color de la línea</target>
-  </trans-unit>
   <trans-unit id="colorChartFillLabel">
     <source>Color de relleno</source>
     <target>Color de relleno</target>
   </trans-unit>
-  <trans-unit id="kpiLabelColorLabel">
+  <trans-unit id="labelColorLabel">
     <source>Color del texto de etiquetas</source>
     <target>Color del texto de etiquetas</target>
   </trans-unit>
-  <trans-unit id="kpiLabelBackgroundColorLabel">
+  <trans-unit id="labelBackgroundColorLabel">
     <source>Fondo de etiquetas</source>
     <target>Fondo de etiquetas</target>
   </trans-unit>
   <!-- END SDA CUSTOM -->
-</body>
+  </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -431,6 +431,88 @@
     <source>Desbloquear panel</source>
     <target>Desbloquear panel</target>
   </trans-unit>
+  <trans-unit id="colorKpiLabel">
+    <source>Color del KPI</source>
+    <target>Cor do KPI</target>
+  </trans-unit>
+  <trans-unit id="colorChartLabel">
+    <source>Color del gráfico</source>
+    <target>Cor do gráfico</target>
+  </trans-unit>
+  <trans-unit id="kpiLineH6">
+    <source>Línea</source>
+    <target>Liña</target>
+  </trans-unit>
+  <trans-unit id="kpiLineWidthLabel">
+    <source>Ancho de línea</source>
+    <target>Ancho da liña</target>
+  </trans-unit>
+  <trans-unit id="kpiLineStyleLabel">
+    <source>Estilo de línea</source>
+    <target>Estilo de liña</target>
+  </trans-unit>
+  <trans-unit id="kpiLineStyleSolid">
+    <source>Sólida</source>
+    <target>Sólida</target>
+  </trans-unit>
+  <trans-unit id="kpiLineStyleDashed">
+    <source>Discontinua</source>
+    <target>Descontinua</target>
+  </trans-unit>
+  <trans-unit id="kpiLineStyleDotted">
+    <source>Punteada</source>
+    <target>Punteada</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisH6">
+    <source>Eje horizontal</source>
+    <target>Eixe horizontal</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisShowLabel">
+    <source>Mostrar eje</source>
+    <target>Mostrar eixe</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisLabelsLabel">
+    <source>Mostrar etiquetas del eje</source>
+    <target>Mostrar etiquetas do eixe</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisAllLabelsLabel">
+    <source>Todas las etiquetas</source>
+    <target>Todas as etiquetas</target>
+  </trans-unit>
+  <trans-unit id="kpiXAxisLabelCountLabel">
+    <source>Número de etiquetas</source>
+    <target>Número de etiquetas</target>
+  </trans-unit>
+  <!-- SDA CUSTOM - KPI/chart option labels -->
+  <trans-unit id="showLabels">
+    <source>Mostrar etiquetas del gráfico</source>
+    <target>Mostrar etiquetas do gráfico</target>
+  </trans-unit>
+  <trans-unit id="showLabelsPercent">
+    <source>Mostrar Etiquetas en Porcentajes</source>
+    <target>Mostrar etiquetas en porcentaxes</target>
+  </trans-unit>
+  <trans-unit id="colorChartBorderLabel">
+    <source>Color del borde</source>
+    <target>Cor do bordo</target>
+  </trans-unit>
+  <trans-unit id="colorChartLineLabel">
+    <source>Color de la línea</source>
+    <target>Cor da liña</target>
+  </trans-unit>
+  <trans-unit id="colorChartFillLabel">
+    <source>Color de relleno</source>
+    <target>Cor de recheo</target>
+  </trans-unit>
+  <trans-unit id="kpiLabelColorLabel">
+    <source>Color de las etiquetas</source>
+    <target>Cor das etiquetas</target>
+  </trans-unit>
+  <trans-unit id="kpiLabelBackgroundColorLabel">
+    <source>Color de fondo de las etiquetas</source>
+    <target>Cor de fondo das etiquetas</target>
+  </trans-unit>
+  <!-- END SDA CUSTOM -->
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -512,7 +512,7 @@
     <target>Máximo de etiquetas</target>
   </trans-unit>
   <!-- SDA CUSTOM - KPI/chart option labels -->
-  <trans-unit id="showLabels">
+  <trans-unit id="showChartLabels">
     <source>Mostrar etiquetas del gráfico</source>
     <target>Mostrar etiquetas do gráfico</target>
   </trans-unit>
@@ -520,7 +520,7 @@
     <source>Mostrar valores en el gráfico</source>
     <target>Mostrar valores no gráfico</target>
   </trans-unit>
-  <trans-unit id="showLabelsPercent">
+  <trans-unit id="showChartLabelsPercent">
     <source>Mostrar Etiquetas en Porcentajes</source>
     <target>Mostrar etiquetas en porcentaxes</target>
   </trans-unit>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -439,83 +439,75 @@
     <source>Color del gráfico</source>
     <target>Cor do gráfico</target>
   </trans-unit>
-  <trans-unit id="kpiAppearanceH6">
+  <trans-unit id="appearanceSection">
     <source>Apariencia</source>
     <target>Aparencia</target>
   </trans-unit>
-  <trans-unit id="kpiOptionsPanelTitle">
+  <trans-unit id="panelTitleOptions">
     <source>Opciones de visualización</source>
     <target>Opcións de visualización</target>
   </trans-unit>
-  <trans-unit id="kpiResetSectionButton">
+  <trans-unit id="resetSectionButton">
     <source>Restaurar</source>
     <target>Restaurar</target>
   </trans-unit>
-  <trans-unit id="kpiIndicatorColorLabel">
+  <trans-unit id="colorLabelIndicator">
     <source>Color del indicador</source>
     <target>Cor do indicador</target>
   </trans-unit>
-  <trans-unit id="kpiSeriesColorLabel">
+  <trans-unit id="colorLabelSeries">
     <source>Color de la serie</source>
     <target>Cor da serie</target>
   </trans-unit>
-  <trans-unit id="kpiLineColorLabel">
+  <trans-unit id="colorLabelLine">
     <source>Color de línea</source>
     <target>Cor da liña</target>
   </trans-unit>
-  <trans-unit id="kpiAreaColorLabel">
+  <trans-unit id="colorLabelArea">
     <source>Color de área</source>
     <target>Cor da área</target>
   </trans-unit>
-  <trans-unit id="kpiAxisScaleH6">
+  <trans-unit id="axisScaleH6">
     <source>Ejes y escala</source>
     <target>Eixes e escala</target>
   </trans-unit>
-  <trans-unit id="kpiLabelsValuesH6">
+  <trans-unit id="labelsValuesH6">
     <source>Etiquetas y valores</source>
     <target>Etiquetas e valores</target>
   </trans-unit>
-  <trans-unit id="kpiLineH6">
-    <source>Línea</source>
-    <target>Liña</target>
-  </trans-unit>
-  <trans-unit id="kpiLineWidthLabel">
+  <trans-unit id="widthLabelLine">
     <source>Grosor de línea</source>
     <target>Grosor da liña</target>
   </trans-unit>
-  <trans-unit id="kpiLineStyleLabel">
+  <trans-unit id="lineStyleLabel">
     <source>Tipo de línea</source>
     <target>Tipo de liña</target>
   </trans-unit>
-  <trans-unit id="kpiLineStyleSolid">
+  <trans-unit id="lineStyleSolid">
     <source>Sólida</source>
     <target>Sólida</target>
   </trans-unit>
-  <trans-unit id="kpiLineStyleDashed">
+  <trans-unit id="lineStyleDashed">
     <source>Discontinua</source>
     <target>Descontinua</target>
   </trans-unit>
-  <trans-unit id="kpiLineStyleDotted">
+  <trans-unit id="lineStyleDotted">
     <source>Punteada</source>
     <target>Punteada</target>
   </trans-unit>
-  <trans-unit id="kpiXAxisH6">
-    <source>Eje horizontal</source>
-    <target>Eixe horizontal</target>
-  </trans-unit>
-  <trans-unit id="kpiXAxisShowLabel">
+  <trans-unit id="xAxisShowLabel">
     <source>Mostrar eje X</source>
     <target>Mostrar eixe X</target>
   </trans-unit>
-  <trans-unit id="kpiXAxisLabelsLabel">
+  <trans-unit id="xAxisLabelsLabel">
     <source>Mostrar etiquetas del eje X</source>
     <target>Mostrar etiquetas do eixe X</target>
   </trans-unit>
-  <trans-unit id="kpiXAxisAllLabelsLabel">
+  <trans-unit id="xAxisAllLabelsLabel">
     <source>Mostrar todas las etiquetas</source>
     <target>Mostrar todas as etiquetas</target>
   </trans-unit>
-  <trans-unit id="kpiXAxisLabelCountLabel">
+  <trans-unit id="xAxisLabelCountLabel">
     <source>Máximo de etiquetas</source>
     <target>Máximo de etiquetas</target>
   </trans-unit>
@@ -524,7 +516,7 @@
     <source>Mostrar etiquetas del gráfico</source>
     <target>Mostrar etiquetas do gráfico</target>
   </trans-unit>
-  <trans-unit id="kpiShowValueLabelsLabel">
+  <trans-unit id="showValueLabelsLabel">
     <source>Mostrar valores en el gráfico</source>
     <target>Mostrar valores no gráfico</target>
   </trans-unit>
@@ -532,15 +524,15 @@
     <source>Mostrar Etiquetas en Porcentajes</source>
     <target>Mostrar etiquetas en porcentaxes</target>
   </trans-unit>
-  <trans-unit id="kpiShowValuePercentLabel">
+  <trans-unit id="showValuePercentLabel">
     <source>Mostrar valores en porcentaje</source>
     <target>Mostrar valores en porcentaxe</target>
   </trans-unit>
-  <trans-unit id="kpiValueLabelsTooltip">
+  <trans-unit id="valueLabelsTooltip">
     <source>Mostrar u ocultar los valores en el gráfico</source>
     <target>Mostrar ou ocultar os valores no gráfico</target>
   </trans-unit>
-  <trans-unit id="kpiValueLabelsPercentTooltip">
+  <trans-unit id="valueLabelsPercentTooltip">
     <source>Mostrar u ocultar los valores en porcentaje en el gráfico</source>
     <target>Mostrar ou ocultar os valores en porcentaxe no gráfico</target>
   </trans-unit>
@@ -548,19 +540,15 @@
     <source>Color del borde</source>
     <target>Cor do bordo</target>
   </trans-unit>
-  <trans-unit id="colorChartLineLabel">
-    <source>Color de la línea</source>
-    <target>Cor da liña</target>
-  </trans-unit>
   <trans-unit id="colorChartFillLabel">
     <source>Color de relleno</source>
     <target>Cor de recheo</target>
   </trans-unit>
-  <trans-unit id="kpiLabelColorLabel">
+  <trans-unit id="labelColorLabel">
     <source>Color del texto de etiquetas</source>
     <target>Cor do texto das etiquetas</target>
   </trans-unit>
-  <trans-unit id="kpiLabelBackgroundColorLabel">
+  <trans-unit id="labelBackgroundColorLabel">
     <source>Fondo de etiquetas</source>
     <target>Fondo das etiquetas</target>
   </trans-unit>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -439,17 +439,45 @@
     <source>Color del gráfico</source>
     <target>Cor do gráfico</target>
   </trans-unit>
+  <trans-unit id="kpiAppearanceH6">
+    <source>Apariencia</source>
+    <target>Aparencia</target>
+  </trans-unit>
+  <trans-unit id="kpiIndicatorColorLabel">
+    <source>Color del indicador</source>
+    <target>Cor do indicador</target>
+  </trans-unit>
+  <trans-unit id="kpiSeriesColorLabel">
+    <source>Color de la serie</source>
+    <target>Cor da serie</target>
+  </trans-unit>
+  <trans-unit id="kpiLineColorLabel">
+    <source>Color de línea</source>
+    <target>Cor da liña</target>
+  </trans-unit>
+  <trans-unit id="kpiAreaColorLabel">
+    <source>Color de área</source>
+    <target>Cor da área</target>
+  </trans-unit>
+  <trans-unit id="kpiAxisScaleH6">
+    <source>Ejes y escala</source>
+    <target>Eixes e escala</target>
+  </trans-unit>
+  <trans-unit id="kpiLabelsValuesH6">
+    <source>Etiquetas y valores</source>
+    <target>Etiquetas e valores</target>
+  </trans-unit>
   <trans-unit id="kpiLineH6">
     <source>Línea</source>
     <target>Liña</target>
   </trans-unit>
   <trans-unit id="kpiLineWidthLabel">
-    <source>Ancho de línea</source>
-    <target>Ancho da liña</target>
+    <source>Grosor de línea</source>
+    <target>Grosor da liña</target>
   </trans-unit>
   <trans-unit id="kpiLineStyleLabel">
-    <source>Estilo de línea</source>
-    <target>Estilo de liña</target>
+    <source>Tipo de línea</source>
+    <target>Tipo de liña</target>
   </trans-unit>
   <trans-unit id="kpiLineStyleSolid">
     <source>Sólida</source>
@@ -468,29 +496,45 @@
     <target>Eixe horizontal</target>
   </trans-unit>
   <trans-unit id="kpiXAxisShowLabel">
-    <source>Mostrar eje</source>
-    <target>Mostrar eixe</target>
+    <source>Mostrar eje X</source>
+    <target>Mostrar eixe X</target>
   </trans-unit>
   <trans-unit id="kpiXAxisLabelsLabel">
-    <source>Mostrar etiquetas del eje</source>
-    <target>Mostrar etiquetas do eixe</target>
+    <source>Mostrar etiquetas del eje X</source>
+    <target>Mostrar etiquetas do eixe X</target>
   </trans-unit>
   <trans-unit id="kpiXAxisAllLabelsLabel">
-    <source>Todas las etiquetas</source>
-    <target>Todas as etiquetas</target>
+    <source>Mostrar todas las etiquetas</source>
+    <target>Mostrar todas as etiquetas</target>
   </trans-unit>
   <trans-unit id="kpiXAxisLabelCountLabel">
-    <source>Número de etiquetas</source>
-    <target>Número de etiquetas</target>
+    <source>Máximo de etiquetas</source>
+    <target>Máximo de etiquetas</target>
   </trans-unit>
   <!-- SDA CUSTOM - KPI/chart option labels -->
   <trans-unit id="showLabels">
     <source>Mostrar etiquetas del gráfico</source>
     <target>Mostrar etiquetas do gráfico</target>
   </trans-unit>
+  <trans-unit id="kpiShowValueLabelsLabel">
+    <source>Mostrar valores en el gráfico</source>
+    <target>Mostrar valores no gráfico</target>
+  </trans-unit>
   <trans-unit id="showLabelsPercent">
     <source>Mostrar Etiquetas en Porcentajes</source>
     <target>Mostrar etiquetas en porcentaxes</target>
+  </trans-unit>
+  <trans-unit id="kpiShowValuePercentLabel">
+    <source>Mostrar valores en porcentaje</source>
+    <target>Mostrar valores en porcentaxe</target>
+  </trans-unit>
+  <trans-unit id="kpiValueLabelsTooltip">
+    <source>Mostrar u ocultar los valores en el gráfico</source>
+    <target>Mostrar ou ocultar os valores no gráfico</target>
+  </trans-unit>
+  <trans-unit id="kpiValueLabelsPercentTooltip">
+    <source>Mostrar u ocultar los valores en porcentaje en el gráfico</source>
+    <target>Mostrar ou ocultar os valores en porcentaxe no gráfico</target>
   </trans-unit>
   <trans-unit id="colorChartBorderLabel">
     <source>Color del borde</source>
@@ -505,12 +549,12 @@
     <target>Cor de recheo</target>
   </trans-unit>
   <trans-unit id="kpiLabelColorLabel">
-    <source>Color de las etiquetas</source>
-    <target>Cor das etiquetas</target>
+    <source>Color del texto de etiquetas</source>
+    <target>Cor do texto das etiquetas</target>
   </trans-unit>
   <trans-unit id="kpiLabelBackgroundColorLabel">
-    <source>Color de fondo de las etiquetas</source>
-    <target>Cor de fondo das etiquetas</target>
+    <source>Fondo de etiquetas</source>
+    <target>Fondo das etiquetas</target>
   </trans-unit>
   <!-- END SDA CUSTOM -->
 </body>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -443,6 +443,14 @@
     <source>Apariencia</source>
     <target>Aparencia</target>
   </trans-unit>
+  <trans-unit id="kpiOptionsPanelTitle">
+    <source>Opciones de visualización</source>
+    <target>Opcións de visualización</target>
+  </trans-unit>
+  <trans-unit id="kpiResetSectionButton">
+    <source>Restaurar</source>
+    <target>Restaurar</target>
+  </trans-unit>
   <trans-unit id="kpiIndicatorColorLabel">
     <source>Color del indicador</source>
     <target>Cor do indicador</target>


### PR DESCRIPTION
## Descripción del Cambio
Se resuelve el problema de dimensionamiento de los KPI (simples y combinados) ofreciendo un sistema para redimensionarlos en su propio contenedor, mostrando a los usuarios con permiso de edición del informe controles (+ y -) para aumentar o disminuir su tamaño viendo exactamente cómo se mostrarán con el tamaño de pantalla actual.

Por otro lado, se añaden diversas propiedades de los gráficos combinados y simples para permitir personalizar:
- Color del KPI
- Color del gráfico
- Ancho de línea
- Estilo de línea
- Mostrar eje
- Mostrar etiquetas del eje (número de etiquetas) 
- Mostrar Etiquetas en Porcentaje
- Color de las etiquetas

Aunque este PR solo resuelve la aplicación de propiedades del gráfico para los KPI, **marca el camino** sobre cómo mostrar y aplicar diferentes propiedades a los distintos tipos gráficos, mostrando un número amplio de propiedades que pueden ser personalizadas para obtener gráficos más ricos y configurables. 

## Issue(s) resuelto(s)
<!-- Indicar el #<número> del/los issues resiueltos por este Pull Request -->
- solves #390 

## Pruebas a realizar para validar el cambio
Realizar distintos gráficos KPI simples y combinados y verifica el funcionamiento correcto de redimensionamiento del mismo y la aplicación de las propiedades añadidas al panel

