### PR TITLE
Enhancement - Informes - Posibilidad de duplicar paneles de tipo texto

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.css
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.css
@@ -11,6 +11,107 @@
   color: #13427d !important;
 }
 
+/* SDA CUSTOM - Optimal use of vertical space with configurable alignment */
+.eda-title-panel {
+  height: 100%;
+  line-height: 1.2;      /* Compact line height */
+}
+
+/* SDA CUSTOM - Minimalist style: no borders, no background, only text and menu */
+.title-panel-minimal {
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  outline: none !important;
+  border-radius: 0 !important;
+  border-left: none !important;
+  border-right: none !important;
+  border-top: none !important;
+  border-bottom: none !important;
+}
+
+/* Ensure no extra padding in minimalist mode */
+.title-panel-minimal .panel-heading,
+.title-panel-minimal .justify-content-between {
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+  border-bottom: none !important;
+  border-left: none !important;
+}
+
+/* SDA CUSTOM - Force removal of any border on the internal container */
+.title-panel-minimal .justify-content-between {
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  outline: none !important;
+  border-bottom: none !important;
+  border-left: none !important;
+}
+
+/* SDA CUSTOM - The eda-title-panel title in minimalist mode */
+:host ::ng-deep .title-panel-minimal,
+:host ::ng-deep .title-panel-minimal * {
+  border: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+  background: transparent !important;
+  border-bottom: none !important;
+  border-left: none !important;
+}
+
+/* SDA CUSTOM - Remove any residual border from the panel parent container */
+:host ::ng-deep .title-panel-minimal .panel-heading,
+:host ::ng-deep .title-panel-minimal .panel-heading * {
+  border: none !important;
+  box-shadow: none !important;
+  background: transparent !important;
+  border-bottom: none !important;
+  border-left: none !important;
+}
+
+/* SDA CUSTOM - Force any container inside the title to have no borders */
+.title-panel-minimal > div,
+.title-panel-minimal > div > div {
+  border: none !important;
+  box-shadow: none !important;
+  border-bottom: none !important;
+  border-left: none !important;
+}
+
+.eda-title-panel p,
+.eda-title-panel h1,
+.eda-title-panel h2,
+.eda-title-panel div {
+  margin: 0;            /* Remove margins that waste space */
+  padding: 0;
+  width: 100%;
+}
+
+/* Ensure images don't overflow vertically */
+.eda-title-panel img {
+  max-height: 100%;     /* Images don't overflow vertically */
+  max-width: 100%;
+  object-fit: contain;
+}
+
+.eda-title-panel p,
+.eda-title-panel h1,
+.eda-title-panel h2,
+.eda-title-panel div {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+}
+
+/* Ensure images don't overflow vertically */
+.eda-title-panel img {
+  max-height: 100%;
+  max-width: 100%;
+  object-fit: contain;
+}
 
 
 
