### PR TITLE
Enhancement - API+APP - Problema "public/dashboard" en URL de informes públicos

### DIFF
--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -628,7 +628,10 @@ export class DashboardController {
       next(err)
     }
   }
-/*SDA CUSTOM*/
+
+/*SDA CUSTOM   This function is used to check if a dashboard is public (shared) or not. 
+               It is used in the login guard to allow anonymous users to access public dashboards without needing to log in.
+               It returns a boolean value indicating if the dashboard is public (shared) or not.*/
 /*SDA CUSTOM*/ static async getIsPublic(req: Request, res: Response, next: NextFunction) {
 /*SDA CUSTOM*/   try {
 /*SDA CUSTOM*/     const dashboard = await Dashboard.findById(req.params.id, 'config.visible').exec();

--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -628,6 +628,17 @@ export class DashboardController {
       next(err)
     }
   }
+/*SDA CUSTOM*/
+/*SDA CUSTOM*/ static async getIsPublic(req: Request, res: Response, next: NextFunction) {
+/*SDA CUSTOM*/   try {
+/*SDA CUSTOM*/     const dashboard = await Dashboard.findById(req.params.id, 'config.visible').exec();
+/*SDA CUSTOM*/     if (!dashboard) return next(new HttpException(404, 'Dashboard not found'));
+/*SDA CUSTOM*/     const isAccessible = dashboard.config.visible ===  'shared';
+/*SDA CUSTOM*/     return res.status(200).json({ isAccessible });
+/*SDA CUSTOM*/   } catch (err) {
+/*SDA CUSTOM*/     return next(new HttpException(500, 'Error checking dashboard visibility'));
+/*SDA CUSTOM*/   }
+/*SDA CUSTOM*/ }
 
   static async create(req: Request, res: Response, next: NextFunction) {
     try {

--- a/eda/eda_api/lib/module/dashboard/dashboard.router.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.router.ts
@@ -340,4 +340,6 @@ router.delete('/:id', authGuard, DashboardController.delete);
 
 /*SDA CUSTOM*/ router.post('/:id/clone', authGuard, DashboardController.clone);
 
+/*SDA CUSTOM*/ router.get('/:id/visibility', DashboardController.getIsPublic);
+
 export default router;

--- a/eda/eda_app/src/app/module/pages/pages.routes.ts
+++ b/eda/eda_app/src/app/module/pages/pages.routes.ts
@@ -16,7 +16,6 @@ import { LogsComponent } from './logs/logs.component';
 
 // Guard
 import { VerifyTokenGuard } from '../../services/guards/verify-token.guard';
-/*SDA CUSTOM*/ import { LoginGuardGuard } from '../../services/guards/login-guard.guard';
 import { GroupListComponent } from './groups-management/group-list/group-list.component';
 import { AlertsManagementComponent } from './alerts-management/alerts-management.component';
 import { MailManagementComponent } from './mail-management/mail-management.component';
@@ -25,7 +24,7 @@ import { MailManagementComponent } from './mail-management/mail-management.compo
 const pagesRoutes: Routes = [
 
     /*SDA CUSTOM*/ { path: 'old-home', component: HomeComponent, canActivate: [VerifyTokenGuard] },
-    /*SDA CUSTOM*/ { path: 'dashboard/:id', component: DashboardComponent, canActivate: [LoginGuardGuard, VerifyTokenGuard] },
+    { path: 'dashboard/:id', component: DashboardComponent, canActivate: [VerifyTokenGuard] },
     { path: 'account-settings', component: AccountSettingsComponent, canActivate: [VerifyTokenGuard] },
     { path: 'profile', component: ProfileComponent, canActivate: [VerifyTokenGuard] },
     { path: 'data-source', component: DsConfigWrapperComponent, canActivate: [VerifyTokenGuard] },

--- a/eda/eda_app/src/app/module/pages/pages.routes.ts
+++ b/eda/eda_app/src/app/module/pages/pages.routes.ts
@@ -16,6 +16,7 @@ import { LogsComponent } from './logs/logs.component';
 
 // Guard
 import { VerifyTokenGuard } from '../../services/guards/verify-token.guard';
+/*SDA CUSTOM*/ import { LoginGuardGuard } from '../../services/guards/login-guard.guard';
 import { GroupListComponent } from './groups-management/group-list/group-list.component';
 import { AlertsManagementComponent } from './alerts-management/alerts-management.component';
 import { MailManagementComponent } from './mail-management/mail-management.component';
@@ -24,7 +25,7 @@ import { MailManagementComponent } from './mail-management/mail-management.compo
 const pagesRoutes: Routes = [
 
     /*SDA CUSTOM*/ { path: 'old-home', component: HomeComponent, canActivate: [VerifyTokenGuard] },
-    { path: 'dashboard/:id', component: DashboardComponent, canActivate: [VerifyTokenGuard] },
+    /*SDA CUSTOM*/ { path: 'dashboard/:id', component: DashboardComponent, canActivate: [LoginGuardGuard, VerifyTokenGuard] },
     { path: 'account-settings', component: AccountSettingsComponent, canActivate: [VerifyTokenGuard] },
     { path: 'profile', component: ProfileComponent, canActivate: [VerifyTokenGuard] },
     { path: 'data-source', component: DsConfigWrapperComponent, canActivate: [VerifyTokenGuard] },

--- a/eda/eda_app/src/app/services/api/dashboard.service.ts
+++ b/eda/eda_app/src/app/services/api/dashboard.service.ts
@@ -18,7 +18,8 @@ export class DashboardService extends ApiService {
     getDashboard( id ): Observable<any> {
         return this.get( `${this.route}${id}` );
     }
-/*SDA CUSTOM*/
+/*SDA CUSTOM    // This function is used to check if a dashboard is public (shared) or not. It is used in the login guard to allow anonymous users to access public dashboards without needing to log in.
+                 It returns a boolean value indicating if the dashboard is public (shared) or not.*/
 /*SDA CUSTOM*/   getDashboardVisibility( id ): Observable<any> {
 /*SDA CUSTOM*/       return this.get( `${this.route}${id}/visibility` );
 /*SDA CUSTOM*/   }

--- a/eda/eda_app/src/app/services/api/dashboard.service.ts
+++ b/eda/eda_app/src/app/services/api/dashboard.service.ts
@@ -18,6 +18,10 @@ export class DashboardService extends ApiService {
     getDashboard( id ): Observable<any> {
         return this.get( `${this.route}${id}` );
     }
+/*SDA CUSTOM*/
+/*SDA CUSTOM*/   getDashboardVisibility( id ): Observable<any> {
+/*SDA CUSTOM*/       return this.get( `${this.route}${id}/visibility` );
+/*SDA CUSTOM*/   }
 
     addNewDashboard( dashboard ): Observable<any> {
         return this.post( this.route,  dashboard);

--- a/eda/eda_app/src/app/services/guards/login-guard.guard.ts
+++ b/eda/eda_app/src/app/services/guards/login-guard.guard.ts
@@ -1,21 +1,21 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, Router, ActivatedRouteSnapshot, RouterStateSnapshot, ActivatedRoute } from '@angular/router';
 import { UserService } from '../api/user.service';
-import { DashboardService } from '../api/dashboard.service';
-import { User } from '@eda/models/model.index';
+/*SDA CUSTOM*/ import { DashboardService } from '../api/dashboard.service';
+/*SDA CUSTOM*/ import { User } from '@eda/models/model.index';
 @Injectable()
 export class LoginGuardGuard implements CanActivate {
 
     constructor(
-        public userService: UserService, 
+        public userService: UserService,
         private route: ActivatedRoute,
 /*SDA CUSTOM*/ private dashboardService: DashboardService,
         public router: Router) { }
 
 /*SDA CUSTOM*/canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> | boolean  {
 
-        const token = route.queryParams.token; 
-
+        const token = route.queryParams.token;
+        
         if (this.userService.isLogged()) {
             return true;
         } else {
@@ -26,6 +26,10 @@ export class LoginGuardGuard implements CanActivate {
                 })
                 return false;
             } else {
+/*SDA CUSTOM    This block of code is used to check if the user is trying to access a dashboard without being logged in.
+                If the URL matches the pattern of a dashboard, it will check if the dashboard is public (shared) or not.
+                If it is public, it will log in the user as an anonymous user and allow access to the dashboard.
+                If it is not public, it will redirect the user to the login page.*/
 /*SDA CUSTOM*/  const dashboardMatch = state.url.match(/\/dashboard\/([^?/]+)/);
 /*SDA CUSTOM*/  const loginUrl = { returnUrl: state.url.split('?')[0], params: state.url.split('?')[1] };
 /*SDA CUSTOM*/  const goLogin = () => this.router.navigate(['/login'], { queryParams: loginUrl });

--- a/eda/eda_app/src/app/services/guards/login-guard.guard.ts
+++ b/eda/eda_app/src/app/services/guards/login-guard.guard.ts
@@ -1,19 +1,21 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, Router, ActivatedRouteSnapshot, RouterStateSnapshot, ActivatedRoute } from '@angular/router';
 import { UserService } from '../api/user.service';
-
+import { DashboardService } from '../api/dashboard.service';
+import { User } from '@eda/models/model.index';
 @Injectable()
 export class LoginGuardGuard implements CanActivate {
 
     constructor(
         public userService: UserService, 
         private route: ActivatedRoute,
+/*SDA CUSTOM*/ private dashboardService: DashboardService,
         public router: Router) { }
 
-    canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+/*SDA CUSTOM*/canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> | boolean  {
 
         const token = route.queryParams.token; 
-        
+
         if (this.userService.isLogged()) {
             return true;
         } else {
@@ -24,8 +26,26 @@ export class LoginGuardGuard implements CanActivate {
                 })
                 return false;
             } else {
-                this.router.navigate(['/login'], { queryParams: { returnUrl: state.url.split('?')[0], params: state.url.split('?')[1] } });
-                return false;
+/*SDA CUSTOM*/  const dashboardMatch = state.url.match(/\/dashboard\/([^?/]+)/);
+/*SDA CUSTOM*/  const loginUrl = { returnUrl: state.url.split('?')[0], params: state.url.split('?')[1] };
+/*SDA CUSTOM*/  const goLogin = () => this.router.navigate(['/login'], { queryParams: loginUrl });
+/*SDA CUSTOM*/  if (dashboardMatch) {
+/*SDA CUSTOM*/      return new Promise((resolve) => {
+/*SDA CUSTOM*/          this.dashboardService.getDashboardVisibility(dashboardMatch[1]).subscribe({
+/*SDA CUSTOM*/              next: (res: any) => {
+/*SDA CUSTOM*/                  if (!res.isAccessible) { goLogin(); return resolve(false);}
+/*SDA CUSTOM*/                  const anonymousUser = new User(null, 'edaanonim@jortilles.com', '_-(··)-_edanonymous_-(··)-_');
+/*SDA CUSTOM*/                  this.userService.login(anonymousUser, false).subscribe({
+/*SDA CUSTOM*/                      next: () => { resolve(true); },
+/*SDA CUSTOM*/                      error: (e) => { console.error(e); goLogin(); resolve(false); }
+/*SDA CUSTOM*/                  });
+/*SDA CUSTOM*/              },
+/*SDA CUSTOM*/              error: (e) => { console.error(e); goLogin(); resolve(false); }
+/*SDA CUSTOM*/          });
+/*SDA CUSTOM*/      });
+/*SDA CUSTOM*/  }
+/*SDA CUSTOM*/  goLogin();
+/*SDA CUSTOM*/  return false;
             }
 
         }


### PR DESCRIPTION
## Descripción del Cambio
Se cambia la forma en la que se hace la comprobación de la autorización. Ahora, cuando se recibe una petición a un dashboard. Mira si es público y si es público le inyecta el usuario publico para permitir la visualización del dashboard público.


## Issue(s) resuelto(s)
- solves #321 

## Pruebas a realizar para validar el cambio
Llamar un dashboar con la url http://localhost:4200/#/dashboard/694408370a95d76ec40e0b01?panelMode=true  y el mismo dashobard http://localhost:4200/#/public/694408370a95d76ec40e0b01?panelMode=true  para comprobar la compatibilidad hacia atrás. 

