### PR TITLE
Hotfix - Informes - Error al eliminar filtro de tabla relacionada

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -1577,11 +1577,13 @@ export class EdaBlankPanelComponent implements OnInit {
     public loadColumns = (table: any) => PanelInteractionUtils.loadColumns(this, table);
 
 /**SDA CUSTOM  */   public removeColumn = (c: Column, list?: string) => {
-/**SDA CUSTOM  */       // Conditions to check if we can delete the column
-/**SDA CUSTOM  */       const isNotRootColumn = !!c?.joins?.length;
-/**SDA CUSTOM  */       const rootColumnElements = this.currentQuery.filter(col => !col?.joins?.length).length;
+/**SDA CUSTOM  */       // rootTableName To have the principal table => conditions to check if we can delete the column
+/**SDA CUSTOM  */       const rootTableName = this.rootTable?.table_name;
+/**SDA CUSTOM  */       // joins is reliable when interacting on the app; table_id comparison is the fallback after save and reload when joins may be empty
+/**SDA CUSTOM  */       const isNotRootColumn = !!c?.joins?.length || (!!rootTableName && c?.table_id !== rootTableName);
+/**SDA CUSTOM  */       const rootColumnElements = this.currentQuery.filter(col => !col?.joins?.length && (!rootTableName || col?.table_id === rootTableName)).length;
 /**SDA CUSTOM  */       const currentQueryLength = this.currentQuery.length;
-/**SDA CUSTOM  */
+
 /**SDA CUSTOM  */       // We just proceed if it is not the last column of the root table
 /**SDA CUSTOM  */       if (isNotRootColumn || rootColumnElements > 1 || currentQueryLength === 1) {
 /**SDA CUSTOM  */           // We check if when deleting a field it has a filter at selectedFilters


### PR DESCRIPTION
## Descripción del Cambio
Se cambia la lógica para identificar si todavía queda una columna de la tabla principal

## Issue(s) resuelto(s)
- solves #431

## Pruebas a realizar para validar el cambio
Las descritas  en el issue. Hacer un panel con columnas y filtros de la tabla principal  e intentar eleiminar el filtros