### PR TITLE
Hotfix - Informes - Guardar flag activo por defecto al crear informe

### DIFF
--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -1405,7 +1405,8 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
                     sendViaMailConfig: this.sendViaMailConfig,
                     onlyIcanEdit: this.onlyIcanEdit,
                     styles : this.styles,
-                    urls: this.urls
+                    urls: this.urls,
+                    /*SDA CUSTOM*/ active: this.dashboard.active !== undefined ? this.dashboard.active : true
 
                 },
                 group: this.form.value.group ? _.map(this.form.value.group, '_id') : undefined

--- a/eda/eda_app/src/app/shared/components/create-dashboard/create-dashboard.component.ts
+++ b/eda/eda_app/src/app/shared/components/create-dashboard/create-dashboard.component.ts
@@ -107,7 +107,8 @@ export class CreateDashboardComponent implements OnInit {
                     styles:this.stylesProviderService.generateDefaultStyles(),
                     /*SDA CUSTOM*/ createdAt: new Date(),
                     /*SDA CUSTOM*/ modifiedAt: new Date(),
-                    external: null
+                    external: null,
+                    /*SDA CUSTOM*/ active: true
                 },
                 group: this.form.value.group
                     ? _.map(this.form.value.group, '_id')


### PR DESCRIPTION
## Descripción del Cambio
Los informes creados por usuarios no administradores ahora se guardan con el flag `active: true` por defecto. Esto resuelve el problema donde los usuarios no administradores no podían ver sus propios informes después de crearlos hasta que un administrador accedía

- Se añade el campo `active: true` al crear un nuevo informe desde `create-dashboard.component.ts`
- Se asegura que el campo `active` se preserve al guardar un informe existente en `dashboard.component.ts`
- Se añade la propiedad `active` al modelo de datos en el backend

## Pruebas a realizar
- Verificar que un usuario no admin puede ver sus informes inmediatamente después de crearlos
