### PR TITLE
Mejora - General - Añadir información de error cuando un campo no está disponible

### DIFF
--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -1938,7 +1938,7 @@ export class DashboardController {
 /*SDA CUSTOM*/   // Error number: 1054; Symbol: ER_BAD_FIELD_ERROR; 
 /*SDA CUSTOM*/   const unknownColumn = msg.match(/Unknown column '([^']+)' in '([^']+)'/i);
 /*SDA CUSTOM*/   if (unknownColumn) {
-/*SDA CUSTOM*/     return `El campo '${unknownColumn[1]}' está incluido en el informe, pero no está disponible en la base de datos.`;
+/*SDA CUSTOM*/     return `The field '${unknownColumn[1]}' is included in the report but is not available in the database.`;
 /*SDA CUSTOM*/   }
 /*SDA CUSTOM*/
 /*SDA CUSTOM*/   //Error number: 1146; Symbol: ER_NO_SUCH_TABLE; SQLSTATE: 42S02
@@ -1946,22 +1946,22 @@ export class DashboardController {
 /*SDA CUSTOM*/   const unknownTable = msg.match(/Table '([^']+)' doesn't exist/i);
 /*SDA CUSTOM*/   if (unknownTable) {
 /*SDA CUSTOM*/     const tableName = unknownTable[1].split('.').pop();
-/*SDA CUSTOM*/     return `La tabla '${tableName}' no existe en la base de datos. Revise el modelo de datos.`;
+/*SDA CUSTOM*/     return `Table '${tableName}' does not exist in the database. Please review the data model.`;
 /*SDA CUSTOM*/   }
 /*SDA CUSTOM*/
 /*SDA CUSTOM*/   // Error number: 1698; Symbol: ER_ACCESS_DENIED_NO_PASSWORD_ERROR; SQLSTATE: 28000
 /*SDA CUSTOM*/   // Access denied for user
 /*SDA CUSTOM*/   if (/Access denied for user/i.test(msg)) {
-/*SDA CUSTOM*/     return `Acceso denegado a la base de datos. Revise las credenciales de conexión.`;
+/*SDA CUSTOM*/     return `Access denied to the database. Please check the connection credentials.`;
 /*SDA CUSTOM*/   }
-/*SDA CUSTOM*/   
+/*SDA CUSTOM*/
 /*SDA CUSTOM*/   // Generic fallback with the MYSQL/MARIADB original message
 /*SDA CUSTOM*/   if (msg) {
-/*SDA CUSTOM*/     return `Error al consultar la base de datos: ${msg}`;
+/*SDA CUSTOM*/     return `Database query error: ${msg.length > 500 ? msg.substring(0, 500) + '...' : msg}`;
 /*SDA CUSTOM*/   }
 /*SDA CUSTOM*/
 /*SDA CUSTOM*/   // if bbdd is not MySQL or MariaDB return default value
-/*SDA CUSTOM*/   return 'Error quering database';
+/*SDA CUSTOM*/   return 'Error querying database';
 /*SDA CUSTOM*/ }
 }
 

--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -1454,7 +1454,7 @@ export class DashboardController {
       }
     } catch (err) {
       console.log(err)
-      next(new HttpException(500, 'Error quering database'))
+/*SDA CUSTOM*/ next(new HttpException(500, DashboardController.parseDbErrorMySQL(err)))
     }
   }
 
@@ -1649,14 +1649,10 @@ export class DashboardController {
       }
     } catch (err) {
       console.log(err)
-      next(new HttpException(500, 'Error quering database'))
+/*SDA CUSTOM*/ next(new HttpException(500, DashboardController.parseDbErrorMySQL(err)))
     }
   }
-
-
-  
   //Check if a value is not numeric
-  
   static isNotNumeric(val) {
 
     let isNotNumeric = false;
@@ -1794,7 +1790,7 @@ export class DashboardController {
       return res.status(200).json(output)
     } catch (err) {
       console.log(err)
-      next(new HttpException(500, 'Error quering database'))
+/*SDA CUSTOM*/ next(new HttpException(500, DashboardController.parseDbErrorMySQL(err)))
     }
   }
 
@@ -1933,6 +1929,40 @@ export class DashboardController {
 
     return res.status(200).json({ ok: true })
   }
+
+/*SDA CUSTOM*/ static parseDbErrorMySQL(err: any): string {
+/*SDA CUSTOM*/   /**Parse a database error and return a descriptive message for the user. */
+/*SDA CUSTOM*/   const msg: string = err?.message || '';
+/*SDA CUSTOM*/
+/*SDA CUSTOM*/   // Unknown column in 'field list'
+/*SDA CUSTOM*/   // Error number: 1054; Symbol: ER_BAD_FIELD_ERROR; 
+/*SDA CUSTOM*/   const unknownColumn = msg.match(/Unknown column '([^']+)' in '([^']+)'/i);
+/*SDA CUSTOM*/   if (unknownColumn) {
+/*SDA CUSTOM*/     return `El campo '${unknownColumn[1]}' está incluido en el informe, pero no está disponible en la base de datos.`;
+/*SDA CUSTOM*/   }
+/*SDA CUSTOM*/
+/*SDA CUSTOM*/   //Error number: 1146; Symbol: ER_NO_SUCH_TABLE; SQLSTATE: 42S02
+/*SDA CUSTOM*/   // Table  doesn't exist
+/*SDA CUSTOM*/   const unknownTable = msg.match(/Table '([^']+)' doesn't exist/i);
+/*SDA CUSTOM*/   if (unknownTable) {
+/*SDA CUSTOM*/     const tableName = unknownTable[1].split('.').pop();
+/*SDA CUSTOM*/     return `La tabla '${tableName}' no existe en la base de datos. Revise el modelo de datos.`;
+/*SDA CUSTOM*/   }
+/*SDA CUSTOM*/
+/*SDA CUSTOM*/   // Error number: 1698; Symbol: ER_ACCESS_DENIED_NO_PASSWORD_ERROR; SQLSTATE: 28000
+/*SDA CUSTOM*/   // Access denied for user
+/*SDA CUSTOM*/   if (/Access denied for user/i.test(msg)) {
+/*SDA CUSTOM*/     return `Acceso denegado a la base de datos. Revise las credenciales de conexión.`;
+/*SDA CUSTOM*/   }
+/*SDA CUSTOM*/   
+/*SDA CUSTOM*/   // Generic fallback with the MYSQL/MARIADB original message
+/*SDA CUSTOM*/   if (msg) {
+/*SDA CUSTOM*/     return `Error al consultar la base de datos: ${msg}`;
+/*SDA CUSTOM*/   }
+/*SDA CUSTOM*/
+/*SDA CUSTOM*/   // if bbdd is not MySQL or MariaDB return default value
+/*SDA CUSTOM*/   return 'Error quering database';
+/*SDA CUSTOM*/ }
 }
 
 function insertServerLog(


### PR DESCRIPTION
## Descripción del Cambio
Se añaden una serie de mensajes genéricos con explicación del motivo del error. Si no se caza el error se muestra el mensaje de la base de datos. 


## Issue(s) resuelto(s)
- solves  #336

## Pruebas a realizar para validar el cambio
Hacer una consutla que genere un error y comprobar el mensaje de error. 

