### PR TITLE
Hotfix - Filtros - Pérdida de valores en filtros con nombres duplicados al eliminar uno de ellos

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -1585,7 +1585,7 @@ export class EdaBlankPanelComponent implements OnInit {
 /**SDA CUSTOM  */       // We just proceed if it is not the last column of the root table
 /**SDA CUSTOM  */       if (isNotRootColumn || rootColumnElements > 1 || currentQueryLength === 1) {
 /**SDA CUSTOM  */           // We check if when deleting a field it has a filter at selectedFilters
-                            if (this.selectedFilters.some((sf: any) => sf.filter_column === c.column_name && sf.filter_table === c.table_id)) {
+/**SDA CUSTOM  */           if (this.selectedFilters.some((sf: any) => sf.filter_column === c.column_name && sf.filter_table === c.table_id)) {
                                 if (this.sortedFilters.length !== 0) {
                                     this.alertService.addWarning($localize`:@@filterSettingsReboot:La configuración de filtros se ha reiniciado`);
                                 }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -1585,7 +1585,7 @@ export class EdaBlankPanelComponent implements OnInit {
 /**SDA CUSTOM  */       // We just proceed if it is not the last column of the root table
 /**SDA CUSTOM  */       if (isNotRootColumn || rootColumnElements > 1 || currentQueryLength === 1) {
 /**SDA CUSTOM  */           // We check if when deleting a field it has a filter at selectedFilters
-                            if (this.selectedFilters.some((sf: any) => sf.filter_column === c.column_name)) {
+                            if (this.selectedFilters.some((sf: any) => sf.filter_column === c.column_name && sf.filter_table === c.table_id)) {
                                 if (this.sortedFilters.length !== 0) {
                                     this.alertService.addWarning($localize`:@@filterSettingsReboot:La configuración de filtros se ha reiniciado`);
                                 }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
@@ -690,18 +690,12 @@ export const PanelInteractionUtils = {
     }
   },
 
-
-
-
-
-
   /**
-    * Removes given column from content
-    * @param c column to remove
-    * @param list where collumn is present (select, filters)
-    */
+  * Removes given column from content
+  * @param c column to remove
+  * @param list where collumn is present (select, filters)
+  */
   removeColumn: (ebp: EdaBlankPanelComponent, c: Column, list?: string) => {
-
     ebp.disableBtnSave();
     // Searches the array index, the column to delete and does it
     if (list === 'select') {
@@ -714,7 +708,7 @@ export const PanelInteractionUtils = {
           // If only there is 1 column of rootTable, check if panel have any globalFilter linked it.
           if (ebp.currentQuery.map((query) => query.table_id == rootTable).length <= 1) {
             if (ebp.globalFilters.some((filter) => filter.filter_table === rootTable)) {
-/**SDA CUSTOM  */ event.stopPropagation();
+                /**SDA CUSTOM  */ event.stopPropagation();
               ebp.alertService.addError($localize`@@removeColumnGlobalFilter:No se puede eliminar la columna porque hay vinculado un Filtro`);
               throw '[Error]: Can not remove this column cause there is a GlobalFilter linked.'
             }
@@ -752,9 +746,8 @@ export const PanelInteractionUtils = {
       _.map(ebp.currentQuery, selected => selected.table_id === c.table_id);
     }
 
-    const filters = ebp.selectedFilters.filter(f => f.filter_column === c.column_name);
+    const filters = ebp.selectedFilters.filter(f => f.filter_column === c.column_name && f.filter_table === c.table_id);
     filters.forEach(f => ebp.selectedFilters = ebp.selectedFilters.filter(ff => ff.filter_id !== f.filter_id));
-
   }
 
 }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
@@ -746,7 +746,7 @@ export const PanelInteractionUtils = {
       _.map(ebp.currentQuery, selected => selected.table_id === c.table_id);
     }
 
-    const filters = ebp.selectedFilters.filter(f => f.filter_column === c.column_name && f.filter_table === c.table_id);
+    /**SDA CUSTOM  */ const filters = ebp.selectedFilters.filter(f => f.filter_column === c.column_name && f.filter_table === c.table_id);
     filters.forEach(f => ebp.selectedFilters = ebp.selectedFilters.filter(ff => ff.filter_id !== f.filter_id));
   }
 


### PR DESCRIPTION

## Descripción del Cambio
Se añade comprobación de tabla  en la eliminación de los filtros.


## Issue(s) resuelto(s)

- solves #427 

## Pruebas a realizar para validar el cambio
Las descritas en el issue. Añadir dos filtros de panel de tablas distintas con el mismo nombre y eliminar uno de ellos.