@@ -56,14 +157,13 @@ h2.ql-align-right {
 
 
 
-
 strong {
 font-weight: bold !important;
 }
 
 
-/*============================================================== 
-  For Laptop & above all (1370px) 
+/*==============================================================
+  For Laptop & above all (1370px)
   ============================================================== */
   @media (max-width: 1370px) {
     .ql-size-small {

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.css
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.css
@@ -30,15 +30,15 @@
   border-bottom: none !important;
 }
 
-/* Ensure no extra padding in minimalist mode */
-.title-panel-minimal .panel-heading,
-.title-panel-minimal .justify-content-between {
-  background: transparent !important;
-  border: none !important;
-  box-shadow: none !important;
-  outline: none !important;
-  border-bottom: none !important;
-  border-left: none !important;
+/* SDA CUSTOM - Ensure no extra padding in minimalist mode */
+/* SDA CUSTOM */ .title-panel-minimal .panel-heading,
+/* SDA CUSTOM */ .title-panel-minimal .justify-content-between {
+/* SDA CUSTOM */   background: transparent !important;
+/* SDA CUSTOM */   border: none !important;
+/* SDA CUSTOM */   box-shadow: none !important;
+/* SDA CUSTOM */   outline: none !important;
+/* SDA CUSTOM */   border-bottom: none !important;
+/* SDA CUSTOM */   border-left: none !important;
 }
 
 /* SDA CUSTOM - Force removal of any border on the internal container */
@@ -81,33 +81,18 @@
   border-left: none !important;
 }
 
-.eda-title-panel p,
-.eda-title-panel h1,
-.eda-title-panel h2,
-.eda-title-panel div {
-  margin: 0;            /* Remove margins that waste space */
-  padding: 0;
-  width: 100%;
-}
-
-/* Ensure images don't overflow vertically */
-.eda-title-panel img {
-  max-height: 100%;     /* Images don't overflow vertically */
-  max-width: 100%;
-  object-fit: contain;
-}
-
-.eda-title-panel p,
-.eda-title-panel h1,
-.eda-title-panel h2,
-.eda-title-panel div {
+/* SDA CUSTOM - Remove margins that waste space in text panel elements */
+/* SDA CUSTOM */ .eda-title-panel p,
+/* SDA CUSTOM */ .eda-title-panel h1,
+/* SDA CUSTOM */ .eda-title-panel h2,
+/* SDA CUSTOM */ .eda-title-panel div {
   margin: 0;
   padding: 0;
   width: 100%;
 }
 
-/* Ensure images don't overflow vertically */
-.eda-title-panel img {
+/* SDA CUSTOM - Ensure images don't overflow vertically in text panels */
+/* SDA CUSTOM */ .eda-title-panel img {
   max-height: 100%;
   max-width: 100%;
   object-fit: contain;

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.html
@@ -1,7 +1,7 @@
 <div class="panel-heading d-flex justify-content-between">
 
-    <div class="panel-heading justify-content-between  h-75" style="margin-top: 0.2rem;">
-<!-- SDA CUSTOM -->        <div class="mb-0 pointer w-90 eda-title-panel" [innerHTML]="panel.title | sanitizeHtml" (dblclick)="display.editMode && openEditDialog()"></div>
+    <div class="panel-heading justify-content-between h-75" style="margin-top: 0.2rem;">
+<!-- SDA CUSTOM -->        <div class="mb-0 pointer w-90 eda-title-panel" style="padding-left: 8px;" [innerHTML]="panel.title | sanitizeHtml" (dblclick)="display.editMode && openEditDialog()"></div>
     </div>
 
 <!-- SDA CUSTOM -->    <div *ngIf="display.editMode" class="d-flex align-items-center">

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.html
@@ -1,7 +1,7 @@
 <div class="panel-heading d-flex justify-content-between">
 
     <div class="panel-heading justify-content-between  h-75" style="margin-top: 0.2rem;">
-        <div class="mb-0 pointer w-90 eda-title-panel" [innerHTML]="panel.title | sanitizeHtml"></div>
+<!-- SDA CUSTOM -->        <div class="mb-0 pointer w-90 eda-title-panel" [innerHTML]="panel.title | sanitizeHtml" (dblclick)="display.editMode && openEditDialog()"></div>
     </div>
 
 <!-- SDA CUSTOM -->    <div *ngIf="display.editMode" class="d-flex align-items-center">

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.html
@@ -1,7 +1,10 @@
-<div class="panel-heading d-flex justify-content-between">
+<!-- SDA CUSTOM - Apply border styles to panel - minimal class when no borders or background -->
+<div class="panel-heading d-flex justify-content-between h-100" 
+     [ngClass]="{'title-panel-minimal': isMinimalStyle()}"
+     [ngStyle]="getPanelStyle()">
 
-    <div class="panel-heading justify-content-between h-75" style="margin-top: 0.2rem;">
-<!-- SDA CUSTOM -->        <div class="mb-0 pointer w-90 eda-title-panel" style="padding-left: 8px;" [innerHTML]="panel.title | sanitizeHtml" (dblclick)="display.editMode && openEditDialog()"></div>
+    <div class="panel-heading justify-content-between h-100 w-100 d-flex align-items-center" style="margin-top: 0.2rem;">
+<!-- SDA CUSTOM -->        <div #titleContainer class="mb-0 pointer w-100 eda-title-panel" style="padding-left: 8px; overflow: hidden; max-height: 100%;" [ngStyle]="getTitleStyle()" [innerHTML]="getScaledTitle() | sanitizeHtml" (dblclick)="display.editMode && openEditDialog()"></div>
     </div>
 
 <!-- SDA CUSTOM -->    <div *ngIf="display.editMode" class="d-flex align-items-center">

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.ts
@@ -1,5 +1,5 @@
 import { DashboardService } from './../../../../services/api/dashboard.service';
-import { Component, OnInit, Input, Output, EventEmitter, ViewEncapsulation } from "@angular/core";
+import { Component, OnInit, Input, Output, EventEmitter, ViewEncapsulation, ViewChild, ElementRef, AfterViewInit, OnDestroy } from "@angular/core";
 import { InjectEdaPanel, EdaTitlePanel } from '@eda/models/model.index';
 import { EdaContextMenu, EdaContextMenuItem, EdaDialogCloseEvent, EdaDialogController } from '@eda/shared/components/shared-components.index';
 import { DomSanitizer } from '@angular/platform-browser'
@@ -15,12 +15,13 @@ import { environment } from 'environments/environment';
     encapsulation: ViewEncapsulation.None
 })
 
-export class EdaTitlePanelComponent implements OnInit {
+export class EdaTitlePanelComponent implements OnInit, AfterViewInit, OnDestroy {
     @Input() id: string;
     @Input() panel: EdaTitlePanel;
     @Input() inject: InjectEdaPanel;
     @Output() remove: EventEmitter<any> = new EventEmitter();
 /* SDA CUSTOM */    @Output() duplicate: EventEmitter<any> = new EventEmitter();
+/* SDA CUSTOM */    @ViewChild('titleContainer') titleContainer: ElementRef;
 
     titleClick: boolean = false;
     contextMenu: EdaContextMenu;
@@ -30,9 +31,10 @@ export class EdaTitlePanelComponent implements OnInit {
     }
     public htmlPipe : SafeHtmlPipe
     public urlPipe : SafeUrlPipe
-/* SDA CUSTOM */    public lockPanelTooltip: string = $localize`:@@lockPanel:Bloquear panel`;
-/* SDA CUSTOM */    public unlockPanelTooltip: string = $localize`:@@unlockPanel:Desbloquear panel`;
-
+/* SDA CUSTOM */    public lockPanelTooltip: string = $localize`:@@lockPanel:Lock panel`;
+/* SDA CUSTOM */    public unlockPanelTooltip: string = $localize`:@@unlockPanel:Unlock panel`;
+/* SDA CUSTOM */    private resizeObserver: ResizeObserver;
+/* SDA CUSTOM */    private readonly scaleTolerance = 0.05; // Tolerance to recalculate scale
 
     constructor(public sanitized: DomSanitizer, public dashboardService : DashboardService){}
     
@@ -41,6 +43,175 @@ export class EdaTitlePanelComponent implements OnInit {
         this.initContextMenu()
         this.setEditMode();
     }
+
+/* SDA CUSTOM */    ngAfterViewInit(): void {
+/* SDA CUSTOM */        this.initResizeObserver();
+/* SDA CUSTOM */    }
+
+/* SDA CUSTOM */    ngOnDestroy(): void {
+/* SDA CUSTOM */        if (this.resizeObserver) {
+/* SDA CUSTOM */            this.resizeObserver.disconnect();
+/* SDA CUSTOM */        }
+/* SDA CUSTOM */    }
+
+/* SDA CUSTOM */    private initResizeObserver(): void {
+/* SDA CUSTOM */        if (this.titleContainer && 'ResizeObserver' in window) {
+/* SDA CUSTOM */            this.resizeObserver = new ResizeObserver((entries) => {
+/* SDA CUSTOM */                for (const entry of entries) {
+/* SDA CUSTOM */                    // Force change detection when size changes
+/* SDA CUSTOM */                    if (this.panel.baseWidth && entry.contentRect.width > 0) {
+/* SDA CUSTOM */                        // Scale is calculated automatically in getTitleStyle()
+/* SDA CUSTOM */                    }
+/* SDA CUSTOM */                }
+/* SDA CUSTOM */            });
+/* SDA CUSTOM */            this.resizeObserver.observe(this.titleContainer.nativeElement);
+/* SDA CUSTOM */        }
+/* SDA CUSTOM */    }
+
+/* SDA CUSTOM */    // Calculates scale factor based on current width and height vs base dimensions
+/* SDA CUSTOM */    // Maximizes use of available space both horizontally and vertically
+/* SDA CUSTOM */    getScale(): number {
+/* SDA CUSTOM */        if (!this.panel.baseWidth || this.panel.baseWidth <= 0) {
+/* SDA CUSTOM */            return 1;
+/* SDA CUSTOM */        }
+/* SDA CUSTOM */        if (!this.titleContainer || !this.titleContainer.nativeElement) {
+/* SDA CUSTOM */            return 1;
+/* SDA CUSTOM */        }
+/* SDA CUSTOM */        const currentWidth = this.titleContainer.nativeElement.offsetWidth;
+/* SDA CUSTOM */        const currentHeight = this.titleContainer.nativeElement.offsetHeight;
+/* SDA CUSTOM */        if (currentWidth <= 0 || currentHeight <= 0) {
+/* SDA CUSTOM */            return 1;
+/* SDA CUSTOM */        }
+/* SDA CUSTOM */        // Estimate typical base height (proportional to base width with 1:4 ratio approx)
+/* SDA CUSTOM */        const baseHeight = this.panel.baseWidth / 4;
+/* SDA CUSTOM */        // Calculate width and height ratios
+/* SDA CUSTOM */        const widthRatio = currentWidth / this.panel.baseWidth;
+/* SDA CUSTOM */        const heightRatio = currentHeight / baseHeight;
+/* SDA CUSTOM */        // Use the ratio that allows leveraging more space (the larger one, but limited)
+/* SDA CUSTOM */        // This allows text to grow if vertical space is available
+/* SDA CUSTOM */        let ratio = Math.max(widthRatio, heightRatio * 0.8); // 0.8 to give vertical safety margin
+/* SDA CUSTOM */        // Only scale if there is significant change (outside tolerance)
+/* SDA CUSTOM */        if (ratio >= (1 - this.scaleTolerance) && ratio <= (1 + this.scaleTolerance)) {
+/* SDA CUSTOM */            return 1;
+/* SDA CUSTOM */        }
+/* SDA CUSTOM */        return ratio;
+/* SDA CUSTOM */    }
+
+/* SDA CUSTOM */    // Returns CSS style for the title container
+/* SDA CUSTOM */    // Includes the vertical alignment selected by the user
+/* SDA CUSTOM */    getTitleStyle(): any {
+/* SDA CUSTOM */        const align = this.panel.verticalAlign || 'center';
+/* SDA CUSTOM */        let alignItems = 'center';
+/* SDA CUSTOM */        if (align === 'top') alignItems = 'flex-start';
+/* SDA CUSTOM */        else if (align === 'bottom') alignItems = 'flex-end';
+/* SDA CUSTOM */
+/* SDA CUSTOM */        return {
+/* SDA CUSTOM */            'display': 'flex',
+/* SDA CUSTOM */            'align-items': alignItems,
+/* SDA CUSTOM */            'transform-origin': 'left center',
+/* SDA CUSTOM */            'color': this.panel.textColor || 'inherit'
+/* SDA CUSTOM */        };
+/* SDA CUSTOM */    }
+
+/* SDA CUSTOM */    // Indicates if the panel should use minimal style (no borders or background)
+/* SDA CUSTOM */    isMinimalStyle(): boolean {
+/* SDA CUSTOM */        const showBorder = this.panel.showBorder !== false;
+/* SDA CUSTOM */        return !showBorder && this.panel.backgroundTransparent;
+/* SDA CUSTOM */    }
+
+/* SDA CUSTOM */    // Returns CSS style for the panel (borders)
+    /* SDA CUSTOM */    // When there is no border or background, the panel is completely clean/minimalist
+    /* SDA CUSTOM */    getPanelStyle(): any {
+    /* SDA CUSTOM */        const showBorder = this.panel.showBorder !== false; // default true
+    /* SDA CUSTOM */        const borderColor = this.panel.borderColor || '#d7dde6';
+    /* SDA CUSTOM */        const backgroundTransparent = this.panel.backgroundTransparent;
+    /* SDA CUSTOM */        
+    /* SDA CUSTOM */        // In minimalist mode, remove ALL borders and shadows
+    /* SDA CUSTOM */        if (!showBorder && backgroundTransparent) {
+    /* SDA CUSTOM */            return {
+    /* SDA CUSTOM */                'border': 'none',
+    /* SDA CUSTOM */                'border-top': 'none',
+    /* SDA CUSTOM */                'border-bottom': 'none',
+    /* SDA CUSTOM */                'border-left': 'none',
+    /* SDA CUSTOM */                'border-right': 'none',
+    /* SDA CUSTOM */                'border-radius': '0',
+    /* SDA CUSTOM */                'box-shadow': 'none',
+    /* SDA CUSTOM */                '-webkit-box-shadow': 'none',
+    /* SDA CUSTOM */                'background': 'transparent',
+    /* SDA CUSTOM */                'outline': 'none'
+    /* SDA CUSTOM */            };
+    /* SDA CUSTOM */        }
+    /* SDA CUSTOM */        
+    /* SDA CUSTOM */        return {
+    /* SDA CUSTOM */            'border': showBorder ? `1px solid ${borderColor}` : 'none',
+    /* SDA CUSTOM */            'border-top': showBorder ? `1px solid ${borderColor}` : 'none',
+    /* SDA CUSTOM */            'border-bottom': showBorder ? `1px solid ${borderColor}` : 'none',
+    /* SDA CUSTOM */            'border-left': showBorder ? `1px solid ${borderColor}` : 'none',
+    /* SDA CUSTOM */            'border-right': showBorder ? `1px solid ${borderColor}` : 'none',
+    /* SDA CUSTOM */            'border-radius': showBorder ? '4px' : '0',
+    /* SDA CUSTOM */            'box-shadow': 'none',
+    /* SDA CUSTOM */            'background': backgroundTransparent ? 'transparent' : undefined
+    /* SDA CUSTOM */        };
+    /* SDA CUSTOM */    }
+
+/* SDA CUSTOM */    // Processes the title HTML and adjusts font sizes according to scale factor
+/* SDA CUSTOM */    getScaledTitle(): string {
+/* SDA CUSTOM */        if (!this.panel.title) {
+/* SDA CUSTOM */            return '';
+/* SDA CUSTOM */        }
+/* SDA CUSTOM */        const scale = this.getScale();
+/* SDA CUSTOM */        if (scale === 1) {
+/* SDA CUSTOM */            return this.panel.title;
+/* SDA CUSTOM */        }
+/* SDA CUSTOM */        // Limit maximum scale to 1.3x to prevent text from becoming too large
+/* SDA CUSTOM */        const limitedScale = Math.min(scale, 1.3);
+/* SDA CUSTOM */        // Process HTML and adjust font sizes
+/* SDA CUSTOM */        return this.adjustFontSizes(this.panel.title, limitedScale);
+/* SDA CUSTOM */    }
+
+/* SDA CUSTOM */    // Adjusts font sizes in HTML according to scale factor
+/* SDA CUSTOM */    private adjustFontSizes(html: string, scale: number): string {
+/* SDA CUSTOM */        if (!html || scale === 1) {
+/* SDA CUSTOM */            return html;
+/* SDA CUSTOM */        }
+/* SDA CUSTOM */        // Create a temporary div to parse the HTML
+/* SDA CUSTOM */        const tempDiv = document.createElement('div');
+/* SDA CUSTOM */        tempDiv.innerHTML = html;
+/* SDA CUSTOM */        // Adjust font sizes in elements with inline style
+/* SDA CUSTOM */        const elementsWithStyle = tempDiv.querySelectorAll('[style*="font-size"]');
+/* SDA CUSTOM */        elementsWithStyle.forEach(el => {
+/* SDA CUSTOM */            const style = el.getAttribute('style') || '';
+/* SDA CUSTOM */            const newStyle = this.scaleFontSizeInStyle(style, scale);
+/* SDA CUSTOM */            el.setAttribute('style', newStyle);
+/* SDA CUSTOM */        });
+/* SDA CUSTOM */        // Adjust span elements with Quill sizes (ql-size-*)
+/* SDA CUSTOM */        const sizeClasses = ['ql-size-small', 'ql-size-large', 'ql-size-huge'];
+/* SDA CUSTOM */        sizeClasses.forEach(className => {
+/* SDA CUSTOM */            const elements = tempDiv.querySelectorAll(`.${className}`);
+/* SDA CUSTOM */            elements.forEach(el => {
+/* SDA CUSTOM */                let currentSize = 16;
+/* SDA CUSTOM */                if (className === 'ql-size-small') currentSize = 10;
+/* SDA CUSTOM */                else if (className === 'ql-size-large') currentSize = 18;
+/* SDA CUSTOM */                else if (className === 'ql-size-huge') currentSize = 32;
+/* SDA CUSTOM */                const newSize = Math.round(currentSize * scale);
+/* SDA CUSTOM */                el.classList.remove(className);
+/* SDA CUSTOM */                const currentStyle = el.getAttribute('style') || '';
+/* SDA CUSTOM */                el.setAttribute('style', `${currentStyle}; font-size: ${newSize}px;`.replace(/^; /, ''));
+/* SDA CUSTOM */            });
+/* SDA CUSTOM */        });
+/* SDA CUSTOM */        return tempDiv.innerHTML;
+/* SDA CUSTOM */    }
+
+/* SDA CUSTOM */    // Scales font size in a CSS style string
+/* SDA CUSTOM */    private scaleFontSizeInStyle(style: string, scale: number): string {
+/* SDA CUSTOM */        const fontSizeMatch = style.match(/font-size:\s*(\d+)px/);
+/* SDA CUSTOM */        if (fontSizeMatch) {
+/* SDA CUSTOM */            const currentSize = parseInt(fontSizeMatch[1], 10);
+/* SDA CUSTOM */            const newSize = Math.round(currentSize * scale);
+/* SDA CUSTOM */            return style.replace(/font-size:\s*\d+px/, `font-size: ${newSize}px`);
+/* SDA CUSTOM */        }
+/* SDA CUSTOM */        return style;
+/* SDA CUSTOM */    }
 
 /* SDA CUSTOM */   public toggleLock(): void {
 /* SDA CUSTOM */       this.panel.locked = !this.panel.locked;
@@ -55,21 +226,35 @@ export class EdaTitlePanelComponent implements OnInit {
 
     public initContextMenu(): void {
         this.contextMenu = new EdaContextMenu({
-            header: $localize`:@@panelOptions0:OPCIONES DEL PANEL`,
+            header: $localize`:@@panelOptions0:PANEL OPTIONS`,
             contextMenuItems: [
                 new EdaContextMenuItem({
-                    label: $localize`:@@panelOptions2:Editar opciones del gráfico`,
+                    label: $localize`:@@panelOptions2:Edit chart options`,
                     icon: 'mdi mdi-wrench',
                     command: () => {
                         
                         this.contextMenu.hideContextMenu();
 
+                        // SDA CUSTOM - Get current container width for proportional scaling
+                        const currentWidth = this.titleContainer?.nativeElement?.offsetWidth || 0;
+                        const baseWidth = this.panel.baseWidth || currentWidth;
+
                         this.editTittleController = new EdaDialogController({
-                        /* SDA CUSTOM */ params: { title: this.panel.title, backgroundTransparent: this.panel.backgroundTransparent },
+                        /* SDA CUSTOM */ params: { title: this.panel.title, backgroundTransparent: this.panel.backgroundTransparent, baseWidth: baseWidth, verticalAlign: this.panel.verticalAlign, textColor: this.panel.textColor, borderColor: this.panel.borderColor, showBorder: this.panel.showBorder },
                             close: (event, response) => {
                                 if(!_.isEqual(event, EdaDialogCloseEvent.NONE)){
                                     this.panel.title = response.title;
-                        /* SDA CUSTOM */ this.panel.backgroundTransparent = response.backgroundTransparent;
+/* SDA CUSTOM */ this.panel.backgroundTransparent = response.backgroundTransparent;
+                                    // SDA CUSTOM - Save base width for proportional scaling (only if new)
+                                    if (!this.panel.baseWidth && response.baseWidth) {
+                                        this.panel.baseWidth = response.baseWidth;
+                                    }
+                                    // SDA CUSTOM - Save vertical alignment
+                                    this.panel.verticalAlign = response.verticalAlign || 'center';
+                                    // SDA CUSTOM - Save appearance options
+                                    this.panel.textColor = response.textColor || '#000000';
+                                    this.panel.borderColor = response.borderColor || '#d7dde6';
+                                    this.panel.showBorder = response.showBorder !== false;
                                     this.setPanelSize()
                                     this.dashboardService._notSaved.next(true);
                                 }
@@ -79,7 +264,7 @@ export class EdaTitlePanelComponent implements OnInit {
                     }
                 }),
 /* SDA CUSTOM */                new EdaContextMenuItem({
-/* SDA CUSTOM */                    label: $localize`:@@duplicatePanel:Duplicar panel`,
+/* SDA CUSTOM */                    label: $localize`:@@duplicatePanel:Duplicate panel`,
 /* SDA CUSTOM */                    icon: 'fa fa-copy',
 /* SDA CUSTOM */                    command: () => {
 /* SDA CUSTOM */                        this.contextMenu.hideContextMenu();
@@ -87,7 +272,7 @@ export class EdaTitlePanelComponent implements OnInit {
 /* SDA CUSTOM */                    }
                 }),
                 new EdaContextMenuItem({
-                    label: $localize`:@@panelOptions4:Eliminar panel`,
+                    label: $localize`:@@panelOptions4:Delete panel`,
                     icon: 'fa fa-trash',
                     command: () => {
                         this.contextMenu.hideContextMenu();
@@ -104,12 +289,26 @@ export class EdaTitlePanelComponent implements OnInit {
     }
 
 /* SDA CUSTOM */     public openEditDialog(): void {
+/* SDA CUSTOM */         // Get current container width for proportional scaling
+/* SDA CUSTOM */         const currentWidth = this.titleContainer?.nativeElement?.offsetWidth || 0;
+/* SDA CUSTOM */         const baseWidth = this.panel.baseWidth || currentWidth;
+/* SDA CUSTOM */
 /* SDA CUSTOM */         this.editTittleController = new EdaDialogController({
-/* SDA CUSTOM */             params: { title: this.panel.title, backgroundTransparent: this.panel.backgroundTransparent },
+/* SDA CUSTOM */             params: { title: this.panel.title, backgroundTransparent: this.panel.backgroundTransparent, baseWidth: baseWidth, verticalAlign: this.panel.verticalAlign, textColor: this.panel.textColor, borderColor: this.panel.borderColor, showBorder: this.panel.showBorder },
 /* SDA CUSTOM */             close: (event, response) => {
 /* SDA CUSTOM */                 if(!_.isEqual(event, EdaDialogCloseEvent.NONE)){
 /* SDA CUSTOM */                     this.panel.title = response.title;
 /* SDA CUSTOM */                     this.panel.backgroundTransparent = response.backgroundTransparent;
+/* SDA CUSTOM */                     // Save base width for proportional scaling (only if new)
+/* SDA CUSTOM */                     if (!this.panel.baseWidth && response.baseWidth) {
+/* SDA CUSTOM */                         this.panel.baseWidth = response.baseWidth;
+/* SDA CUSTOM */                     }
+/* SDA CUSTOM */                     // Save vertical alignment
+/* SDA CUSTOM */                     this.panel.verticalAlign = response.verticalAlign || 'center';
+/* SDA CUSTOM */                     // Save appearance options
+/* SDA CUSTOM */                     this.panel.textColor = response.textColor || '#000000';
+/* SDA CUSTOM */                     this.panel.borderColor = response.borderColor || '#d7dde6';
+/* SDA CUSTOM */                     this.panel.showBorder = response.showBorder !== false;
 /* SDA CUSTOM */                     this.setPanelSize()
 /* SDA CUSTOM */                     this.dashboardService._notSaved.next(true);
 /* SDA CUSTOM */                 }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.ts
@@ -20,6 +20,7 @@ export class EdaTitlePanelComponent implements OnInit {
     @Input() panel: EdaTitlePanel;
     @Input() inject: InjectEdaPanel;
     @Output() remove: EventEmitter<any> = new EventEmitter();
+/* SDA CUSTOM */    @Output() duplicate: EventEmitter<any> = new EventEmitter();
 
     titleClick: boolean = false;
     contextMenu: EdaContextMenu;
@@ -84,6 +85,14 @@ export class EdaTitlePanelComponent implements OnInit {
                             }
                           });
                     }
+/* SDA CUSTOM */                }),
+/* SDA CUSTOM */                new EdaContextMenuItem({
+/* SDA CUSTOM */                    label: $localize`:@@duplicatePanel:Duplicar panel`,
+/* SDA CUSTOM */                    icon: 'fa fa-copy',
+/* SDA CUSTOM */                    command: () => {
+/* SDA CUSTOM */                        this.contextMenu.hideContextMenu();
+/* SDA CUSTOM */                        this.duplicatePanel();
+/* SDA CUSTOM */                    }
                 })
             ]
         });
@@ -93,6 +102,34 @@ export class EdaTitlePanelComponent implements OnInit {
     public removePanel(): void {
         this.remove.emit(this.panel.id);
     }
+/* SDA CUSTOM */     public openEditDialog(): void {
+/* SDA CUSTOM */         this.editTittleController = new EdaDialogController({
+/* SDA CUSTOM */             params: { title: this.panel.title },
+/* SDA CUSTOM */             close: (event, response) => {
+/* SDA CUSTOM */                 if(!_.isEqual(event, EdaDialogCloseEvent.NONE)){
+/* SDA CUSTOM */                     this.panel.title = response.title;
+/* SDA CUSTOM */                     this.setPanelSize()
+/* SDA CUSTOM */                     this.dashboardService._notSaved.next(true);
+/* SDA CUSTOM */                 }
+/* SDA CUSTOM */                 this.editTittleController = null;
+/* SDA CUSTOM */             }
+/* SDA CUSTOM */         });
+/* SDA CUSTOM */     }
+
+/* SDA CUSTOM */    public duplicatePanel(): void {
+/* SDA CUSTOM */        const duplicatedPanel = _.cloneDeep(this.panel, true);
+/* SDA CUSTOM */        duplicatedPanel.id = this.generateUUID();
+/* SDA CUSTOM */        duplicatedPanel.y = duplicatedPanel.y + 1;
+/* SDA CUSTOM */        this.duplicate.emit(duplicatedPanel);
+/* SDA CUSTOM */    }
+
+/* SDA CUSTOM */    private generateUUID(): string {
+/* SDA CUSTOM */        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+/* SDA CUSTOM */            const r = Math.random() * 16 | 0;
+/* SDA CUSTOM */            const v = c === 'x' ? r : (r & 0x3 | 0x8);
+/* SDA CUSTOM */            return v.toString(16);
+/* SDA CUSTOM */        });
+/* SDA CUSTOM */    }
 
     public setPanelSize(): void {
         let element: any;

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.ts
@@ -58,34 +58,26 @@ export class EdaTitlePanelComponent implements OnInit {
             header: $localize`:@@panelOptions0:OPCIONES DEL PANEL`,
             contextMenuItems: [
                 new EdaContextMenuItem({
-                    label: $localize`:@@panelOptions4:Eliminar panel`,
-                    icon: 'fa fa-trash',
-                    command: () => {
-                        this.contextMenu.hideContextMenu();
-                        this.removePanel();
-                    }
-                }),
-                new EdaContextMenuItem({
                     label: $localize`:@@panelOptions2:Editar opciones del gráfico`,
-                    icon: 'mdi mdi-wrench', 
+                    icon: 'mdi mdi-wrench',
                     command: () => {
                         
                         this.contextMenu.hideContextMenu();
 
                         this.editTittleController = new EdaDialogController({
-                            params: { title: this.panel.title },
+                        /* SDA CUSTOM */ params: { title: this.panel.title, backgroundTransparent: this.panel.backgroundTransparent },
                             close: (event, response) => {
                                 if(!_.isEqual(event, EdaDialogCloseEvent.NONE)){
                                     this.panel.title = response.title;
+                        /* SDA CUSTOM */ this.panel.backgroundTransparent = response.backgroundTransparent;
                                     this.setPanelSize()
                                     this.dashboardService._notSaved.next(true);
                                 }
                                 this.editTittleController = null;
-                                // this.setPanelSize()
                             }
                           });
                     }
-/* SDA CUSTOM */                }),
+                }),
 /* SDA CUSTOM */                new EdaContextMenuItem({
 /* SDA CUSTOM */                    label: $localize`:@@duplicatePanel:Duplicar panel`,
 /* SDA CUSTOM */                    icon: 'fa fa-copy',
@@ -93,7 +85,15 @@ export class EdaTitlePanelComponent implements OnInit {
 /* SDA CUSTOM */                        this.contextMenu.hideContextMenu();
 /* SDA CUSTOM */                        this.duplicatePanel();
 /* SDA CUSTOM */                    }
-                })
+                }),
+                new EdaContextMenuItem({
+                    label: $localize`:@@panelOptions4:Eliminar panel`,
+                    icon: 'fa fa-trash',
+                    command: () => {
+                        this.contextMenu.hideContextMenu();
+                        this.removePanel();
+                    }
+                }),
             ]
         });
 
@@ -102,12 +102,14 @@ export class EdaTitlePanelComponent implements OnInit {
     public removePanel(): void {
         this.remove.emit(this.panel.id);
     }
+
 /* SDA CUSTOM */     public openEditDialog(): void {
 /* SDA CUSTOM */         this.editTittleController = new EdaDialogController({
-/* SDA CUSTOM */             params: { title: this.panel.title },
+/* SDA CUSTOM */             params: { title: this.panel.title, backgroundTransparent: this.panel.backgroundTransparent },
 /* SDA CUSTOM */             close: (event, response) => {
 /* SDA CUSTOM */                 if(!_.isEqual(event, EdaDialogCloseEvent.NONE)){
 /* SDA CUSTOM */                     this.panel.title = response.title;
+/* SDA CUSTOM */                     this.panel.backgroundTransparent = response.backgroundTransparent;
 /* SDA CUSTOM */                     this.setPanelSize()
 /* SDA CUSTOM */                     this.dashboardService._notSaved.next(true);
 /* SDA CUSTOM */                 }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.ts
@@ -1,5 +1,5 @@
 import { DashboardService } from './../../../../services/api/dashboard.service';
-import { Component, OnInit, Input, Output, EventEmitter, ViewEncapsulation, ViewChild, ElementRef, AfterViewInit, OnDestroy } from "@angular/core";
+import { Component, OnInit, Input, Output, EventEmitter, ViewEncapsulation, ViewChild, ElementRef, AfterViewInit, OnDestroy, ChangeDetectorRef } from "@angular/core";
 import { InjectEdaPanel, EdaTitlePanel } from '@eda/models/model.index';
 import { EdaContextMenu, EdaContextMenuItem, EdaDialogCloseEvent, EdaDialogController } from '@eda/shared/components/shared-components.index';
 import { DomSanitizer } from '@angular/platform-browser'
@@ -35,8 +35,9 @@ export class EdaTitlePanelComponent implements OnInit, AfterViewInit, OnDestroy 
 /* SDA CUSTOM */    public unlockPanelTooltip: string = $localize`:@@unlockPanel:Unlock panel`;
 /* SDA CUSTOM */    private resizeObserver: ResizeObserver;
 /* SDA CUSTOM */    private readonly scaleTolerance = 0.05; // Tolerance to recalculate scale
+/* SDA CUSTOM */    public scaledTitle: string = '';
 
-    constructor(public sanitized: DomSanitizer, public dashboardService : DashboardService){}
+    constructor(public sanitized: DomSanitizer, public dashboardService : DashboardService, private cdr: ChangeDetectorRef){}
     
 
     ngOnInit(): void {
@@ -46,6 +47,10 @@ export class EdaTitlePanelComponent implements OnInit, AfterViewInit, OnDestroy 
 
 /* SDA CUSTOM */    ngAfterViewInit(): void {
 /* SDA CUSTOM */        this.initResizeObserver();
+/* SDA CUSTOM */        setTimeout(() => {
+/* SDA CUSTOM */            this.scaledTitle = this.computeScaledTitle();
+/* SDA CUSTOM */            this.cdr.detectChanges();
+/* SDA CUSTOM */        });
 /* SDA CUSTOM */    }
 
 /* SDA CUSTOM */    ngOnDestroy(): void {
@@ -58,9 +63,11 @@ export class EdaTitlePanelComponent implements OnInit, AfterViewInit, OnDestroy 
 /* SDA CUSTOM */        if (this.titleContainer && 'ResizeObserver' in window) {
 /* SDA CUSTOM */            this.resizeObserver = new ResizeObserver((entries) => {
 /* SDA CUSTOM */                for (const entry of entries) {
-/* SDA CUSTOM */                    // Force change detection when size changes
 /* SDA CUSTOM */                    if (this.panel.baseWidth && entry.contentRect.width > 0) {
-/* SDA CUSTOM */                        // Scale is calculated automatically in getTitleStyle()
+/* SDA CUSTOM */                        requestAnimationFrame(() => {
+/* SDA CUSTOM */                            this.scaledTitle = this.computeScaledTitle();
+/* SDA CUSTOM */                            this.cdr.detectChanges();
+/* SDA CUSTOM */                        });
 /* SDA CUSTOM */                    }
 /* SDA CUSTOM */                }
 /* SDA CUSTOM */            });
@@ -108,8 +115,7 @@ export class EdaTitlePanelComponent implements OnInit, AfterViewInit, OnDestroy 
 /* SDA CUSTOM */        return {
 /* SDA CUSTOM */            'display': 'flex',
 /* SDA CUSTOM */            'align-items': alignItems,
-/* SDA CUSTOM */            'transform-origin': 'left center',
-/* SDA CUSTOM */            'color': this.panel.textColor || 'inherit'
+/* SDA CUSTOM */            'transform-origin': 'left center'
 /* SDA CUSTOM */        };
 /* SDA CUSTOM */    }
 
@@ -150,12 +156,16 @@ export class EdaTitlePanelComponent implements OnInit, AfterViewInit, OnDestroy 
     /* SDA CUSTOM */            'border-right': showBorder ? `1px solid ${borderColor}` : 'none',
     /* SDA CUSTOM */            'border-radius': showBorder ? '4px' : '0',
     /* SDA CUSTOM */            'box-shadow': 'none',
-    /* SDA CUSTOM */            'background': backgroundTransparent ? 'transparent' : undefined
+    /* SDA CUSTOM */            'background': backgroundTransparent ? 'transparent' : (this.panel.backgroundColor || undefined)
     /* SDA CUSTOM */        };
     /* SDA CUSTOM */    }
 
 /* SDA CUSTOM */    // Processes the title HTML and adjusts font sizes according to scale factor
 /* SDA CUSTOM */    getScaledTitle(): string {
+/* SDA CUSTOM */        return this.scaledTitle || this.panel.title || '';
+/* SDA CUSTOM */    }
+
+/* SDA CUSTOM */    private computeScaledTitle(): string {
 /* SDA CUSTOM */        if (!this.panel.title) {
 /* SDA CUSTOM */            return '';
 /* SDA CUSTOM */        }
@@ -163,9 +173,7 @@ export class EdaTitlePanelComponent implements OnInit, AfterViewInit, OnDestroy 
 /* SDA CUSTOM */        if (scale === 1) {
 /* SDA CUSTOM */            return this.panel.title;
 /* SDA CUSTOM */        }
-/* SDA CUSTOM */        // Limit maximum scale to 1.3x to prevent text from becoming too large
 /* SDA CUSTOM */        const limitedScale = Math.min(scale, 1.3);
-/* SDA CUSTOM */        // Process HTML and adjust font sizes
 /* SDA CUSTOM */        return this.adjustFontSizes(this.panel.title, limitedScale);
 /* SDA CUSTOM */    }
 
@@ -240,11 +248,13 @@ export class EdaTitlePanelComponent implements OnInit, AfterViewInit, OnDestroy 
                         const baseWidth = this.panel.baseWidth || currentWidth;
 
                         this.editTittleController = new EdaDialogController({
-                        /* SDA CUSTOM */ params: { title: this.panel.title, backgroundTransparent: this.panel.backgroundTransparent, baseWidth: baseWidth, verticalAlign: this.panel.verticalAlign, textColor: this.panel.textColor, borderColor: this.panel.borderColor, showBorder: this.panel.showBorder },
+                        /* SDA CUSTOM */ params: { title: this.panel.title, backgroundTransparent: this.panel.backgroundTransparent, baseWidth: baseWidth, verticalAlign: this.panel.verticalAlign, borderColor: this.panel.borderColor, showBorder: this.panel.showBorder, backgroundColor: this.panel.backgroundColor },
                             close: (event, response) => {
                                 if(!_.isEqual(event, EdaDialogCloseEvent.NONE)){
                                     this.panel.title = response.title;
 /* SDA CUSTOM */ this.panel.backgroundTransparent = response.backgroundTransparent;
+/* SDA CUSTOM */                                    this.scaledTitle = '';
+/* SDA CUSTOM */                                    setTimeout(() => { this.scaledTitle = this.computeScaledTitle(); this.cdr.detectChanges(); });
                                     // SDA CUSTOM - Save base width for proportional scaling (only if new)
                                     if (!this.panel.baseWidth && response.baseWidth) {
                                         this.panel.baseWidth = response.baseWidth;
@@ -252,9 +262,10 @@ export class EdaTitlePanelComponent implements OnInit, AfterViewInit, OnDestroy 
                                     // SDA CUSTOM - Save vertical alignment
                                     this.panel.verticalAlign = response.verticalAlign || 'center';
                                     // SDA CUSTOM - Save appearance options
-                                    this.panel.textColor = response.textColor || '#000000';
                                     this.panel.borderColor = response.borderColor || '#d7dde6';
                                     this.panel.showBorder = response.showBorder !== false;
+                                    // SDA CUSTOM - Save background color
+                                    this.panel.backgroundColor = response.backgroundColor || '#ffffff';
                                     this.setPanelSize()
                                     this.dashboardService._notSaved.next(true);
                                 }
@@ -294,11 +305,13 @@ export class EdaTitlePanelComponent implements OnInit, AfterViewInit, OnDestroy 
 /* SDA CUSTOM */         const baseWidth = this.panel.baseWidth || currentWidth;
 /* SDA CUSTOM */
 /* SDA CUSTOM */         this.editTittleController = new EdaDialogController({
-/* SDA CUSTOM */             params: { title: this.panel.title, backgroundTransparent: this.panel.backgroundTransparent, baseWidth: baseWidth, verticalAlign: this.panel.verticalAlign, textColor: this.panel.textColor, borderColor: this.panel.borderColor, showBorder: this.panel.showBorder },
+/* SDA CUSTOM */             params: { title: this.panel.title, backgroundTransparent: this.panel.backgroundTransparent, baseWidth: baseWidth, verticalAlign: this.panel.verticalAlign, borderColor: this.panel.borderColor, showBorder: this.panel.showBorder, backgroundColor: this.panel.backgroundColor },
 /* SDA CUSTOM */             close: (event, response) => {
 /* SDA CUSTOM */                 if(!_.isEqual(event, EdaDialogCloseEvent.NONE)){
 /* SDA CUSTOM */                     this.panel.title = response.title;
 /* SDA CUSTOM */                     this.panel.backgroundTransparent = response.backgroundTransparent;
+/* SDA CUSTOM */                     this.scaledTitle = '';
+/* SDA CUSTOM */                     setTimeout(() => { this.scaledTitle = this.computeScaledTitle(); this.cdr.detectChanges(); });
 /* SDA CUSTOM */                     // Save base width for proportional scaling (only if new)
 /* SDA CUSTOM */                     if (!this.panel.baseWidth && response.baseWidth) {
 /* SDA CUSTOM */                         this.panel.baseWidth = response.baseWidth;
@@ -306,9 +319,10 @@ export class EdaTitlePanelComponent implements OnInit, AfterViewInit, OnDestroy 
 /* SDA CUSTOM */                     // Save vertical alignment
 /* SDA CUSTOM */                     this.panel.verticalAlign = response.verticalAlign || 'center';
 /* SDA CUSTOM */                     // Save appearance options
-/* SDA CUSTOM */                     this.panel.textColor = response.textColor || '#000000';
 /* SDA CUSTOM */                     this.panel.borderColor = response.borderColor || '#d7dde6';
 /* SDA CUSTOM */                     this.panel.showBorder = response.showBorder !== false;
+/* SDA CUSTOM */                     // Save background color
+/* SDA CUSTOM */                     this.panel.backgroundColor = response.backgroundColor || '#ffffff';
 /* SDA CUSTOM */                     this.setPanelSize()
 /* SDA CUSTOM */                     this.dashboardService._notSaved.next(true);
 /* SDA CUSTOM */                 }
@@ -321,7 +335,8 @@ export class EdaTitlePanelComponent implements OnInit, AfterViewInit, OnDestroy 
 /* SDA CUSTOM */        const duplicatedPanel = _.cloneDeep(this.panel, true);
 /* SDA CUSTOM */        duplicatedPanel.id = this.generateUUID();
 /* SDA CUSTOM */        duplicatedPanel.y = duplicatedPanel.y + 1;
-/* SDA CUSTOM */        this.duplicate.emit(duplicatedPanel);
+/* SDA CUSTOM */        const sourcePanelId = this.panel.id;
+/* SDA CUSTOM */        this.duplicate.emit({ panel: duplicatedPanel, sourcePanelId: sourcePanelId });
 /* SDA CUSTOM */    }
 
 /* SDA CUSTOM */    private generateUUID(): string {

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.ts
@@ -244,8 +244,8 @@ export class EdaTitlePanelComponent implements OnInit, AfterViewInit, OnDestroy 
                         this.contextMenu.hideContextMenu();
 
                         // SDA CUSTOM - Get current container width for proportional scaling
-                        const currentWidth = this.titleContainer?.nativeElement?.offsetWidth || 0;
-                        const baseWidth = this.panel.baseWidth || currentWidth;
+/* SDA CUSTOM */                        const currentWidth = this.titleContainer?.nativeElement?.offsetWidth || 0;
+/* SDA CUSTOM */                        const baseWidth = this.panel.baseWidth || currentWidth;
 
                         this.editTittleController = new EdaDialogController({
                         /* SDA CUSTOM */ params: { title: this.panel.title, backgroundTransparent: this.panel.backgroundTransparent, baseWidth: baseWidth, verticalAlign: this.panel.verticalAlign, borderColor: this.panel.borderColor, showBorder: this.panel.showBorder, backgroundColor: this.panel.backgroundColor },
@@ -256,16 +256,16 @@ export class EdaTitlePanelComponent implements OnInit, AfterViewInit, OnDestroy 
 /* SDA CUSTOM */                                    this.scaledTitle = '';
 /* SDA CUSTOM */                                    setTimeout(() => { this.scaledTitle = this.computeScaledTitle(); this.cdr.detectChanges(); });
                                     // SDA CUSTOM - Save base width for proportional scaling (only if new)
-                                    if (!this.panel.baseWidth && response.baseWidth) {
-                                        this.panel.baseWidth = response.baseWidth;
+/* SDA CUSTOM */                                    if (!this.panel.baseWidth && response.baseWidth) {
+/* SDA CUSTOM */                                        this.panel.baseWidth = response.baseWidth;
                                     }
                                     // SDA CUSTOM - Save vertical alignment
-                                    this.panel.verticalAlign = response.verticalAlign || 'center';
+/* SDA CUSTOM */                                    this.panel.verticalAlign = response.verticalAlign || 'center';
                                     // SDA CUSTOM - Save appearance options
-                                    this.panel.borderColor = response.borderColor || '#d7dde6';
-                                    this.panel.showBorder = response.showBorder !== false;
+/* SDA CUSTOM */                                    this.panel.borderColor = response.borderColor || '#d7dde6';
+/* SDA CUSTOM */                                    this.panel.showBorder = response.showBorder !== false;
                                     // SDA CUSTOM - Save background color
-                                    this.panel.backgroundColor = response.backgroundColor || '#ffffff';
+/* SDA CUSTOM */                                    this.panel.backgroundColor = response.backgroundColor || '#ffffff';
                                     this.setPanelSize()
                                     this.dashboardService._notSaved.next(true);
                                 }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/eda-title-panel.component.ts
@@ -275,7 +275,7 @@ export class EdaTitlePanelComponent implements OnInit, AfterViewInit, OnDestroy 
                     }
                 }),
 /* SDA CUSTOM */                new EdaContextMenuItem({
-/* SDA CUSTOM */                    label: $localize`:@@duplicatePanel:Duplicate panel`,
+/* SDA CUSTOM */                    label: $localize`:@@duplicatePanel:Duplicar panel`,
 /* SDA CUSTOM */                    icon: 'fa fa-copy',
 /* SDA CUSTOM */                    command: () => {
 /* SDA CUSTOM */                        this.contextMenu.hideContextMenu();

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.html
@@ -1,91 +1,194 @@
 <eda-dialog [inject]="dialog">
-	<div body class="grid">
-<!-- SDA CUSTOM -->		<div class="col-12 mb-2">
-<!-- SDA CUSTOM -->			<p-checkbox [(ngModel)]="backgroundTransparent" [binary]="true" inputId="bgTransparent"></p-checkbox>
-<!-- SDA CUSTOM -->			<label for="bgTransparent" class="ml-2">Quitar fondo del panel</label>
-<!-- SDA CUSTOM -->		</div>
-		<div class="col-12">
+	<!-- SDA CUSTOM - Reorganized layout with side options panel similar to kpi-options-shell -->
+	<div body class="grid h-100 p-4">
+		<!-- Main column: Editor -->
+		<div class="col-8">
+			<div class="h-100">
+				<p-editor #Editor [(ngModel)]="title" [style]="{'height':'calc(100% - 42px)'}">
+					<p-header>
+						<span class="ql-formats">
+							<!-- <select class="ql-font"></select> -->
+							<!-- SDA CUSTOM - Custom font sizes in px -->
+							<select class="ql-size">
+								<option value="10px">10px</option>
+								<option value="12px">12px</option>
+								<option value="14px">14px</option>
+								<option value="16px" selected>16px</option>
+								<option value="18px">18px</option>
+								<option value="20px">20px</option>
+								<option value="24px">24px</option>
+								<option value="28px">28px</option>
+								<option value="32px">32px</option>
+								<option value="36px">36px</option>
+								<option value="42px">42px</option>
+								<option value="48px">48px</option>
+							</select>
+							<!-- END SDA CUSTOM -->
+						</span>
+						<span class="ql-formats">
+							<button class="ql-bold"></button>
+							<button class="ql-italic"></button>
+							<button class="ql-underline"></button>
+							<button class="ql-strike"></button>
+						</span>
+						<span class="ql-formats">
+							<select class="ql-color"></select>
+							<select class="ql-background"></select>
+						</span>
+						<span class="ql-formats">
+							<button class="ql-script" value="sub"></button>
+							<button class="ql-script" value="super"></button>
+						</span>
+						<span class="ql-formats">
+							<button class="ql-header" value="1"></button>
+							<button class="ql-header" value="2"></button>
+							<button class="ql-blockquote"></button>
+							<!-- <button class="ql-code-block"></button> -->
+						</span>
+						<span class="ql-formats">
+							<button class="ql-list" value="ordered"></button>
+							<button class="ql-list" value="bullet"></button>
+							<!-- <button class="ql-indent" value="-1"></button>
+							<button class="ql-indent" value="+1"></button> -->
+						</span>
+						<span class="ql-formats">
+							<button type="button" class="ql-align" value="" inputId="i1">
+								<svg viewBox="0 0 18 18">
+									<line class="ql-stroke" x1="3" x2="15" y1="9" y2="9"></line>
+									<line class="ql-stroke" x1="3" x2="13" y1="14" y2="14"></line>
+									<line class="ql-stroke" x1="3" x2="9" y1="4" y2="4"></line>
+								</svg>
+							</button>
+							<button type="button" class="ql-align" value="center" inputId="i2">
+								<svg viewBox="0 0 18 18">
+									<line class="ql-stroke" x1="15" x2="3" y1="9" y2="9"></line>
+									<line class="ql-stroke" x1="14" x2="4" y1="14" y2="14"></line>
+									<line class="ql-stroke" x1="12" x2="6" y1="4" y2="4"></line>
+								</svg>
+							</button>
+							<button type="button" class="ql-align" value="right" inputId="i3">
+								<svg viewBox="0 0 18 18">
+									<line class="ql-stroke" x1="15" x2="3" y1="9" y2="9"></line>
+									<line class="ql-stroke" x1="15" x2="5" y1="14" y2="14"></line>
+									<line class="ql-stroke" x1="15" x2="9" y1="4" y2="4"></line>
+								</svg>
+							</button>
+						</span>
+						<span class="ql-formats">
+							<button class="ql-link"></button>
+							<button class="ql-image"></button>
+							<button class="ql-video"></button>
+							<button id="qlUrlImage">Url</button>
+							<!-- < class="ql-video"></> -->
+							<!-- <button class="ql-formula"></button> -->
+						</span>
+						<span class="ql-formats">
+							<button class="ql-clean"></button>
+						</span>
+					</p-header>
+				</p-editor>
+			</div>
+		</div>
 
-			<p-editor #Editor [(ngModel)]="title" [style]="{'height':'100%'}">
-				<p-header>
-					<span class="ql-formats">
-						<!-- <select class="ql-font"></select> -->
-						<select class="ql-size"></select>
-					</span>
-					<span class="ql-formats">
-						<button class="ql-bold"></button>
-						<button class="ql-italic"></button>
-						<button class="ql-underline"></button>
-						<button class="ql-strike"></button>
-					</span>
-					<span class="ql-formats">
-						<select class="ql-color"></select>
-						<select class="ql-background"></select>
-					</span>
-					<span class="ql-formats">
-						<button class="ql-script" value="sub"></button>
-						<button class="ql-script" value="super"></button>
-					</span>
-					<span class="ql-formats">
-						<button class="ql-header" value="1"></button>
-						<button class="ql-header" value="2"></button>
-						<button class="ql-blockquote"></button>
-						<!-- <button class="ql-code-block"></button> -->
-					</span>
-					<span class="ql-formats">
-						<button class="ql-list" value="ordered"></button>
-						<button class="ql-list" value="bullet"></button>
-						<!-- <button class="ql-indent" value="-1"></button>
-        <button class="ql-indent" value="+1"></button> -->
-					</span>
-					<span class="ql-formats">
-						<button type="button" class="ql-align" value="" inputId="i1">
-							<svg viewBox="0 0 18 18">
-								<line class="ql-stroke" x1="3" x2="15" y1="9" y2="9"></line>
-								<line class="ql-stroke" x1="3" x2="13" y1="14" y2="14"></line>
-								<line class="ql-stroke" x1="3" x2="9" y1="4" y2="4"></line>
-							</svg>
-						</button>
-						<button type="button" class="ql-align" value="center" inputId="i2">
-							<svg viewBox="0 0 18 18">
-								<line class="ql-stroke" x1="15" x2="3" y1="9" y2="9"></line>
-								<line class="ql-stroke" x1="14" x2="4" y1="14" y2="14"></line>
-								<line class="ql-stroke" x1="12" x2="6" y1="4" y2="4"></line>
-							</svg>
-						</button>
-						<button type="button" class="ql-align" value="right" inputId="i3">
-							<svg viewBox="0 0 18 18">
-								<line class="ql-stroke" x1="15" x2="3" y1="9" y2="9"></line>
-								<line class="ql-stroke" x1="15" x2="5" y1="14" y2="14"></line>
-								<line class="ql-stroke" x1="15" x2="9" y1="4" y2="4"></line>
-							</svg>
-						</button>
+		<!-- Side column: Configuration options - kpi-options-shell style -->
+		<div class="col-4">
+			<div class="title-options-shell">
+				<div class="title-options-shell__header">
+					<h5 class="title-options-title">Panel Options</h5>
+				</div>
+				<div class="title-config-panel">
+					<!-- Section: Appearance -->
+					<div class="title-config-section" [class.is-expanded]="isAppearanceExpanded">
+						<div class="title-section-head" role="button" tabindex="0"
+							(click)="toggleSection('appearance')"
+							(keydown.enter)="toggleSection('appearance')"
+							(keydown.space)="toggleSection('appearance')">
+							<h6>Appearance</h6>
+							<div class="title-section-actions">
+								<i class="pi" [ngClass]="isAppearanceExpanded ? 'pi-chevron-up' : 'pi-chevron-down'"></i>
+							</div>
+						</div>
+						<div class="title-section-content" *ngIf="isAppearanceExpanded">
+							<!-- Option: Transparent background - switch style like KPIs -->
+							<div class="config-row chart-color-row chart-color-row--spaced">
+								<span class="chart-color-label">Remove panel background</span>
+								<span class="chart-color-controls">
+									<p-inputSwitch [(ngModel)]="backgroundTransparent" inputId="bgTransparent"></p-inputSwitch>
+								</span>
+							</div>
 
-					</span>
-					<span class="ql-formats">
-						<button class="ql-link"></button>
-						<button class="ql-image"></button>
-						<button class="ql-video"></button>
-						<button id="qlUrlImage">Url</button>
-						<!-- < class="ql-video"></> -->
-						<!-- <button class="ql-formula"></button> -->
-					</span>
-					<span class="ql-formats">
-						<button class="ql-clean"></button>
-					</span>
-				</p-header>
-			</p-editor>
+							<!-- SDA CUSTOM - Text color -->
+							<div class="config-row chart-color-row chart-color-row--spaced">
+								<span class="chart-color-label">Text color</span>
+								<span class="chart-color-controls">
+									<input type="text" [(ngModel)]="textColor" pInputText class="chart-color-input" />
+									<span class="chart-color-picker">
+										<p-colorPicker [(ngModel)]="textColor" appendTo="body" format="hex"></p-colorPicker>
+									</span>
+								</span>
+							</div>
+
+							<!-- SDA CUSTOM - Show panel border -->
+							<div class="config-row chart-color-row chart-color-row--spaced">
+								<span class="chart-color-label">Show border</span>
+								<span class="chart-color-controls">
+									<p-inputSwitch [(ngModel)]="showBorder" inputId="showBorder"></p-inputSwitch>
+								</span>
+							</div>
+
+							<!-- SDA CUSTOM - Border color (only if showBorder is true) -->
+							<div class="config-row chart-color-row chart-color-row--spaced" *ngIf="showBorder">
+								<span class="chart-color-label">Border color</span>
+								<span class="chart-color-controls">
+									<input type="text" [(ngModel)]="borderColor" pInputText class="chart-color-input" />
+									<span class="chart-color-picker">
+										<p-colorPicker [(ngModel)]="borderColor" appendTo="body" format="hex"></p-colorPicker>
+									</span>
+								</span>
+							</div>
+						</div>
+					</div>
+
+					<!-- Section: Alignment -->
+					<div class="title-config-section" [class.is-expanded]="isAlignmentExpanded">
+						<div class="title-section-head" role="button" tabindex="0"
+							(click)="toggleSection('alignment')"
+							(keydown.enter)="toggleSection('alignment')"
+							(keydown.space)="toggleSection('alignment')">
+							<h6>Vertical alignment</h6>
+							<div class="title-section-actions">
+								<i class="pi" [ngClass]="isAlignmentExpanded ? 'pi-chevron-up' : 'pi-chevron-down'"></i>
+							</div>
+						</div>
+						<div class="title-section-content" *ngIf="isAlignmentExpanded">
+							<div class="config-row">
+								<p-radioButton name="verticalAlign" value="top" [(ngModel)]="verticalAlign" inputId="alignTop"></p-radioButton>
+								<label for="alignTop">Top</label>
+							</div>
+							<div class="config-row">
+								<p-radioButton name="verticalAlign" value="center" [(ngModel)]="verticalAlign" inputId="alignCenter"></p-radioButton>
+								<label for="alignCenter">Center</label>
+							</div>
+							<div class="config-row">
+								<p-radioButton name="verticalAlign" value="bottom" [(ngModel)]="verticalAlign" inputId="alignBottom"></p-radioButton>
+								<label for="alignBottom">Bottom</label>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
 		</div>
 	</div>
+	<!-- END SDA CUSTOM -->
 
 	<div footer>
 		<div class="ui-dialog-buttonpanel ui-widget-content ui-helper-clearfix text-right">
 			<button type="submit" pButton (click)="saveChartConfig()" icon="fa fa-check"
-				class="p-button-raised p-button-success" i18n-label="@@guardarButton" label="Confirmar"
+				class="p-button-raised p-button-success" i18n-label="@@guardarButton" label="Confirm"
 				id="eda_chart_dialog_confirmar">
 			</button>
 			<button type="button" pButton (click)="closeChartConfig()" icon="fa fa-times"
-				class="p-button-raised p-button-danger" i18n-label="@@cancelarButton" label="Cancelar">
+				class="p-button-raised p-button-danger" i18n-label="@@cancelarButton" label="Cancel">
 			</button>
 		</div>
 	</div>

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.html
@@ -1,5 +1,9 @@
 <eda-dialog [inject]="dialog">
 	<div body class="grid">
+<!-- SDA CUSTOM -->		<div class="col-12 mb-2">
+<!-- SDA CUSTOM -->			<p-checkbox [(ngModel)]="backgroundTransparent" [binary]="true" inputId="bgTransparent"></p-checkbox>
+<!-- SDA CUSTOM -->			<label for="bgTransparent" class="ml-2">Quitar fondo del panel</label>
+<!-- SDA CUSTOM -->		</div>
 		<div class="col-12">
 
 			<p-editor #Editor [(ngModel)]="title" [style]="{'height':'100%'}">

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.html
@@ -190,12 +190,14 @@
 <!-- SDA CUSTOM -->		<div *ngIf="showTextColorPicker" class="ql-overlay-picker">
 <!-- SDA CUSTOM -->			<p-colorPicker [(ngModel)]="customTextColor" (ngModelChange)="onTextColorLive($event)" inline="true" format="hex"></p-colorPicker>
 <!-- SDA CUSTOM -->			<input type="text" [(ngModel)]="customTextColor" (keydown.enter)="onTextColorLive(customTextColor)" class="ql-hex-input-popup" placeholder="#000000" maxlength="7" />
+<!-- SDA CUSTOM -->			<button type="button" pButton (click)="removeTextFormat('color'); textColorOL.hide()" label="Clear" class="p-button-sm p-button-outlined p-button-secondary" style="width:100%; margin-top:4px;"></button>
 <!-- SDA CUSTOM -->		</div>
 <!-- SDA CUSTOM -->	</p-overlayPanel>
 <!-- SDA CUSTOM -->	<p-overlayPanel #textBgColorOL (onShow)="onOverlayShow('textBgColor')" (onHide)="showTextBgColorPicker = false">
 <!-- SDA CUSTOM -->		<div *ngIf="showTextBgColorPicker" class="ql-overlay-picker">
 <!-- SDA CUSTOM -->			<p-colorPicker [(ngModel)]="customTextBgColor" (ngModelChange)="onTextBgColorLive($event)" inline="true" format="hex"></p-colorPicker>
 <!-- SDA CUSTOM -->			<input type="text" [(ngModel)]="customTextBgColor" (keydown.enter)="onTextBgColorLive(customTextBgColor)" class="ql-hex-input-popup" placeholder="#ffffff" maxlength="7" />
+<!-- SDA CUSTOM -->			<button type="button" pButton (click)="removeTextFormat('background'); textBgColorOL.hide()" label="Clear" class="p-button-sm p-button-outlined p-button-secondary" style="width:100%; margin-top:4px;"></button>
 <!-- SDA CUSTOM -->		</div>
 <!-- SDA CUSTOM -->	</p-overlayPanel>
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.html
@@ -115,14 +115,14 @@
 						<div class="title-section-content" *ngIf="isAppearanceExpanded">
 							<!-- SDA CUSTOM - Transparent background toggle with i18n -->
 <!-- SDA CUSTOM -->							<div class="config-row chart-color-row chart-color-row--spaced">
-<!-- SDA CUSTOM -->								<span class="chart-color-label" i18n="@@titlePanelRemoveBg">Remove panel background</span>
+<!-- SDA CUSTOM -->								<span class="chart-color-label" i18n="@@titlePanelShowBg">Show panel background</span>
 								<span class="chart-color-controls">
-									<p-inputSwitch [(ngModel)]="backgroundTransparent" inputId="bgTransparent"></p-inputSwitch>
+									<p-inputSwitch [(ngModel)]="showPanelBackground" inputId="showPanelBackground"></p-inputSwitch>
 								</span>
 							</div>
 
-							<!-- SDA CUSTOM - Panel background color (only if not transparent) -->
-<!-- SDA CUSTOM -->							<div class="config-row chart-color-row chart-color-row--spaced" *ngIf="!backgroundTransparent">
+							<!-- SDA CUSTOM - Panel background color (only if showPanelBackground is true) -->
+<!-- SDA CUSTOM -->							<div class="config-row chart-color-row chart-color-row--spaced" *ngIf="showPanelBackground">
 <!-- SDA CUSTOM -->								<span class="chart-color-label" i18n="@@titlePanelBgColor">Background color</span>
 								<span class="chart-color-controls">
 									<input type="text" [(ngModel)]="backgroundColor" pInputText class="chart-color-input" />

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.html
@@ -32,8 +32,12 @@
 							<button class="ql-strike"></button>
 						</span>
 						<span class="ql-formats">
-							<select class="ql-color"></select>
-							<select class="ql-background"></select>
+<!-- SDA CUSTOM -->							<button type="button" class="ql-custom-color-btn" (click)="openColorOverlay($event, textColorOL)">
+<!-- SDA CUSTOM -->								<svg viewBox="0 0 18 18"><line class="ql-color-label ql-stroke ql-transparent" x1="3" x2="15" y1="15" y2="15"></line><polyline class="ql-stroke" points="5.5 11 9 3 12.5 11"></polyline><line class="ql-stroke" x1="11.63" x2="6.38" y1="9" y2="9"></line></svg>
+<!-- SDA CUSTOM -->							</button>
+<!-- SDA CUSTOM -->							<button type="button" class="ql-custom-color-btn" (click)="openColorOverlay($event, textBgColorOL)">
+<!-- SDA CUSTOM -->								<svg viewBox="0 0 18 18"><g class="ql-fill ql-color-label"><polygon points="6 6.868 6 6 5 6 5 7 5.942 7 6 6.868"></polygon><rect height="1" width="1" x="4" y="4"></rect><polygon points="6.817 5 6 5 6 6 6.38 6 6.817 5"></polygon></g><polyline class="ql-stroke" points="5.5 13 9 5 12.5 13"></polyline><line class="ql-stroke" x1="11.63" x2="6.38" y1="11" y2="11"></line></svg>
+<!-- SDA CUSTOM -->							</button>
 						</span>
 						<span class="ql-formats">
 							<button class="ql-script" value="sub"></button>
@@ -94,7 +98,7 @@
 		<div class="col-4">
 			<div class="title-options-shell">
 				<div class="title-options-shell__header">
-					<h5 class="title-options-title">Panel Options</h5>
+<!-- SDA CUSTOM -->					<h5 class="title-options-title" i18n="@@titlePanelOptions">Panel Options</h5>
 				</div>
 				<div class="title-config-panel">
 					<!-- Section: Appearance -->
@@ -103,42 +107,42 @@
 							(click)="toggleSection('appearance')"
 							(keydown.enter)="toggleSection('appearance')"
 							(keydown.space)="toggleSection('appearance')">
-							<h6>Appearance</h6>
+<!-- SDA CUSTOM -->							<h6 i18n="@@titlePanelAppearance">Appearance</h6>
 							<div class="title-section-actions">
 								<i class="pi" [ngClass]="isAppearanceExpanded ? 'pi-chevron-up' : 'pi-chevron-down'"></i>
 							</div>
 						</div>
 						<div class="title-section-content" *ngIf="isAppearanceExpanded">
-							<!-- Option: Transparent background - switch style like KPIs -->
-							<div class="config-row chart-color-row chart-color-row--spaced">
-								<span class="chart-color-label">Remove panel background</span>
+							<!-- SDA CUSTOM - Transparent background toggle with i18n -->
+<!-- SDA CUSTOM -->							<div class="config-row chart-color-row chart-color-row--spaced">
+<!-- SDA CUSTOM -->								<span class="chart-color-label" i18n="@@titlePanelRemoveBg">Remove panel background</span>
 								<span class="chart-color-controls">
 									<p-inputSwitch [(ngModel)]="backgroundTransparent" inputId="bgTransparent"></p-inputSwitch>
 								</span>
 							</div>
 
-							<!-- SDA CUSTOM - Text color -->
-							<div class="config-row chart-color-row chart-color-row--spaced">
-								<span class="chart-color-label">Text color</span>
+							<!-- SDA CUSTOM - Panel background color (only if not transparent) -->
+<!-- SDA CUSTOM -->							<div class="config-row chart-color-row chart-color-row--spaced" *ngIf="!backgroundTransparent">
+<!-- SDA CUSTOM -->								<span class="chart-color-label" i18n="@@titlePanelBgColor">Background color</span>
 								<span class="chart-color-controls">
-									<input type="text" [(ngModel)]="textColor" pInputText class="chart-color-input" />
+									<input type="text" [(ngModel)]="backgroundColor" pInputText class="chart-color-input" />
 									<span class="chart-color-picker">
-										<p-colorPicker [(ngModel)]="textColor" appendTo="body" format="hex"></p-colorPicker>
+										<p-colorPicker [(ngModel)]="backgroundColor" appendTo="body" format="hex"></p-colorPicker>
 									</span>
 								</span>
 							</div>
 
 							<!-- SDA CUSTOM - Show panel border -->
-							<div class="config-row chart-color-row chart-color-row--spaced">
-								<span class="chart-color-label">Show border</span>
+<!-- SDA CUSTOM -->							<div class="config-row chart-color-row chart-color-row--spaced">
+<!-- SDA CUSTOM -->								<span class="chart-color-label" i18n="@@titlePanelShowBorder">Show border</span>
 								<span class="chart-color-controls">
 									<p-inputSwitch [(ngModel)]="showBorder" inputId="showBorder"></p-inputSwitch>
 								</span>
 							</div>
 
 							<!-- SDA CUSTOM - Border color (only if showBorder is true) -->
-							<div class="config-row chart-color-row chart-color-row--spaced" *ngIf="showBorder">
-								<span class="chart-color-label">Border color</span>
+<!-- SDA CUSTOM -->							<div class="config-row chart-color-row chart-color-row--spaced" *ngIf="showBorder">
+<!-- SDA CUSTOM -->								<span class="chart-color-label" i18n="@@titlePanelBorderColor">Border color</span>
 								<span class="chart-color-controls">
 									<input type="text" [(ngModel)]="borderColor" pInputText class="chart-color-input" />
 									<span class="chart-color-picker">
@@ -155,7 +159,7 @@
 							(click)="toggleSection('alignment')"
 							(keydown.enter)="toggleSection('alignment')"
 							(keydown.space)="toggleSection('alignment')">
-							<h6>Vertical alignment</h6>
+<!-- SDA CUSTOM -->							<h6 i18n="@@titlePanelVerticalAlign">Vertical alignment</h6>
 							<div class="title-section-actions">
 								<i class="pi" [ngClass]="isAlignmentExpanded ? 'pi-chevron-up' : 'pi-chevron-down'"></i>
 							</div>
@@ -163,15 +167,15 @@
 						<div class="title-section-content" *ngIf="isAlignmentExpanded">
 							<div class="config-row">
 								<p-radioButton name="verticalAlign" value="top" [(ngModel)]="verticalAlign" inputId="alignTop"></p-radioButton>
-								<label for="alignTop">Top</label>
+<!-- SDA CUSTOM -->								<label for="alignTop" i18n="@@titlePanelAlignTop">Top</label>
 							</div>
 							<div class="config-row">
 								<p-radioButton name="verticalAlign" value="center" [(ngModel)]="verticalAlign" inputId="alignCenter"></p-radioButton>
-								<label for="alignCenter">Center</label>
+<!-- SDA CUSTOM -->								<label for="alignCenter" i18n="@@titlePanelAlignCenter">Center</label>
 							</div>
 							<div class="config-row">
 								<p-radioButton name="verticalAlign" value="bottom" [(ngModel)]="verticalAlign" inputId="alignBottom"></p-radioButton>
-								<label for="alignBottom">Bottom</label>
+<!-- SDA CUSTOM -->								<label for="alignBottom" i18n="@@titlePanelAlignBottom">Bottom</label>
 							</div>
 						</div>
 					</div>
@@ -180,6 +184,20 @@
 		</div>
 	</div>
 	<!-- END SDA CUSTOM -->
+
+	<!-- SDA CUSTOM - Overlay with inline picker + hex input, recreated on each open -->
+<!-- SDA CUSTOM -->	<p-overlayPanel #textColorOL (onShow)="onOverlayShow('textColor')" (onHide)="showTextColorPicker = false">
+<!-- SDA CUSTOM -->		<div *ngIf="showTextColorPicker" class="ql-overlay-picker">
+<!-- SDA CUSTOM -->			<p-colorPicker [(ngModel)]="customTextColor" (ngModelChange)="onTextColorLive($event)" inline="true" format="hex"></p-colorPicker>
+<!-- SDA CUSTOM -->			<input type="text" [(ngModel)]="customTextColor" (keydown.enter)="onTextColorLive(customTextColor)" class="ql-hex-input-popup" placeholder="#000000" maxlength="7" />
+<!-- SDA CUSTOM -->		</div>
+<!-- SDA CUSTOM -->	</p-overlayPanel>
+<!-- SDA CUSTOM -->	<p-overlayPanel #textBgColorOL (onShow)="onOverlayShow('textBgColor')" (onHide)="showTextBgColorPicker = false">
+<!-- SDA CUSTOM -->		<div *ngIf="showTextBgColorPicker" class="ql-overlay-picker">
+<!-- SDA CUSTOM -->			<p-colorPicker [(ngModel)]="customTextBgColor" (ngModelChange)="onTextBgColorLive($event)" inline="true" format="hex"></p-colorPicker>
+<!-- SDA CUSTOM -->			<input type="text" [(ngModel)]="customTextBgColor" (keydown.enter)="onTextBgColorLive(customTextBgColor)" class="ql-hex-input-popup" placeholder="#ffffff" maxlength="7" />
+<!-- SDA CUSTOM -->		</div>
+<!-- SDA CUSTOM -->	</p-overlayPanel>
 
 	<div footer>
 		<div class="ui-dialog-buttonpanel ui-widget-content ui-helper-clearfix text-right">

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.html
@@ -98,7 +98,7 @@
 		<div class="col-4">
 			<div class="title-options-shell">
 				<div class="title-options-shell__header">
-<!-- SDA CUSTOM -->					<h5 class="title-options-title" i18n="@@titlePanelOptions">Panel Options</h5>
+<!-- SDA CUSTOM -->					<h5 class="title-options-title" i18n="@@titlePanelOptions">Opciones del panel</h5>
 				</div>
 				<div class="title-config-panel">
 					<!-- Section: Appearance -->
@@ -107,7 +107,7 @@
 							(click)="toggleSection('appearance')"
 							(keydown.enter)="toggleSection('appearance')"
 							(keydown.space)="toggleSection('appearance')">
-<!-- SDA CUSTOM -->							<h6 i18n="@@titlePanelAppearance">Appearance</h6>
+<!-- SDA CUSTOM -->							<h6 i18n="@@titlePanelAppearance">Apariencia</h6>
 							<div class="title-section-actions">
 								<i class="pi" [ngClass]="isAppearanceExpanded ? 'pi-chevron-up' : 'pi-chevron-down'"></i>
 							</div>
@@ -115,7 +115,7 @@
 						<div class="title-section-content" *ngIf="isAppearanceExpanded">
 							<!-- SDA CUSTOM - Transparent background toggle with i18n -->
 <!-- SDA CUSTOM -->							<div class="config-row chart-color-row chart-color-row--spaced">
-<!-- SDA CUSTOM -->								<span class="chart-color-label" i18n="@@titlePanelShowBg">Show panel background</span>
+<!-- SDA CUSTOM -->								<span class="chart-color-label" i18n="@@titlePanelShowBg">Mostrar fondo del panel</span>
 								<span class="chart-color-controls">
 									<p-inputSwitch [(ngModel)]="showPanelBackground" inputId="showPanelBackground"></p-inputSwitch>
 								</span>
@@ -123,7 +123,7 @@
 
 							<!-- SDA CUSTOM - Panel background color (only if showPanelBackground is true) -->
 <!-- SDA CUSTOM -->							<div class="config-row chart-color-row chart-color-row--spaced" *ngIf="showPanelBackground">
-<!-- SDA CUSTOM -->								<span class="chart-color-label" i18n="@@titlePanelBgColor">Background color</span>
+<!-- SDA CUSTOM -->								<span class="chart-color-label" i18n="@@titlePanelBgColor">Color de fondo</span>
 								<span class="chart-color-controls">
 									<input type="text" [(ngModel)]="backgroundColor" pInputText class="chart-color-input" />
 									<span class="chart-color-picker">
@@ -134,7 +134,7 @@
 
 							<!-- SDA CUSTOM - Show panel border -->
 <!-- SDA CUSTOM -->							<div class="config-row chart-color-row chart-color-row--spaced">
-<!-- SDA CUSTOM -->								<span class="chart-color-label" i18n="@@titlePanelShowBorder">Show border</span>
+<!-- SDA CUSTOM -->								<span class="chart-color-label" i18n="@@titlePanelShowBorder">Mostrar borde</span>
 								<span class="chart-color-controls">
 									<p-inputSwitch [(ngModel)]="showBorder" inputId="showBorder"></p-inputSwitch>
 								</span>
@@ -142,7 +142,7 @@
 
 							<!-- SDA CUSTOM - Border color (only if showBorder is true) -->
 <!-- SDA CUSTOM -->							<div class="config-row chart-color-row chart-color-row--spaced" *ngIf="showBorder">
-<!-- SDA CUSTOM -->								<span class="chart-color-label" i18n="@@titlePanelBorderColor">Border color</span>
+<!-- SDA CUSTOM -->								<span class="chart-color-label" i18n="@@titlePanelBorderColor">Color del borde</span>
 								<span class="chart-color-controls">
 									<input type="text" [(ngModel)]="borderColor" pInputText class="chart-color-input" />
 									<span class="chart-color-picker">
@@ -159,7 +159,7 @@
 							(click)="toggleSection('alignment')"
 							(keydown.enter)="toggleSection('alignment')"
 							(keydown.space)="toggleSection('alignment')">
-<!-- SDA CUSTOM -->							<h6 i18n="@@titlePanelVerticalAlign">Vertical alignment</h6>
+<!-- SDA CUSTOM -->							<h6 i18n="@@titlePanelVerticalAlign">Alineación vertical</h6>
 							<div class="title-section-actions">
 								<i class="pi" [ngClass]="isAlignmentExpanded ? 'pi-chevron-up' : 'pi-chevron-down'"></i>
 							</div>
@@ -167,15 +167,15 @@
 						<div class="title-section-content" *ngIf="isAlignmentExpanded">
 							<div class="config-row">
 								<p-radioButton name="verticalAlign" value="top" [(ngModel)]="verticalAlign" inputId="alignTop"></p-radioButton>
-<!-- SDA CUSTOM -->								<label for="alignTop" i18n="@@titlePanelAlignTop">Top</label>
+<!-- SDA CUSTOM -->								<label for="alignTop" i18n="@@titlePanelAlignTop">Arriba</label>
 							</div>
 							<div class="config-row">
 								<p-radioButton name="verticalAlign" value="center" [(ngModel)]="verticalAlign" inputId="alignCenter"></p-radioButton>
-<!-- SDA CUSTOM -->								<label for="alignCenter" i18n="@@titlePanelAlignCenter">Center</label>
+<!-- SDA CUSTOM -->								<label for="alignCenter" i18n="@@titlePanelAlignCenter">Centro</label>
 							</div>
 							<div class="config-row">
 								<p-radioButton name="verticalAlign" value="bottom" [(ngModel)]="verticalAlign" inputId="alignBottom"></p-radioButton>
-<!-- SDA CUSTOM -->								<label for="alignBottom" i18n="@@titlePanelAlignBottom">Bottom</label>
+<!-- SDA CUSTOM -->								<label for="alignBottom" i18n="@@titlePanelAlignBottom">Abajo</label>
 							</div>
 						</div>
 					</div>

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.ts
@@ -12,6 +12,7 @@ export class TitleDialogComponent extends EdaDialogAbstract {
 	@ViewChild('Editor') editor: Editor;
 	public dialog: EdaDialog;
 	public title: string;
+/* SDA CUSTOM */	public backgroundTransparent: boolean = false;
 	constructor(private sanitizer: DomSanitizer) {
 		super();
 		this.dialog = new EdaDialog({
@@ -24,6 +25,7 @@ export class TitleDialogComponent extends EdaDialogAbstract {
 
 	public onShow(): void {
 		this.title = this.controller.params.title;
+/* SDA CUSTOM */		this.backgroundTransparent = this.controller.params.backgroundTransparent || false;
 		const urlImage = document.querySelector('#qlUrlImage');
 		urlImage.addEventListener('click', ($event) => this.urlImageHandler(event));
 	}
@@ -33,7 +35,7 @@ export class TitleDialogComponent extends EdaDialogAbstract {
 	}
 
 	public saveChartConfig(): void {
-		this.onClose(EdaDialogCloseEvent.UPDATE, { title: this.title });
+		/* SDA CUSTOM */this.onClose(EdaDialogCloseEvent.UPDATE, { title: this.title, backgroundTransparent: this.backgroundTransparent });
 	}
 
 	public urlImageHandler(event?: any): void {

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.ts
@@ -3,9 +3,238 @@ import { EdaDialog, EdaDialogAbstract, EdaDialogCloseEvent } from '@eda/shared/c
 import { Editor } from 'primeng/editor';
 import { DomSanitizer } from '@angular/platform-browser';
 import * as _ from 'lodash';
+import Quill from 'quill';
+import { VerticalAlign } from '@eda/models/dashboard-models/eda-title-panel';
+
+// SDA CUSTOM - Custom font sizes in px for Quill editor
+const Size = Quill.import('attributors/style/size');
+Size.whitelist = ['10px', '12px', '14px', '16px', '18px', '20px', '24px', '28px', '32px', '36px', '42px', '48px'];
+Quill.register(Size, true);
+// END SDA CUSTOM
+
 @Component({
 	selector: 'app-title-dialog',
 	templateUrl: './quill-editor.component.html',
+	// SDA CUSTOM - Styles identical to kpi-options-shell
+	styles: [`
+		/* Main shell - copied from kpi-options-shell */
+		.title-options-shell {
+			border: 1px solid #d7dde6;
+			border-radius: 10px;
+			background: #f7f9fc;
+			padding: 10px 10px 8px 10px;
+			height: auto;
+			align-self: flex-start;
+		}
+
+		.title-options-shell__header {
+			border-bottom: 1px solid #e3e8ef;
+			margin-bottom: 8px;
+			padding-bottom: 6px;
+		}
+
+		.title-options-title {
+			margin: 0;
+			font-size: 14px;
+			line-height: 1.2;
+			font-weight: 600;
+			color: #495057;
+		}
+
+		/* Config panel - copied from kpi-config-panel */
+		.title-config-panel {
+			max-height: 34vh;
+			overflow-y: auto;
+			padding-right: 4px;
+			display: flex;
+			flex-direction: column;
+			gap: 4px;
+			font-size: 12px;
+		}
+
+		/* Sections - copied from kpi-config-section */
+		.title-config-section {
+			padding: 6px 8px 8px 8px;
+			border: 1px solid #d9e0ea;
+			border-radius: 8px;
+			background: #ffffff;
+			overflow: visible;
+		}
+
+		/* Section header - copied from kpi-section-head */
+		.title-section-head {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: 8px;
+			margin-bottom: 4px;
+			padding: 6px 8px;
+			border: 1px solid #dfe6f1;
+			border-radius: 6px;
+			background: #f4f7fb;
+			cursor: pointer;
+			transition: background-color 0.15s ease, border-color 0.15s ease;
+		}
+
+		.title-section-head:hover {
+			background: #eef3fb;
+			border-color: #cfd9e8;
+		}
+
+		.title-config-section.is-expanded .title-section-head {
+			background: #eef3fb;
+			border-color: #c7d4e8;
+		}
+
+		/* Section actions - copied from kpi-section-actions */
+		.title-section-actions {
+			display: inline-flex;
+			align-items: center;
+			gap: 4px;
+		}
+
+		.title-section-actions .pi {
+			font-size: 13px;
+			color: #43546a;
+		}
+
+		/* Section title - copied from custom-border-b1 in kpi */
+		.title-section-head h6 {
+			margin: 0;
+			border-bottom: none;
+			font-size: 12px;
+			line-height: 1.1;
+			font-weight: bold;
+			color: #495057;
+			flex: 1;
+		}
+
+		/* Section content */
+		.title-section-content {
+			padding-top: 4px;
+		}
+
+		/* Config rows - same style as kpi */
+		.config-row {
+			display: flex;
+			align-items: center;
+			padding: 2px 0;
+		}
+
+		.config-row label {
+			font-size: 12px;
+			color: #495057;
+			cursor: pointer;
+			margin-left: 6px;
+		}
+
+		/* Compact radio buttons */
+		.config-row .p-radiobutton {
+			width: 16px;
+			height: 16px;
+		}
+
+		.config-row .p-radiobutton .p-radiobutton-box {
+			width: 16px;
+			height: 16px;
+		}
+
+		.config-row .p-radiobutton .p-radiobutton-box .p-radiobutton-icon {
+			width: 8px;
+			height: 8px;
+		}
+
+		/* Compact checkbox */
+		.config-row .p-checkbox {
+			width: 16px;
+			height: 16px;
+		}
+
+		.config-row .p-checkbox .p-checkbox-box {
+			width: 16px;
+			height: 16px;
+			border-radius: 3px;
+		}
+
+		/* Editor styles */
+		:host ::ng-deep .p-editor-container {
+			height: 100%;
+			border: 1px solid #d7dde6;
+			border-radius: 10px;
+		}
+
+		:host ::ng-deep .p-editor-content {
+			border-bottom-left-radius: 10px;
+			border-bottom-right-radius: 10px;
+		}
+
+		/* SDA CUSTOM - Options rows styles (copied from kpi-dialog) */
+		.chart-color-row {
+			display: grid;
+			grid-template-columns: minmax(0, 1fr) minmax(110px, 160px);
+			align-items: center;
+			gap: 4px;
+			min-height: 24px;
+		}
+
+		@container (max-width: 320px) {
+			.chart-color-row {
+				grid-template-columns: 1fr;
+			}
+		}
+
+		.chart-color-row--spaced {
+			margin-top: 2px;
+		}
+
+		.chart-color-label {
+			white-space: normal;
+			min-width: 0;
+			overflow-wrap: break-word;
+			word-break: break-word;
+			line-height: 1.2;
+			font-size: 12px;
+			color: #495057;
+		}
+
+		.chart-color-controls {
+			display: flex;
+			align-items: center;
+			gap: 4px;
+			justify-content: flex-end;
+			width: 100%;
+		}
+
+		/* Switch styles - same as kpi-config-panel */
+		:host ::ng-deep .title-config-panel .p-inputswitch {
+			height: 18px;
+			width: 34px;
+		}
+
+		:host ::ng-deep .title-config-panel .p-inputswitch .p-inputswitch-slider::before {
+			width: 14px;
+			height: 14px;
+			margin-top: -7px;
+			margin-left: -7px;
+		}
+
+		/* SDA CUSTOM - Color picker styles (copied from kpi-dialog) */
+		:host ::ng-deep .chart-color-picker .p-colorpicker-preview {
+			width: 26px;
+			height: 26px;
+			border-radius: 4px;
+			border: 1px solid #d9e0ea;
+		}
+
+		:host ::ng-deep .chart-color-input {
+			width: 90px;
+			padding: 4px 8px;
+			font-size: 12px;
+			border: 1px solid #d9e0ea;
+			border-radius: 4px;
+		}
+	`]
+	// END SDA CUSTOM
 })
 
 export class TitleDialogComponent extends EdaDialogAbstract {
@@ -13,12 +242,20 @@ export class TitleDialogComponent extends EdaDialogAbstract {
 	public dialog: EdaDialog;
 	public title: string;
 /* SDA CUSTOM */	public backgroundTransparent: boolean = false;
+/* SDA CUSTOM */	public baseWidth: number; // Base width of the panel for proportional scaling
+/* SDA CUSTOM */	public verticalAlign: VerticalAlign = 'center'; // Vertical alignment of the title
+/* SDA CUSTOM */	public isAppearanceExpanded: boolean = true; // State of the Appearance section
+/* SDA CUSTOM */	public isAlignmentExpanded: boolean = true; // State of the Alignment section
+/* SDA CUSTOM */	public textColor: string = '#000000'; // Text color of the title
+/* SDA CUSTOM */	public borderColor: string = '#d7dde6'; // Border color of the panel
+/* SDA CUSTOM */	public showBorder: boolean = true; // Show/hide panel border
 	constructor(private sanitizer: DomSanitizer) {
 		super();
 		this.dialog = new EdaDialog({
 			show: () => this.onShow(),
 			hide: () => this.onClose(EdaDialogCloseEvent.NONE),
-			title: $localize`:@@ChartProps:PROPIEDADES DEL GRAFICO`
+			// SDA CUSTOM - Title updated to reflect panel options
+			title: $localize`:@@PanelOptions:PANEL OPTIONS`
 		});
 		this.dialog.style = { width: '80%', height: '70%', top: "-4em", left: '1em' };
 	}
@@ -26,6 +263,11 @@ export class TitleDialogComponent extends EdaDialogAbstract {
 	public onShow(): void {
 		this.title = this.controller.params.title;
 /* SDA CUSTOM */		this.backgroundTransparent = this.controller.params.backgroundTransparent || false;
+/* SDA CUSTOM */		this.baseWidth = this.controller.params.baseWidth;
+/* SDA CUSTOM */		this.verticalAlign = this.controller.params.verticalAlign || 'center';
+/* SDA CUSTOM */		this.textColor = this.controller.params.textColor || '#000000';
+/* SDA CUSTOM */		this.borderColor = this.controller.params.borderColor || '#d7dde6';
+/* SDA CUSTOM */		this.showBorder = this.controller.params.showBorder !== false; // default true
 		const urlImage = document.querySelector('#qlUrlImage');
 		urlImage.addEventListener('click', ($event) => this.urlImageHandler(event));
 	}
@@ -35,7 +277,7 @@ export class TitleDialogComponent extends EdaDialogAbstract {
 	}
 
 	public saveChartConfig(): void {
-		/* SDA CUSTOM */this.onClose(EdaDialogCloseEvent.UPDATE, { title: this.title, backgroundTransparent: this.backgroundTransparent });
+/* SDA CUSTOM */		this.onClose(EdaDialogCloseEvent.UPDATE, { title: this.title, backgroundTransparent: this.backgroundTransparent, baseWidth: this.baseWidth, verticalAlign: this.verticalAlign, textColor: this.textColor, borderColor: this.borderColor, showBorder: this.showBorder });
 	}
 
 	public urlImageHandler(event?: any): void {
@@ -76,5 +318,14 @@ export class TitleDialogComponent extends EdaDialogAbstract {
 	public closeChartConfig(): void {
 		this.onClose(EdaDialogCloseEvent.NONE);
 	}
+
+/* SDA CUSTOM */	// Toggles expansion/collapse of a section
+/* SDA CUSTOM */	toggleSection(section: 'appearance' | 'alignment'): void {
+/* SDA CUSTOM */		if (section === 'appearance') {
+/* SDA CUSTOM */			this.isAppearanceExpanded = !this.isAppearanceExpanded;
+/* SDA CUSTOM */		} else if (section === 'alignment') {
+/* SDA CUSTOM */			this.isAlignmentExpanded = !this.isAlignmentExpanded;
+/* SDA CUSTOM */		}
+/* SDA CUSTOM */	}
 
 }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.ts
@@ -339,7 +339,7 @@ export class TitleDialogComponent extends EdaDialogAbstract {
 			show: () => this.onShow(),
 			hide: () => this.onClose(EdaDialogCloseEvent.NONE),
 			// SDA CUSTOM - Title updated to reflect panel options
-			title: $localize`:@@PanelOptions:PANEL OPTIONS`
+/* SDA CUSTOM */			title: $localize`:@@PanelOptions:PANEL OPTIONS`
 		});
 		this.dialog.style = { width: '80%', height: '70%', top: "-4em", left: '1em' };
 	}
@@ -429,6 +429,15 @@ export class TitleDialogComponent extends EdaDialogAbstract {
 /* SDA CUSTOM */			quill.setSelection(this.savedRange.index, this.savedRange.length, 'silent');
 /* SDA CUSTOM */		} else {
 /* SDA CUSTOM */			quill.format(format, value);
+/* SDA CUSTOM */		}
+/* SDA CUSTOM */		this.title = quill.root.innerHTML;
+/* SDA CUSTOM */	}
+
+/* SDA CUSTOM */	public removeTextFormat(format: string): void {
+/* SDA CUSTOM */		if (!this.editor) return;
+/* SDA CUSTOM */		const quill = this.editor.getQuill();
+/* SDA CUSTOM */		if (this.savedRange && this.savedRange.length > 0) {
+/* SDA CUSTOM */			quill.removeFormat(this.savedRange.index, this.savedRange.length);
 /* SDA CUSTOM */		}
 /* SDA CUSTOM */		this.title = quill.root.innerHTML;
 /* SDA CUSTOM */	}

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.ts
@@ -321,7 +321,7 @@ export class TitleDialogComponent extends EdaDialogAbstract {
 	@ViewChild('Editor') editor: Editor;
 	public dialog: EdaDialog;
 	public title: string;
-/* SDA CUSTOM */	public backgroundTransparent: boolean = false;
+/* SDA CUSTOM */	public showPanelBackground: boolean = true;
 /* SDA CUSTOM */	public baseWidth: number; // Base width of the panel for proportional scaling
 /* SDA CUSTOM */	public verticalAlign: VerticalAlign = 'center'; // Vertical alignment of the title
 /* SDA CUSTOM */	public isAppearanceExpanded: boolean = true; // State of the Appearance section
@@ -346,7 +346,7 @@ export class TitleDialogComponent extends EdaDialogAbstract {
 
 	public onShow(): void {
 		this.title = this.controller.params.title;
-/* SDA CUSTOM */		this.backgroundTransparent = this.controller.params.backgroundTransparent || false;
+/* SDA CUSTOM */		this.showPanelBackground = this.controller.params.backgroundTransparent !== true;
 /* SDA CUSTOM */		this.baseWidth = this.controller.params.baseWidth;
 /* SDA CUSTOM */		this.verticalAlign = this.controller.params.verticalAlign || 'center';
 /* SDA CUSTOM */		this.borderColor = this.controller.params.borderColor || '#d7dde6';
@@ -361,7 +361,7 @@ export class TitleDialogComponent extends EdaDialogAbstract {
 	}
 
 	public saveChartConfig(): void {
-/* SDA CUSTOM */		this.onClose(EdaDialogCloseEvent.UPDATE, { title: this.title, backgroundTransparent: this.backgroundTransparent, baseWidth: this.baseWidth, verticalAlign: this.verticalAlign, borderColor: this.borderColor, showBorder: this.showBorder, backgroundColor: this.backgroundColor });
+/* SDA CUSTOM */		this.onClose(EdaDialogCloseEvent.UPDATE, { title: this.title, backgroundTransparent: !this.showPanelBackground, baseWidth: this.baseWidth, verticalAlign: this.verticalAlign, borderColor: this.borderColor, showBorder: this.showBorder, backgroundColor: this.backgroundColor });
 	}
 
 	public urlImageHandler(event?: any): void {

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-title-panel/edit-title/quill-editor.component.ts
@@ -1,4 +1,5 @@
 import { Component, ViewChild } from '@angular/core';
+import { OverlayPanel } from 'primeng/overlaypanel';
 import { EdaDialog, EdaDialogAbstract, EdaDialogCloseEvent } from '@eda/shared/components/shared-components.index';
 import { Editor } from 'primeng/editor';
 import { DomSanitizer } from '@angular/platform-browser';
@@ -233,6 +234,85 @@ Quill.register(Size, true);
 			border: 1px solid #d9e0ea;
 			border-radius: 4px;
 		}
+
+		/* SDA CUSTOM - Toolbar icon next to color pickers */
+		.ql-toolbar-icon {
+			width: 18px;
+			height: 18px;
+			display: inline-block;
+			vertical-align: middle;
+			margin-right: 2px;
+		}
+
+		.ql-toolbar-icon .ql-stroke {
+			stroke: #444;
+		}
+
+		.ql-toolbar-icon .ql-fill {
+			fill: #444;
+		}
+
+		/* SDA CUSTOM - Style p-colorPicker to blend with Quill toolbar */
+		:host ::ng-deep .ql-formats .ql-toolbar-picker {
+			width: 28px;
+			height: 24px;
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			vertical-align: middle;
+			padding: 3px 5px;
+		}
+
+		:host ::ng-deep .ql-formats .ql-toolbar-picker .p-colorpicker-preview {
+			width: 18px;
+			height: 18px;
+			border-radius: 3px;
+			border: 1px solid rgba(0, 0, 0, 0.2);
+		}
+
+		.ql-custom-color-btn {
+			height: 24px;
+			width: 28px;
+			padding: 3px 5px;
+			border: none;
+			background: transparent;
+			cursor: pointer;
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			vertical-align: middle;
+		}
+
+		.ql-custom-color-btn svg {
+			width: 18px;
+			height: 18px;
+		}
+
+		.ql-custom-color-btn:hover .ql-stroke {
+			stroke: #06c;
+		}
+
+		.ql-custom-color-btn:hover .ql-fill {
+			fill: #06c;
+		}
+
+		.ql-overlay-picker {
+			display: flex;
+			flex-direction: column;
+			gap: 8px;
+			align-items: center;
+			padding: 4px;
+		}
+
+		.ql-hex-input-popup {
+			width: 200px;
+			padding: 4px 8px;
+			font-size: 12px;
+			font-family: monospace;
+			border: 1px solid #d9e0ea;
+			border-radius: 4px;
+			text-align: center;
+		}
 	`]
 	// END SDA CUSTOM
 })
@@ -246,9 +326,13 @@ export class TitleDialogComponent extends EdaDialogAbstract {
 /* SDA CUSTOM */	public verticalAlign: VerticalAlign = 'center'; // Vertical alignment of the title
 /* SDA CUSTOM */	public isAppearanceExpanded: boolean = true; // State of the Appearance section
 /* SDA CUSTOM */	public isAlignmentExpanded: boolean = true; // State of the Alignment section
-/* SDA CUSTOM */	public textColor: string = '#000000'; // Text color of the title
 /* SDA CUSTOM */	public borderColor: string = '#d7dde6'; // Border color of the panel
 /* SDA CUSTOM */	public showBorder: boolean = true; // Show/hide panel border
+/* SDA CUSTOM */	public backgroundColor: string = '#ffffff'; // Panel background color
+/* SDA CUSTOM */	public customTextColor: string = '#000000'; // Custom text color from Quill toolbar color picker
+/* SDA CUSTOM */	public customTextBgColor: string = '#ffffff'; // Custom text background color from Quill toolbar
+/* SDA CUSTOM */	public showTextColorPicker: boolean = false;
+/* SDA CUSTOM */	public showTextBgColorPicker: boolean = false;
 	constructor(private sanitizer: DomSanitizer) {
 		super();
 		this.dialog = new EdaDialog({
@@ -265,9 +349,9 @@ export class TitleDialogComponent extends EdaDialogAbstract {
 /* SDA CUSTOM */		this.backgroundTransparent = this.controller.params.backgroundTransparent || false;
 /* SDA CUSTOM */		this.baseWidth = this.controller.params.baseWidth;
 /* SDA CUSTOM */		this.verticalAlign = this.controller.params.verticalAlign || 'center';
-/* SDA CUSTOM */		this.textColor = this.controller.params.textColor || '#000000';
 /* SDA CUSTOM */		this.borderColor = this.controller.params.borderColor || '#d7dde6';
 /* SDA CUSTOM */		this.showBorder = this.controller.params.showBorder !== false; // default true
+/* SDA CUSTOM */		this.backgroundColor = this.controller.params.backgroundColor || '#ffffff';
 		const urlImage = document.querySelector('#qlUrlImage');
 		urlImage.addEventListener('click', ($event) => this.urlImageHandler(event));
 	}
@@ -277,7 +361,7 @@ export class TitleDialogComponent extends EdaDialogAbstract {
 	}
 
 	public saveChartConfig(): void {
-/* SDA CUSTOM */		this.onClose(EdaDialogCloseEvent.UPDATE, { title: this.title, backgroundTransparent: this.backgroundTransparent, baseWidth: this.baseWidth, verticalAlign: this.verticalAlign, textColor: this.textColor, borderColor: this.borderColor, showBorder: this.showBorder });
+/* SDA CUSTOM */		this.onClose(EdaDialogCloseEvent.UPDATE, { title: this.title, backgroundTransparent: this.backgroundTransparent, baseWidth: this.baseWidth, verticalAlign: this.verticalAlign, borderColor: this.borderColor, showBorder: this.showBorder, backgroundColor: this.backgroundColor });
 	}
 
 	public urlImageHandler(event?: any): void {
@@ -318,6 +402,44 @@ export class TitleDialogComponent extends EdaDialogAbstract {
 	public closeChartConfig(): void {
 		this.onClose(EdaDialogCloseEvent.NONE);
 	}
+
+/* SDA CUSTOM */	private savedRange: any = null;
+
+/* SDA CUSTOM */	public openColorOverlay(event: Event, overlay: OverlayPanel): void {
+/* SDA CUSTOM */		if (this.editor) {
+/* SDA CUSTOM */			const quill = this.editor.getQuill();
+/* SDA CUSTOM */			this.savedRange = quill.getSelection();
+/* SDA CUSTOM */		}
+/* SDA CUSTOM */		overlay.toggle(event);
+/* SDA CUSTOM */		event.stopPropagation();
+/* SDA CUSTOM */	}
+
+/* SDA CUSTOM */	public onOverlayShow(type: string): void {
+/* SDA CUSTOM */		setTimeout(() => {
+/* SDA CUSTOM */			if (type === 'textColor') this.showTextColorPicker = true;
+/* SDA CUSTOM */			else this.showTextBgColorPicker = true;
+/* SDA CUSTOM */		}, 50);
+/* SDA CUSTOM */	}
+
+/* SDA CUSTOM */	private applySavedFormat(format: string, value: string): void {
+/* SDA CUSTOM */		if (!this.editor || !value) return;
+/* SDA CUSTOM */		const quill = this.editor.getQuill();
+/* SDA CUSTOM */		if (this.savedRange && this.savedRange.length > 0) {
+/* SDA CUSTOM */			quill.formatText(this.savedRange.index, this.savedRange.length, format, value);
+/* SDA CUSTOM */			quill.setSelection(this.savedRange.index, this.savedRange.length, 'silent');
+/* SDA CUSTOM */		} else {
+/* SDA CUSTOM */			quill.format(format, value);
+/* SDA CUSTOM */		}
+/* SDA CUSTOM */		this.title = quill.root.innerHTML;
+/* SDA CUSTOM */	}
+
+/* SDA CUSTOM */	public onTextColorLive(value: string): void {
+/* SDA CUSTOM */		this.applySavedFormat('color', value);
+/* SDA CUSTOM */	}
+
+/* SDA CUSTOM */	public onTextBgColorLive(value: string): void {
+/* SDA CUSTOM */		this.applySavedFormat('background', value);
+/* SDA CUSTOM */	}
 
 /* SDA CUSTOM */	// Toggles expansion/collapse of a section
 /* SDA CUSTOM */	toggleSection(section: 'appearance' | 'alignment'): void {

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.css
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.css
@@ -385,3 +385,18 @@ app-dashboard {
 /* SDA CUSTOM */ ::ng-deep ngx-gridster {
 /* SDA CUSTOM */     display: block;
 /* SDA CUSTOM */ }
+/* SDA CUSTOM */
+/* SDA CUSTOM - Transparent background for text panels (type=1) */
+/* SDA CUSTOM */ ::ng-deep .dashboard-grid ngx-gridster-item.background-transparent {
+/* SDA CUSTOM */     background-color: transparent !important;
+/* SDA CUSTOM */     box-shadow: none !important;
+/* SDA CUSTOM */     border: none !important;
+/* SDA CUSTOM */ }
+/* SDA CUSTOM */
+/* SDA CUSTOM */ ::ng-deep .dashboard-grid ngx-gridster-item.background-transparent > div {
+/* SDA CUSTOM */     background-color: transparent !important;
+/* SDA CUSTOM */ }
+/* SDA CUSTOM */
+/* SDA CUSTOM */ ::ng-deep .dashboard-grid ngx-gridster-item.background-transparent .panel-heading {
+/* SDA CUSTOM */     background-color: transparent !important;
+/* SDA CUSTOM */ }

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.css
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.css
@@ -397,6 +397,12 @@ app-dashboard {
 /* SDA CUSTOM */     background-color: transparent !important;
 /* SDA CUSTOM */ }
 /* SDA CUSTOM */
+/* SDA CUSTOM - Remove shadow and border from gridster-item-inner in transparent text panels */
+/* SDA CUSTOM */ ::ng-deep .dashboard-grid ngx-gridster-item.background-transparent .gridster-item-inner {
+/* SDA CUSTOM */     box-shadow: none !important;
+/* SDA CUSTOM */     border: none !important;
+/* SDA CUSTOM */ }
+/* SDA CUSTOM */
 /* SDA CUSTOM */ ::ng-deep .dashboard-grid ngx-gridster-item.background-transparent .panel-heading {
 /* SDA CUSTOM */     background-color: transparent !important;
 /* SDA CUSTOM */ }

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.css
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.css
@@ -460,23 +460,35 @@ app-dashboard {
 /* SDA CUSTOM */     display: block;
 /* SDA CUSTOM */ }
 /* SDA CUSTOM */
-/* SDA CUSTOM - Transparent background for text panels (type=1) */
-/* SDA CUSTOM */ ::ng-deep .dashboard-grid ngx-gridster-item.background-transparent {
+/* SDA CUSTOM - Transparent background for text panels (type=1) - kill all transitions */
+/* SDA CUSTOM */ ::ng-deep .dashboard-grid ngx-gridster-item.background-transparent,
+/* SDA CUSTOM */ ::ng-deep .dashboard-grid ngx-gridster-item.background-transparent *,
+/* SDA CUSTOM */ ::ng-deep .dashboard-grid gridster-item.background-transparent,
+/* SDA CUSTOM */ ::ng-deep .dashboard-grid gridster-item.background-transparent * {
+/* SDA CUSTOM */     transition: none !important;
+/* SDA CUSTOM */     animation: none !important;
+/* SDA CUSTOM */ }
+/* SDA CUSTOM */
+/* SDA CUSTOM */ ::ng-deep .dashboard-grid ngx-gridster-item.background-transparent,
+/* SDA CUSTOM */ ::ng-deep .dashboard-grid gridster-item.background-transparent {
 /* SDA CUSTOM */     background-color: transparent !important;
 /* SDA CUSTOM */     box-shadow: none !important;
 /* SDA CUSTOM */     border: none !important;
 /* SDA CUSTOM */ }
 /* SDA CUSTOM */
-/* SDA CUSTOM */ ::ng-deep .dashboard-grid ngx-gridster-item.background-transparent > div {
+/* SDA CUSTOM */ ::ng-deep .dashboard-grid ngx-gridster-item.background-transparent > div,
+/* SDA CUSTOM */ ::ng-deep .dashboard-grid gridster-item.background-transparent > div {
 /* SDA CUSTOM */     background-color: transparent !important;
 /* SDA CUSTOM */ }
 /* SDA CUSTOM */
 /* SDA CUSTOM - Remove shadow and border from gridster-item-inner in transparent text panels */
-/* SDA CUSTOM */ ::ng-deep .dashboard-grid ngx-gridster-item.background-transparent .gridster-item-inner {
+/* SDA CUSTOM */ ::ng-deep .dashboard-grid ngx-gridster-item.background-transparent .gridster-item-inner,
+/* SDA CUSTOM */ ::ng-deep .dashboard-grid gridster-item.background-transparent .gridster-item-inner {
 /* SDA CUSTOM */     box-shadow: none !important;
 /* SDA CUSTOM */     border: none !important;
 /* SDA CUSTOM */ }
 /* SDA CUSTOM */
-/* SDA CUSTOM */ ::ng-deep .dashboard-grid ngx-gridster-item.background-transparent .panel-heading {
+/* SDA CUSTOM */ ::ng-deep .dashboard-grid ngx-gridster-item.background-transparent .panel-heading,
+/* SDA CUSTOM */ ::ng-deep .dashboard-grid gridster-item.background-transparent .panel-heading {
 /* SDA CUSTOM */     background-color: transparent !important;
 /* SDA CUSTOM */ }

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
@@ -36,21 +36,21 @@
             #gridster1>
             <!-- Normal Size -->
             <ng-container *ngIf="!toLitle && !toMedium" >
-<!-- SDA CUSTOM --> <ngx-gridster-item *ngFor="let panel of panels"  [options]="itemOptions" [dragAndDrop]="!panel.locked" [resizable]="!panel.locked && panel.resizable" [(w)]="panel.w" [(h)]="panel.h" [(x)]="panel.x" [(y)]="panel.y" (change)="itemChange($event, panel)" [class.panel-locked]="panel.locked">
+<!-- SDA CUSTOM --> <ngx-gridster-item *ngFor="let panel of panels"  [options]="itemOptions" [dragAndDrop]="!panel.locked" [resizable]="!panel.locked && panel.resizable" [(w)]="panel.w" [(h)]="panel.h" [(x)]="panel.x" [(y)]="panel.y" (change)="itemChange($event, panel)" [class.panel-locked]="panel.locked" [class.background-transparent]="panel.type === 1 && panel.backgroundTransparent">
                     <ng-container *ngTemplateOutlet="panelTemplate; context: {$implicit: panel}"></ng-container>
                 </ngx-gridster-item>
             </ng-container>
 
             <!-- Mid  Size -->
             <ng-container *ngIf="toMedium">
-<!-- SDA CUSTOM --> <ngx-gridster-item *ngFor="let panel of panels" [options]="itemOptions" [dragAndDrop]="!panel.locked && panel.dragAndDrop" [resizable]="!panel.locked && panel.resizable" [(w)]="panel.tamanyMig.w" [(h)]="panel.tamanyMig.h" [(x)]="panel.tamanyMig.x" [(y)]="panel.tamanyMig.y" (change)="itemChange($event, panel)" [class.panel-locked]="panel.locked">
+<!-- SDA CUSTOM --> <ngx-gridster-item *ngFor="let panel of panels" [options]="itemOptions" [dragAndDrop]="!panel.locked && panel.dragAndDrop" [resizable]="!panel.locked && panel.resizable" [(w)]="panel.tamanyMig.w" [(h)]="panel.tamanyMig.h" [(x)]="panel.tamanyMig.x" [(y)]="panel.tamanyMig.y" (change)="itemChange($event, panel)" [class.panel-locked]="panel.locked" [class.background-transparent]="panel.type === 1 && panel.backgroundTransparent">
                     <ng-container *ngTemplateOutlet="panelTemplate; context: {$implicit: panel}"></ng-container>
                 </ngx-gridster-item>
             </ng-container>
 
             <!-- Mobile Size -->
             <ng-container *ngIf="toLitle">
-<!-- SDA CUSTOM --> <ngx-gridster-item *ngFor="let panel of panels" [options]="itemOptions" [dragAndDrop]="!panel.locked && panel.dragAndDrop" [resizable]="!panel.locked && panel.resizable" [(w)]="panel.tamanyMobil.w" [(h)]="panel.tamanyMobil.h" [(x)]="panel.tamanyMobil.x" [(y)]="panel.tamanyMobil.y" (change)="itemChange($event, panel)" [class.panel-locked]="panel.locked">
+<!-- SDA CUSTOM --> <ngx-gridster-item *ngFor="let panel of panels" [options]="itemOptions" [dragAndDrop]="!panel.locked && panel.dragAndDrop" [resizable]="!panel.locked && panel.resizable" [(w)]="panel.tamanyMobil.w" [(h)]="panel.tamanyMobil.h" [(x)]="panel.tamanyMobil.x" [(y)]="panel.tamanyMobil.y" (change)="itemChange($event, panel)" [class.panel-locked]="panel.locked" [class.background-transparent]="panel.type === 1 && panel.backgroundTransparent">
                     <ng-container *ngTemplateOutlet="panelTemplate; context: {$implicit: panel}"></ng-container>
                 </ngx-gridster-item>
             </ng-container>

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
@@ -122,7 +122,7 @@
     <div *ngIf="display_v.edit_mode && !inject?.isObserver" class="right-sidebar-blocks-options block-options-bg pointer mt-1" (click)="onAddTitle()">
         <div>
             <i class="fa fa-columns"></i>
-            <span i18n="@@opcionTitulo" class="ml-2">NUEVO PANEL DE TEXTO</span>
+            <span i18n="@@opcionTitulo" class="ml-2">NUEVO TEXTO</span>
         </div>
     </div>
 

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
@@ -122,7 +122,7 @@
     <div *ngIf="display_v.edit_mode && !inject?.isObserver" class="right-sidebar-blocks-options block-options-bg pointer mt-1" (click)="onAddTitle()">
         <div>
             <i class="fa fa-columns"></i>
-            <span i18n="@@opcionTitulo" class="ml-2">NUEVO TEXTO</span>
+            <span i18n="@@opcionTitulo" class="ml-2">NUEVO PANEL DE TEXTO</span>
         </div>
     </div>
 

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
@@ -36,21 +36,21 @@
             #gridster1>
             <!-- Normal Size -->
             <ng-container *ngIf="!toLitle && !toMedium" >
-<!-- SDA CUSTOM --> <ngx-gridster-item *ngFor="let panel of panels"  [options]="itemOptions" [dragAndDrop]="!panel.locked" [resizable]="!panel.locked && panel.resizable" [(w)]="panel.w" [(h)]="panel.h" [(x)]="panel.x" [(y)]="panel.y" (change)="itemChange($event, panel)" [class.panel-locked]="panel.locked" [class.panel-filter-highlight]="hoveredFilterPanelIds.includes(panel.id)" [class.background-transparent]="panel.type === 1 && panel.backgroundTransparent" [class.panel-filter-dimmed]="isFilterHoverActive && !hoveredFilterPanelIds.includes(panel.id)">
+<!-- SDA CUSTOM --> <ngx-gridster-item *ngFor="let panel of panels"  [options]="itemOptions" [dragAndDrop]="!panel.locked" [resizable]="!panel.locked && panel.resizable" [(w)]="panel.w" [(h)]="panel.h" [(x)]="panel.x" [(y)]="panel.y" (change)="itemChange($event, panel)" [class.panel-locked]="panel.locked" [class.panel-filter-highlight]="hoveredFilterPanelIds.includes(panel.id)" [class.background-transparent]="panel.type === 1 && panel.backgroundTransparent" [style.transition]="panel.type === 1 && panel.backgroundTransparent ? 'none' : null" [class.panel-filter-dimmed]="isFilterHoverActive && !hoveredFilterPanelIds.includes(panel.id)">
                     <ng-container *ngTemplateOutlet="panelTemplate; context: {$implicit: panel}"></ng-container>
                 </ngx-gridster-item>
             </ng-container>
 
             <!-- Mid  Size -->
             <ng-container *ngIf="toMedium">
-<!-- SDA CUSTOM --> <ngx-gridster-item *ngFor="let panel of panels" [options]="itemOptions" [dragAndDrop]="!panel.locked && panel.dragAndDrop" [resizable]="!panel.locked && panel.resizable" [(w)]="panel.tamanyMig.w" [(h)]="panel.tamanyMig.h" [(x)]="panel.tamanyMig.x" [(y)]="panel.tamanyMig.y" (change)="itemChange($event, panel)" [class.panel-locked]="panel.locked" [class.background-transparent]="panel.type === 1 && panel.backgroundTransparent" [class.panel-filter-highlight]="hoveredFilterPanelIds.includes(panel.id)" [class.panel-filter-dimmed]="isFilterHoverActive && !hoveredFilterPanelIds.includes(panel.id)">
+<!-- SDA CUSTOM --> <ngx-gridster-item *ngFor="let panel of panels" [options]="itemOptions" [dragAndDrop]="!panel.locked && panel.dragAndDrop" [resizable]="!panel.locked && panel.resizable" [(w)]="panel.tamanyMig.w" [(h)]="panel.tamanyMig.h" [(x)]="panel.tamanyMig.x" [(y)]="panel.tamanyMig.y" (change)="itemChange($event, panel)" [class.panel-locked]="panel.locked" [class.background-transparent]="panel.type === 1 && panel.backgroundTransparent" [style.transition]="panel.type === 1 && panel.backgroundTransparent ? 'none' : null" [class.panel-filter-highlight]="hoveredFilterPanelIds.includes(panel.id)" [class.panel-filter-dimmed]="isFilterHoverActive && !hoveredFilterPanelIds.includes(panel.id)">
                     <ng-container *ngTemplateOutlet="panelTemplate; context: {$implicit: panel}"></ng-container>
                 </ngx-gridster-item>
             </ng-container>
 
             <!-- Mobile Size -->
             <ng-container *ngIf="toLitle">
-<!-- SDA CUSTOM --> <ngx-gridster-item *ngFor="let panel of panels" [options]="itemOptions" [dragAndDrop]="!panel.locked && panel.dragAndDrop" [resizable]="!panel.locked && panel.resizable" [(w)]="panel.tamanyMobil.w" [(h)]="panel.tamanyMobil.h" [(x)]="panel.tamanyMobil.x" [(y)]="panel.tamanyMobil.y" (change)="itemChange($event, panel)" [class.panel-locked]="panel.locked" [class.background-transparent]="panel.type === 1 && panel.backgroundTransparent" [class.panel-filter-highlight]="hoveredFilterPanelIds.includes(panel.id)" [class.panel-filter-dimmed]="isFilterHoverActive && !hoveredFilterPanelIds.includes(panel.id)">
+<!-- SDA CUSTOM --> <ngx-gridster-item *ngFor="let panel of panels" [options]="itemOptions" [dragAndDrop]="!panel.locked && panel.dragAndDrop" [resizable]="!panel.locked && panel.resizable" [(w)]="panel.tamanyMobil.w" [(h)]="panel.tamanyMobil.h" [(x)]="panel.tamanyMobil.x" [(y)]="panel.tamanyMobil.y" (change)="itemChange($event, panel)" [class.panel-locked]="panel.locked" [class.background-transparent]="panel.type === 1 && panel.backgroundTransparent" [style.transition]="panel.type === 1 && panel.backgroundTransparent ? 'none' : null" [class.panel-filter-highlight]="hoveredFilterPanelIds.includes(panel.id)" [class.panel-filter-dimmed]="isFilterHoverActive && !hoveredFilterPanelIds.includes(panel.id)">
                     <ng-container *ngTemplateOutlet="panelTemplate; context: {$implicit: panel}"></ng-container>
                 </ngx-gridster-item>
             </ng-container>

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -1357,7 +1357,8 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
             resizable: true,
             dragAndDrop: true,
             fontsize: '22px',
-            color: '#000000'
+            color: '#000000',
+            backgroundColor: '#ffffff'
         });
         this.setPanelSizes(panel);
         this.display_v.rightSidebar = false;

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -1387,7 +1387,7 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
         /*SDA CUSTOM*/             }
         /*SDA CUSTOM*/         });
         /*SDA CUSTOM*/ }
-                        this.panels.push(panel);
+        /*SDA CUSTOM*/        this.panels.push(panel);
                         this.dashboardService._notSaved.next(true);
         /*SDA CUSTOM*/ const _dupSub = this.edaPanels.changes.subscribe(() => {
         /*SDA CUSTOM*/     _dupSub.unsubscribe();

--- a/eda/eda_app/src/app/shared/models/dashboard-models/eda-panel.model.ts
+++ b/eda/eda_app/src/app/shared/models/dashboard-models/eda-panel.model.ts
@@ -16,6 +16,7 @@ export class EdaPanel {
     public x: number;
     public y: number;
     /* SDA CUSTOM */ public locked: boolean = false;
+    /* SDA CUSTOM */ public backgroundTransparent?: boolean;
     public content: any[any];
     public inject: any = {};
     public tamanyMobil: IMobileSizes = {x: 0, y: 0, w: 0, h: 0};

--- a/eda/eda_app/src/app/shared/models/dashboard-models/eda-title-panel.ts
+++ b/eda/eda_app/src/app/shared/models/dashboard-models/eda-title-panel.ts
@@ -3,6 +3,7 @@ import { EdaPanel } from '@eda/models/dashboard-models/eda-panel.model';
 export class EdaTitlePanel extends EdaPanel {
     fontsize: string;
     color: string;
+/* SDA CUSTOM */    backgroundTransparent: boolean = false;
 
     constructor(init?: Partial<EdaTitlePanel>) {
         super(init);

--- a/eda/eda_app/src/app/shared/models/dashboard-models/eda-title-panel.ts
+++ b/eda/eda_app/src/app/shared/models/dashboard-models/eda-title-panel.ts
@@ -1,9 +1,16 @@
 import { EdaPanel } from '@eda/models/dashboard-models/eda-panel.model';
 
+export type VerticalAlign = 'top' | 'center' | 'bottom';
+
 export class EdaTitlePanel extends EdaPanel {
     fontsize: string;
     color: string;
 /* SDA CUSTOM */    backgroundTransparent: boolean = false;
+/* SDA CUSTOM */    baseWidth?: number; // Base width of the panel for proportional scaling
+/* SDA CUSTOM */    verticalAlign?: VerticalAlign; // Vertical alignment of the title
+/* SDA CUSTOM */    textColor?: string; // Text color of the title
+/* SDA CUSTOM */    borderColor?: string; // Border color of the panel
+/* SDA CUSTOM */    showBorder?: boolean; // Show/hide panel border
 
     constructor(init?: Partial<EdaTitlePanel>) {
         super(init);

--- a/eda/eda_app/src/app/shared/models/dashboard-models/eda-title-panel.ts
+++ b/eda/eda_app/src/app/shared/models/dashboard-models/eda-title-panel.ts
@@ -11,6 +11,7 @@ export class EdaTitlePanel extends EdaPanel {
 /* SDA CUSTOM */    textColor?: string; // Text color of the title
 /* SDA CUSTOM */    borderColor?: string; // Border color of the panel
 /* SDA CUSTOM */    showBorder?: boolean; // Show/hide panel border
+/* SDA CUSTOM */    backgroundColor?: string; // Panel background color
 
     constructor(init?: Partial<EdaTitlePanel>) {
         super(init);

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -431,6 +431,14 @@
     <source>Desbloquear panel</source>
     <target>Desbloqueja el panell</target>
   </trans-unit>
+  <trans-unit id="opcionTitulo" datatype="html">
+    <source>PANEL DE TEXTO</source>
+    <target>NOU PANELL DE TEXT</target>
+    <context-group purpose="location">
+      <context context-type="sourcefile">app/module/pages/dashboard/dashboard.component.html</context>
+      <context context-type="linenumber">137</context>
+    </context-group>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -935,15 +935,15 @@
   </trans-unit>
   <trans-unit id="titlePanelShowBg">
     <source>Mostrar fondo del panel</source>
-    <target>Mostrar fons del panell</target>
+    <target>Mostra el fons del panell</target>
   </trans-unit>
   <trans-unit id="titlePanelBgColor">
     <source>Color de fondo</source>
-    <target>Color de fons</target>
+    <target>Color del fons</target>
   </trans-unit>
   <trans-unit id="titlePanelShowBorder">
     <source>Mostrar borde</source>
-    <target>Mostrar vora</target>
+    <target>Mostra la vora</target>
   </trans-unit>
   <trans-unit id="titlePanelBorderColor">
     <source>Color del borde</source>
@@ -959,7 +959,7 @@
   </trans-unit>
   <trans-unit id="titlePanelAlignCenter">
     <source>Centro</source>
-    <target>Centre</target>
+    <target>Al centre</target>
   </trans-unit>
   <trans-unit id="titlePanelAlignBottom">
     <source>Abajo</source>
@@ -967,7 +967,7 @@
   </trans-unit>
   <trans-unit id="duplicatePanel">
     <source>Duplicar panel</source>
-    <target>Duplicar panell</target>
+    <target>Duplica el panell</target>
   </trans-unit>
 </body>
   </file>

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -908,6 +908,10 @@
   </trans-unit>
   <!-- END SDA CUSTOM -->
   <!-- END SDA CUSTOM -->
+  <trans-unit id="opcionTitulo">
+    <source>NUEVO TEXTO</source>
+    <target>NOU PANELL DE TEXT</target>
+  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -937,9 +937,9 @@
     <source>Appearance</source>
     <target>Aparença</target>
   </trans-unit>
-  <trans-unit id="titlePanelRemoveBg">
-    <source>Remove panel background</source>
-    <target>Treure fons del panell</target>
+  <trans-unit id="titlePanelShowBg">
+    <source>Show panel background</source>
+    <target>Mostrar fons del panell</target>
   </trans-unit>
   <trans-unit id="titlePanelBgColor">
     <source>Background color</source>

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -513,7 +513,6 @@
     <source>Máximo de etiquetas</source>
     <target>Màxim d'etiquetes</target>
   </trans-unit>
-  <!-- SDA CUSTOM - KPI/chart option labels -->
   <trans-unit id="showChartLabels">
     <source>Mostrar etiquetas del gráfico</source>
     <target>Mostra les etiquetes del gràfic</target>
@@ -554,8 +553,6 @@
     <source>Fondo de etiquetas</source>
     <target>Fons de les etiquetes</target>
   </trans-unit>
-  <!-- END SDA CUSTOM -->
-  <!-- SDA CUSTOM - Logs viewer labels -->
   <trans-unit id="LogsViewer" datatype="html">
     <source>Visor de logs</source>
     <target>Visor de registres</target>
@@ -684,7 +681,6 @@
     <source>Mostrar accesos a informes</source>
     <target>Mostrar accessos als informes</target>
   </trans-unit>
-  <!-- SDA CUSTOM - Logs action labels i18n -->
   <trans-unit id="LogsActionAccess">
     <source>Access</source>
     <target>Accés</target>
@@ -797,7 +793,6 @@
     <source>Login</source>
     <target>Inici de sessió</target>
   </trans-unit>
-  <!-- SDA CUSTOM - Logs action column labels i18n -->
   <trans-unit id="LogsActionNewLogin">
     <source>Login</source>
     <target>Inici de sessió</target>
@@ -906,13 +901,10 @@
     <source>Update Model Failed</source>
     <target>Error en actualització del model</target>
   </trans-unit>
-  <!-- END SDA CUSTOM -->
-  <!-- END SDA CUSTOM -->
   <trans-unit id="opcionTitulo">
     <source>NUEVO TEXTO</source>
     <target>NOU PANELL DE TEXT</target>
   </trans-unit>
-  <!-- SDA CUSTOM - Download JSON title -->
   <trans-unit id="downloadJsonTitle">
     <source>Download JSON</source>
     <target>Descarregar JSON</target>
@@ -976,6 +968,10 @@
   <trans-unit id="titlePanelAlignBottom">
     <source>Bottom</source>
     <target>A baix</target>
+  </trans-unit>
+  <trans-unit id="duplicatePanel">
+    <source>Duplicate panel</source>
+    <target>Duplicar panell</target>
   </trans-unit>
 </body>
   </file>

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -901,10 +901,6 @@
     <source>Update Model Failed</source>
     <target>Error en actualització del model</target>
   </trans-unit>
-  <trans-unit id="opcionTitulo">
-    <source>NUEVO PANEL DE TEXTO</source>
-    <target>NOU PANELL DE TEXT</target>
-  </trans-unit>
   <trans-unit id="downloadJsonTitle">
     <source>Download JSON</source>
     <target>Descarregar JSON</target>
@@ -926,7 +922,7 @@
     <target>Panells no afectats per aquest filtre</target>
   </trans-unit>
   <trans-unit id="opcionTitulo">
-    <source>NUEVO PANEL DE TEXTO</source>
+    <source>NUEVO TEXTO</source>
     <target>NOU PANELL DE TEXT</target>
   </trans-unit>
   <trans-unit id="titlePanelOptions">

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -902,7 +902,7 @@
     <target>Error en actualització del model</target>
   </trans-unit>
   <trans-unit id="opcionTitulo">
-    <source>NUEVO TEXTO</source>
+    <source>NUEVO PANEL DE TEXTO</source>
     <target>NOU PANELL DE TEXT</target>
   </trans-unit>
   <trans-unit id="downloadJsonTitle">
@@ -926,51 +926,51 @@
     <target>Panells no afectats per aquest filtre</target>
   </trans-unit>
   <trans-unit id="opcionTitulo">
-    <source>NUEVO TEXTO</source>
+    <source>NUEVO PANEL DE TEXTO</source>
     <target>NOU PANELL DE TEXT</target>
   </trans-unit>
   <trans-unit id="titlePanelOptions">
-    <source>Panel Options</source>
+    <source>Opciones del panel</source>
     <target>Opcions del panell</target>
   </trans-unit>
   <trans-unit id="titlePanelAppearance">
-    <source>Appearance</source>
+    <source>Apariencia</source>
     <target>Aparença</target>
   </trans-unit>
   <trans-unit id="titlePanelShowBg">
-    <source>Show panel background</source>
+    <source>Mostrar fondo del panel</source>
     <target>Mostrar fons del panell</target>
   </trans-unit>
   <trans-unit id="titlePanelBgColor">
-    <source>Background color</source>
+    <source>Color de fondo</source>
     <target>Color de fons</target>
   </trans-unit>
   <trans-unit id="titlePanelShowBorder">
-    <source>Show border</source>
+    <source>Mostrar borde</source>
     <target>Mostrar vora</target>
   </trans-unit>
   <trans-unit id="titlePanelBorderColor">
-    <source>Border color</source>
+    <source>Color del borde</source>
     <target>Color de la vora</target>
   </trans-unit>
   <trans-unit id="titlePanelVerticalAlign">
-    <source>Vertical alignment</source>
+    <source>Alineación vertical</source>
     <target>Alineació vertical</target>
   </trans-unit>
   <trans-unit id="titlePanelAlignTop">
-    <source>Top</source>
+    <source>Arriba</source>
     <target>A dalt</target>
   </trans-unit>
   <trans-unit id="titlePanelAlignCenter">
-    <source>Center</source>
+    <source>Centro</source>
     <target>Centre</target>
   </trans-unit>
   <trans-unit id="titlePanelAlignBottom">
-    <source>Bottom</source>
+    <source>Abajo</source>
     <target>A baix</target>
   </trans-unit>
   <trans-unit id="duplicatePanel">
-    <source>Duplicate panel</source>
+    <source>Duplicar panel</source>
     <target>Duplicar panell</target>
   </trans-unit>
 </body>

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -933,6 +933,50 @@
     <source>Paneles no afectados por este filtro</source>
     <target>Panells no afectats per aquest filtre</target>
   </trans-unit>
+  <trans-unit id="opcionTitulo">
+    <source>NUEVO TEXTO</source>
+    <target>NOU PANELL DE TEXT</target>
+  </trans-unit>
+  <trans-unit id="titlePanelOptions">
+    <source>Panel Options</source>
+    <target>Opcions del panell</target>
+  </trans-unit>
+  <trans-unit id="titlePanelAppearance">
+    <source>Appearance</source>
+    <target>Aparença</target>
+  </trans-unit>
+  <trans-unit id="titlePanelRemoveBg">
+    <source>Remove panel background</source>
+    <target>Treure fons del panell</target>
+  </trans-unit>
+  <trans-unit id="titlePanelBgColor">
+    <source>Background color</source>
+    <target>Color de fons</target>
+  </trans-unit>
+  <trans-unit id="titlePanelShowBorder">
+    <source>Show border</source>
+    <target>Mostrar vora</target>
+  </trans-unit>
+  <trans-unit id="titlePanelBorderColor">
+    <source>Border color</source>
+    <target>Color de la vora</target>
+  </trans-unit>
+  <trans-unit id="titlePanelVerticalAlign">
+    <source>Vertical alignment</source>
+    <target>Alineació vertical</target>
+  </trans-unit>
+  <trans-unit id="titlePanelAlignTop">
+    <source>Top</source>
+    <target>A dalt</target>
+  </trans-unit>
+  <trans-unit id="titlePanelAlignCenter">
+    <source>Center</source>
+    <target>Centre</target>
+  </trans-unit>
+  <trans-unit id="titlePanelAlignBottom">
+    <source>Bottom</source>
+    <target>A baix</target>
+  </trans-unit>
 </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -431,6 +431,14 @@
     <source>Desbloquear panel</source>
     <target>Unlock panel</target>
   </trans-unit>
+  <trans-unit id="opcionTitulo" datatype="html">
+    <source>PANEL DE TEXTO</source>
+    <target>NEW TEXT PANEL</target>
+    <context-group purpose="location">
+      <context context-type="sourcefile">app/module/pages/dashboard/dashboard.component.html</context>
+      <context context-type="linenumber">137</context>
+    </context-group>
+  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -931,6 +931,50 @@
     <source>Paneles no afectados por este filtro</source>
     <target>Panels not affected by this filter</target>
   </trans-unit>
+  <trans-unit id="opcionTitulo">
+    <source>NUEVO TEXTO</source>
+    <target>NEW TEXT PANEL</target>
+  </trans-unit>
+  <trans-unit id="titlePanelOptions">
+    <source>Panel Options</source>
+    <target>Panel Options</target>
+  </trans-unit>
+  <trans-unit id="titlePanelAppearance">
+    <source>Appearance</source>
+    <target>Appearance</target>
+  </trans-unit>
+  <trans-unit id="titlePanelRemoveBg">
+    <source>Remove panel background</source>
+    <target>Remove panel background</target>
+  </trans-unit>
+  <trans-unit id="titlePanelBgColor">
+    <source>Background color</source>
+    <target>Background color</target>
+  </trans-unit>
+  <trans-unit id="titlePanelShowBorder">
+    <source>Show border</source>
+    <target>Show border</target>
+  </trans-unit>
+  <trans-unit id="titlePanelBorderColor">
+    <source>Border color</source>
+    <target>Border color</target>
+  </trans-unit>
+  <trans-unit id="titlePanelVerticalAlign">
+    <source>Vertical alignment</source>
+    <target>Vertical alignment</target>
+  </trans-unit>
+  <trans-unit id="titlePanelAlignTop">
+    <source>Top</source>
+    <target>Top</target>
+  </trans-unit>
+  <trans-unit id="titlePanelAlignCenter">
+    <source>Center</source>
+    <target>Center</target>
+  </trans-unit>
+  <trans-unit id="titlePanelAlignBottom">
+    <source>Bottom</source>
+    <target>Bottom</target>
+  </trans-unit>
 </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -925,7 +925,7 @@
   </trans-unit>
   <trans-unit id="titlePanelOptions">
     <source>Opciones del panel</source>
-    <target>Panel Options</target>
+    <target>Panel options</target>
   </trans-unit>
   <trans-unit id="titlePanelAppearance">
     <source>Apariencia</source>
@@ -957,7 +957,7 @@
   </trans-unit>
   <trans-unit id="titlePanelAlignCenter">
     <source>Centro</source>
-    <target>Center</target>
+    <target>Middle</target>
   </trans-unit>
   <trans-unit id="titlePanelAlignBottom">
     <source>Abajo</source>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -511,7 +511,6 @@
     <source>Máximo de etiquetas</source>
     <target>Maximum labels</target>
   </trans-unit>
-  <!-- SDA CUSTOM - KPI/chart option labels -->
   <trans-unit id="showChartLabels">
     <source>Mostrar etiquetas del gráfico</source>
     <target>Show chart labels</target>
@@ -552,8 +551,6 @@
     <source>Fondo de etiquetas</source>
     <target>Label background</target>
   </trans-unit>
-  <!-- END SDA CUSTOM -->
-  <!-- SDA CUSTOM - Logs viewer labels -->
   <trans-unit id="LogsViewer" datatype="html">
     <source>Visor de logs</source>
     <target>Logs viewer</target>
@@ -682,7 +679,6 @@
     <source>Mostrar accesos a informes</source>
     <target>Show report accesses</target>
   </trans-unit>
-  <!-- SDA CUSTOM - Logs action labels i18n -->
   <trans-unit id="LogsActionAccess">
     <source>Access</source>
     <target>Access</target>
@@ -795,7 +791,6 @@
     <source>Login</source>
     <target>Login</target>
   </trans-unit>
-  <!-- SDA CUSTOM - Logs action column labels i18n -->
   <trans-unit id="LogsActionNewLogin">
     <source>Login</source>
     <target>Login</target>
@@ -904,13 +899,10 @@
     <source>Update Model Failed</source>
     <target>Model update failed</target>
   </trans-unit>
-  <!-- END SDA CUSTOM -->
   <trans-unit id="opcionTitulo">
     <source>NUEVO TEXTO</source>
     <target>NEW TEXT PANEL</target>
   </trans-unit>
-<!-- END SDA CUSTOM -->
-  <!-- SDA CUSTOM - Download JSON title -->
   <trans-unit id="downloadJsonTitle">
     <source>Download JSON</source>
     <target>Download JSON</target>
@@ -974,6 +966,10 @@
   <trans-unit id="titlePanelAlignBottom">
     <source>Bottom</source>
     <target>Bottom</target>
+  </trans-unit>
+  <trans-unit id="duplicatePanel">
+    <source>Duplicate panel</source>
+    <target>Duplicate panel</target>
   </trans-unit>
 </body>
   </file>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -935,9 +935,9 @@
     <source>Appearance</source>
     <target>Appearance</target>
   </trans-unit>
-  <trans-unit id="titlePanelRemoveBg">
-    <source>Remove panel background</source>
-    <target>Remove panel background</target>
+  <trans-unit id="titlePanelShowBg">
+    <source>Show panel background</source>
+    <target>Show panel background</target>
   </trans-unit>
   <trans-unit id="titlePanelBgColor">
     <source>Background color</source>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -899,10 +899,6 @@
     <source>Update Model Failed</source>
     <target>Model update failed</target>
   </trans-unit>
-  <trans-unit id="opcionTitulo">
-    <source>NUEVO PANEL DE TEXTO</source>
-    <target>NEW TEXT PANEL</target>
-  </trans-unit>
   <trans-unit id="downloadJsonTitle">
     <source>Download JSON</source>
     <target>Download JSON</target>
@@ -924,7 +920,7 @@
     <target>Panels not affected by this filter</target>
   </trans-unit>
   <trans-unit id="opcionTitulo">
-    <source>NUEVO PANEL DE TEXTO</source>
+    <source>NUEVO TEXTO</source>
     <target>NEW TEXT PANEL</target>
   </trans-unit>
   <trans-unit id="titlePanelOptions">

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -900,7 +900,7 @@
     <target>Model update failed</target>
   </trans-unit>
   <trans-unit id="opcionTitulo">
-    <source>NUEVO TEXTO</source>
+    <source>NUEVO PANEL DE TEXTO</source>
     <target>NEW TEXT PANEL</target>
   </trans-unit>
   <trans-unit id="downloadJsonTitle">
@@ -924,51 +924,51 @@
     <target>Panels not affected by this filter</target>
   </trans-unit>
   <trans-unit id="opcionTitulo">
-    <source>NUEVO TEXTO</source>
+    <source>NUEVO PANEL DE TEXTO</source>
     <target>NEW TEXT PANEL</target>
   </trans-unit>
   <trans-unit id="titlePanelOptions">
-    <source>Panel Options</source>
+    <source>Opciones del panel</source>
     <target>Panel Options</target>
   </trans-unit>
   <trans-unit id="titlePanelAppearance">
-    <source>Appearance</source>
+    <source>Apariencia</source>
     <target>Appearance</target>
   </trans-unit>
   <trans-unit id="titlePanelShowBg">
-    <source>Show panel background</source>
+    <source>Mostrar fondo del panel</source>
     <target>Show panel background</target>
   </trans-unit>
   <trans-unit id="titlePanelBgColor">
-    <source>Background color</source>
+    <source>Color de fondo</source>
     <target>Background color</target>
   </trans-unit>
   <trans-unit id="titlePanelShowBorder">
-    <source>Show border</source>
+    <source>Mostrar borde</source>
     <target>Show border</target>
   </trans-unit>
   <trans-unit id="titlePanelBorderColor">
-    <source>Border color</source>
+    <source>Color del borde</source>
     <target>Border color</target>
   </trans-unit>
   <trans-unit id="titlePanelVerticalAlign">
-    <source>Vertical alignment</source>
+    <source>Alineación vertical</source>
     <target>Vertical alignment</target>
   </trans-unit>
   <trans-unit id="titlePanelAlignTop">
-    <source>Top</source>
+    <source>Arriba</source>
     <target>Top</target>
   </trans-unit>
   <trans-unit id="titlePanelAlignCenter">
-    <source>Center</source>
+    <source>Centro</source>
     <target>Center</target>
   </trans-unit>
   <trans-unit id="titlePanelAlignBottom">
-    <source>Bottom</source>
+    <source>Abajo</source>
     <target>Bottom</target>
   </trans-unit>
   <trans-unit id="duplicatePanel">
-    <source>Duplicate panel</source>
+    <source>Duplicar panel</source>
     <target>Duplicate panel</target>
   </trans-unit>
 </body>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -906,6 +906,10 @@
   </trans-unit>
   <!-- END SDA CUSTOM -->
   <!-- END SDA CUSTOM -->
+  <trans-unit id="opcionTitulo">
+    <source>NUEVO TEXTO</source>
+    <target>NEW TEXT PANEL</target>
+  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -431,6 +431,15 @@
     <source>Desbloquear panel</source>
     <target>Desbloquear panel</target>
   </trans-unit>
+  <trans-unit id="opcionTitulo" datatype="html">
+    <source>PANEL DE TEXTO</source>
+    <target>NUEVO PANEL DE TEXTO</target>
+    <context-group purpose="location">
+    <context context-type="sourcefile">app/module/pages/dashboard/dashboard.component.html</context>
+    <context context-type="linenumber">137</context>
+    </context-group>
+  </trans-unit>
+
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -933,6 +933,50 @@
     <source>Paneles no afectados por este filtro</source>
     <target>Paneles no afectados por este filtro</target>
   </trans-unit>
+  <trans-unit id="opcionTitulo">
+    <source>NUEVO TEXTO</source>
+    <target>NUEVO PANEL DE TEXTO</target>
+  </trans-unit>
+  <trans-unit id="titlePanelOptions">
+    <source>Panel Options</source>
+    <target>Opciones del panel</target>
+  </trans-unit>
+  <trans-unit id="titlePanelAppearance">
+    <source>Appearance</source>
+    <target>Apariencia</target>
+  </trans-unit>
+  <trans-unit id="titlePanelRemoveBg">
+    <source>Remove panel background</source>
+    <target>Quitar fondo del panel</target>
+  </trans-unit>
+  <trans-unit id="titlePanelBgColor">
+    <source>Background color</source>
+    <target>Color de fondo</target>
+  </trans-unit>
+  <trans-unit id="titlePanelShowBorder">
+    <source>Show border</source>
+    <target>Mostrar borde</target>
+  </trans-unit>
+  <trans-unit id="titlePanelBorderColor">
+    <source>Border color</source>
+    <target>Color del borde</target>
+  </trans-unit>
+  <trans-unit id="titlePanelVerticalAlign">
+    <source>Vertical alignment</source>
+    <target>Alineación vertical</target>
+  </trans-unit>
+  <trans-unit id="titlePanelAlignTop">
+    <source>Top</source>
+    <target>Arriba</target>
+  </trans-unit>
+  <trans-unit id="titlePanelAlignCenter">
+    <source>Center</source>
+    <target>Centro</target>
+  </trans-unit>
+  <trans-unit id="titlePanelAlignBottom">
+    <source>Bottom</source>
+    <target>Abajo</target>
+  </trans-unit>
 </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -908,6 +908,10 @@
   </trans-unit>
   <!-- END SDA CUSTOM -->
   <!-- END SDA CUSTOM -->
+  <trans-unit id="opcionTitulo">
+    <source>NUEVO TEXTO</source>
+    <target>NUEVO PANEL DE TEXTO</target>
+  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -902,7 +902,7 @@
     <target>Fallo en actualización del modelo</target>
   </trans-unit>
   <trans-unit id="opcionTitulo">
-    <source>NUEVO TEXTO</source>
+    <source>NUEVO PANEL DE TEXTO</source>
     <target>NUEVO PANEL DE TEXTO</target>
   </trans-unit>
   <trans-unit id="downloadJsonTitle">
@@ -926,51 +926,51 @@
     <target>Paneles no afectados por este filtro</target>
   </trans-unit>
   <trans-unit id="opcionTitulo">
-    <source>NUEVO TEXTO</source>
+    <source>NUEVO PANEL DE TEXTO</source>
     <target>NUEVO PANEL DE TEXTO</target>
   </trans-unit>
   <trans-unit id="titlePanelOptions">
-    <source>Panel Options</source>
+    <source>Opciones del panel</source>
     <target>Opciones del panel</target>
   </trans-unit>
   <trans-unit id="titlePanelAppearance">
-    <source>Appearance</source>
+    <source>Apariencia</source>
     <target>Apariencia</target>
   </trans-unit>
   <trans-unit id="titlePanelShowBg">
-    <source>Show panel background</source>
+    <source>Mostrar fondo del panel</source>
     <target>Mostrar fondo del panel</target>
   </trans-unit>
   <trans-unit id="titlePanelBgColor">
-    <source>Background color</source>
+    <source>Color de fondo</source>
     <target>Color de fondo</target>
   </trans-unit>
   <trans-unit id="titlePanelShowBorder">
-    <source>Show border</source>
+    <source>Mostrar borde</source>
     <target>Mostrar borde</target>
   </trans-unit>
   <trans-unit id="titlePanelBorderColor">
-    <source>Border color</source>
+    <source>Color del borde</source>
     <target>Color del borde</target>
   </trans-unit>
   <trans-unit id="titlePanelVerticalAlign">
-    <source>Vertical alignment</source>
+    <source>Alineación vertical</source>
     <target>Alineación vertical</target>
   </trans-unit>
   <trans-unit id="titlePanelAlignTop">
-    <source>Top</source>
+    <source>Arriba</source>
     <target>Arriba</target>
   </trans-unit>
   <trans-unit id="titlePanelAlignCenter">
-    <source>Center</source>
+    <source>Centro</source>
     <target>Centro</target>
   </trans-unit>
   <trans-unit id="titlePanelAlignBottom">
-    <source>Bottom</source>
+    <source>Abajo</source>
     <target>Abajo</target>
   </trans-unit>
   <trans-unit id="duplicatePanel">
-    <source>Duplicate panel</source>
+    <source>Duplicar panel</source>
     <target>Duplicar panel</target>
   </trans-unit>
 </body>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -901,10 +901,6 @@
     <source>Update Model Failed</source>
     <target>Fallo en actualización del modelo</target>
   </trans-unit>
-  <trans-unit id="opcionTitulo">
-    <source>NUEVO PANEL DE TEXTO</source>
-    <target>NUEVO PANEL DE TEXTO</target>
-  </trans-unit>
   <trans-unit id="downloadJsonTitle">
     <source>Download JSON</source>
     <target>Descargar JSON</target>
@@ -926,7 +922,7 @@
     <target>Paneles no afectados por este filtro</target>
   </trans-unit>
   <trans-unit id="opcionTitulo">
-    <source>NUEVO PANEL DE TEXTO</source>
+    <source>NUEVO TEXTO</source>
     <target>NUEVO PANEL DE TEXTO</target>
   </trans-unit>
   <trans-unit id="titlePanelOptions">

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -513,7 +513,6 @@
     <source>Máximo de etiquetas</source>
     <target>Máximo de etiquetas</target>
   </trans-unit>
-  <!-- SDA CUSTOM - KPI/chart option labels -->
   <trans-unit id="showChartLabels">
     <source>Mostrar etiquetas del gráfico</source>
     <target>Mostrar etiquetas del gráfico</target>
@@ -554,8 +553,6 @@
     <source>Fondo de etiquetas</source>
     <target>Fondo de etiquetas</target>
   </trans-unit>
-  <!-- END SDA CUSTOM -->
-  <!-- SDA CUSTOM - Logs viewer labels -->
   <trans-unit id="LogsViewer" datatype="html">
     <source>Visor de logs</source>
     <target>Visor de logs</target>
@@ -684,7 +681,6 @@
     <source>Mostrar accesos a informes</source>
     <target>Mostrar accesos a informes</target>
   </trans-unit>
-  <!-- SDA CUSTOM - Logs action labels i18n -->
   <trans-unit id="LogsActionAccess">
     <source>Access</source>
     <target>Acceso</target>
@@ -797,7 +793,6 @@
     <source>Login</source>
     <target>Inicio de sesión</target>
   </trans-unit>
-  <!-- SDA CUSTOM - Logs action column labels i18n -->
   <trans-unit id="LogsActionNewLogin">
     <source>Login</source>
     <target>Inicio de sesión</target>
@@ -906,13 +901,10 @@
     <source>Update Model Failed</source>
     <target>Fallo en actualización del modelo</target>
   </trans-unit>
-  <!-- END SDA CUSTOM -->
   <trans-unit id="opcionTitulo">
     <source>NUEVO TEXTO</source>
     <target>NUEVO PANEL DE TEXTO</target>
   </trans-unit>
-<!-- END SDA CUSTOM -->
-  <!-- SDA CUSTOM - Download JSON title -->
   <trans-unit id="downloadJsonTitle">
     <source>Download JSON</source>
     <target>Descargar JSON</target>
@@ -976,6 +968,10 @@
   <trans-unit id="titlePanelAlignBottom">
     <source>Bottom</source>
     <target>Abajo</target>
+  </trans-unit>
+  <trans-unit id="duplicatePanel">
+    <source>Duplicate panel</source>
+    <target>Duplicar panel</target>
   </trans-unit>
 </body>
   </file>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -937,9 +937,9 @@
     <source>Appearance</source>
     <target>Apariencia</target>
   </trans-unit>
-  <trans-unit id="titlePanelRemoveBg">
-    <source>Remove panel background</source>
-    <target>Quitar fondo del panel</target>
+  <trans-unit id="titlePanelShowBg">
+    <source>Show panel background</source>
+    <target>Mostrar fondo del panel</target>
   </trans-unit>
   <trans-unit id="titlePanelBgColor">
     <source>Background color</source>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -431,6 +431,14 @@
     <source>Desbloquear panel</source>
     <target>Desbloquear panel</target>
   </trans-unit>
+  <trans-unit id="opcionTitulo" datatype="html">
+    <source>PANEL DE TEXTO</source>
+    <target>NOVO PANEL DE TEXTO</target>
+    <context-group purpose="location">
+      <context context-type="sourcefile">app/module/pages/dashboard/dashboard.component.html</context>
+      <context context-type="linenumber">137</context>
+    </context-group>
+  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -513,7 +513,6 @@
     <source>Máximo de etiquetas</source>
     <target>Máximo de etiquetas</target>
   </trans-unit>
-  <!-- SDA CUSTOM - KPI/chart option labels -->
   <trans-unit id="showChartLabels">
     <source>Mostrar etiquetas del gráfico</source>
     <target>Mostrar etiquetas do gráfico</target>
@@ -554,8 +553,6 @@
     <source>Fondo de etiquetas</source>
     <target>Fondo das etiquetas</target>
   </trans-unit>
-  <!-- END SDA CUSTOM -->
-  <!-- SDA CUSTOM - Logs viewer labels -->
   <trans-unit id="LogsViewer" datatype="html">
     <source>Visor de logs</source>
     <target>Visor de rexistros</target>
@@ -684,7 +681,6 @@
     <source>Mostrar accesos a informes</source>
     <target>Mostrar accesos aos informes</target>
   </trans-unit>
-  <!-- SDA CUSTOM - Logs action labels i18n -->
   <trans-unit id="LogsActionAccess">
     <source>Access</source>
     <target>Acceso</target>
@@ -797,7 +793,6 @@
     <source>Login</source>
     <target>Inicio de sesión</target>
   </trans-unit>
-  <!-- SDA CUSTOM - Logs action column labels i18n -->
   <trans-unit id="LogsActionNewLogin">
     <source>Login</source>
     <target>Inicio de sesión</target>
@@ -906,13 +901,10 @@
     <source>Update Model Failed</source>
     <target>Fallo en actualización do modelo</target>
   </trans-unit>
-  <!-- END SDA CUSTOM -->
   <trans-unit id="opcionTitulo">
     <source>NUEVO TEXTO</source>
     <target>NUEVO PANEL DE TEXTO</target>
   </trans-unit>
-<!-- END SDA CUSTOM -->
-  <!-- SDA CUSTOM - Download JSON title -->
   <trans-unit id="downloadJsonTitle">
     <source>Download JSON</source>
     <target>Descargar JSON</target>
@@ -976,6 +968,10 @@
   <trans-unit id="titlePanelAlignBottom">
     <source>Bottom</source>
     <target>Abaixo</target>
+  </trans-unit>
+  <trans-unit id="duplicatePanel">
+    <source>Duplicate panel</source>
+    <target>Duplicar panel</target>
   </trans-unit>
 </body>
   </file>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -933,6 +933,50 @@
     <source>Paneles no afectados por este filtro</source>
     <target>Paneis non afectados por este filtro</target>
   </trans-unit>
+  <trans-unit id="opcionTitulo">
+    <source>NUEVO TEXTO</source>
+    <target>NUEVO PANEL DE TEXTO</target>
+  </trans-unit>
+  <trans-unit id="titlePanelOptions">
+    <source>Panel Options</source>
+    <target>Opcións do panel</target>
+  </trans-unit>
+  <trans-unit id="titlePanelAppearance">
+    <source>Appearance</source>
+    <target>Aparencia</target>
+  </trans-unit>
+  <trans-unit id="titlePanelRemoveBg">
+    <source>Remove panel background</source>
+    <target>Quitar fondo do panel</target>
+  </trans-unit>
+  <trans-unit id="titlePanelBgColor">
+    <source>Background color</source>
+    <target>Cor do fondo</target>
+  </trans-unit>
+  <trans-unit id="titlePanelShowBorder">
+    <source>Show border</source>
+    <target>Mostrar bordo</target>
+  </trans-unit>
+  <trans-unit id="titlePanelBorderColor">
+    <source>Border color</source>
+    <target>Cor do bordo</target>
+  </trans-unit>
+  <trans-unit id="titlePanelVerticalAlign">
+    <source>Vertical alignment</source>
+    <target>Aliñación vertical</target>
+  </trans-unit>
+  <trans-unit id="titlePanelAlignTop">
+    <source>Top</source>
+    <target>Arriba</target>
+  </trans-unit>
+  <trans-unit id="titlePanelAlignCenter">
+    <source>Center</source>
+    <target>Centro</target>
+  </trans-unit>
+  <trans-unit id="titlePanelAlignBottom">
+    <source>Bottom</source>
+    <target>Abaixo</target>
+  </trans-unit>
 </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -908,6 +908,10 @@
   </trans-unit>
   <!-- END SDA CUSTOM -->
   <!-- END SDA CUSTOM -->
+  <trans-unit id="opcionTitulo">
+    <source>NUEVO TEXTO</source>
+    <target>NUEVO PANEL DE TEXTO</target>
+  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -937,9 +937,9 @@
     <source>Appearance</source>
     <target>Aparencia</target>
   </trans-unit>
-  <trans-unit id="titlePanelRemoveBg">
-    <source>Remove panel background</source>
-    <target>Quitar fondo do panel</target>
+  <trans-unit id="titlePanelShowBg">
+    <source>Show panel background</source>
+    <target>Mostrar fondo do panel</target>
   </trans-unit>
   <trans-unit id="titlePanelBgColor">
     <source>Background color</source>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -902,7 +902,7 @@
     <target>Fallo en actualización do modelo</target>
   </trans-unit>
   <trans-unit id="opcionTitulo">
-    <source>NUEVO TEXTO</source>
+    <source>NUEVO PANEL DE TEXTO</source>
     <target>NUEVO PANEL DE TEXTO</target>
   </trans-unit>
   <trans-unit id="downloadJsonTitle">
@@ -926,51 +926,51 @@
     <target>Paneis non afectados por este filtro</target>
   </trans-unit>
   <trans-unit id="opcionTitulo">
-    <source>NUEVO TEXTO</source>
+    <source>NUEVO PANEL DE TEXTO</source>
     <target>NUEVO PANEL DE TEXTO</target>
   </trans-unit>
   <trans-unit id="titlePanelOptions">
-    <source>Panel Options</source>
+    <source>Opciones del panel</source>
     <target>Opcións do panel</target>
   </trans-unit>
   <trans-unit id="titlePanelAppearance">
-    <source>Appearance</source>
+    <source>Apariencia</source>
     <target>Aparencia</target>
   </trans-unit>
   <trans-unit id="titlePanelShowBg">
-    <source>Show panel background</source>
+    <source>Mostrar fondo del panel</source>
     <target>Mostrar fondo do panel</target>
   </trans-unit>
   <trans-unit id="titlePanelBgColor">
-    <source>Background color</source>
+    <source>Color de fondo</source>
     <target>Cor do fondo</target>
   </trans-unit>
   <trans-unit id="titlePanelShowBorder">
-    <source>Show border</source>
+    <source>Mostrar borde</source>
     <target>Mostrar bordo</target>
   </trans-unit>
   <trans-unit id="titlePanelBorderColor">
-    <source>Border color</source>
+    <source>Color del borde</source>
     <target>Cor do bordo</target>
   </trans-unit>
   <trans-unit id="titlePanelVerticalAlign">
-    <source>Vertical alignment</source>
+    <source>Alineación vertical</source>
     <target>Aliñación vertical</target>
   </trans-unit>
   <trans-unit id="titlePanelAlignTop">
-    <source>Top</source>
+    <source>Arriba</source>
     <target>Arriba</target>
   </trans-unit>
   <trans-unit id="titlePanelAlignCenter">
-    <source>Center</source>
+    <source>Centro</source>
     <target>Centro</target>
   </trans-unit>
   <trans-unit id="titlePanelAlignBottom">
-    <source>Bottom</source>
+    <source>Abajo</source>
     <target>Abaixo</target>
   </trans-unit>
   <trans-unit id="duplicatePanel">
-    <source>Duplicate panel</source>
+    <source>Duplicar panel</source>
     <target>Duplicar panel</target>
   </trans-unit>
 </body>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -901,10 +901,6 @@
     <source>Update Model Failed</source>
     <target>Fallo en actualización do modelo</target>
   </trans-unit>
-  <trans-unit id="opcionTitulo">
-    <source>NUEVO PANEL DE TEXTO</source>
-    <target>NUEVO PANEL DE TEXTO</target>
-  </trans-unit>
   <trans-unit id="downloadJsonTitle">
     <source>Download JSON</source>
     <target>Descargar JSON</target>
@@ -926,7 +922,7 @@
     <target>Paneis non afectados por este filtro</target>
   </trans-unit>
   <trans-unit id="opcionTitulo">
-    <source>NUEVO PANEL DE TEXTO</source>
+    <source>NUEVO TEXTO</source>
     <target>NUEVO PANEL DE TEXTO</target>
   </trans-unit>
   <trans-unit id="titlePanelOptions">


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaDA/issues/346
## Descripción del Cambio
Se añade funcionalidad para duplicar paneles de texto y editar su contenido mediante doble clic. Anteriormente estas opciones solo estaban disponibles para paneles gráficos.
- Se añade la opción "Duplicar panel" al menú contextual del panel de texto, permitiendo crear una copia del panel desplazada una posición hacia abajo
- Se implementa la edición del texto mediante doble clic, abriendo el diálogo de edición cuando el usuario hace doble clic sobre el panel (solo en modo edición)
- Se conecta el evento de duplicación con el método onDuplicatePanel existente en dashboard.component.ts
- La funcionalidad de duplicado es consistente con el comportamiento existente en paneles gráficos
- El doble clic solo funciona cuando el usuario está en modo edición (no para observadores)
- 
## Pruebas a realizar para validar el cambio

1.  Crear un panel de texto
2.  Abrir el menú contextual (tres puntos)
3.  Verificar que aparece la opción "Duplicar panel"
4.  Seleccionar la opción y confirmar que se crea un nuevo panel desplazado hacia abajo
5.  Verificar que el panel duplicado contiene el mismo contenido
6. Hacer doble clic sobre un panel de texto
7.  Verificar que se abre el diálogo de edición
8.  Modificar el texto y guardar
9.  Verificar que los cambios se reflejan correctamente
