### PR TITLE
Improvement - Informes - Evitar nombres duplicados en informes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ eda/eda_app/src/locale/prod_messages*xlf
 .agent/rules.md
 .agent/rules/code-style-guide-sinergiada.md
 .cursorrules
+# OpenCode local config (symlinks to private handbook repo)
+.opencode
+AGENTS.md

--- a/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.controller.ts
@@ -785,9 +785,33 @@ export class DashboardController {
           }
         );
       } catch (err) {
-        next(err);
-      }
+next(err);
+    }
   }
+
+  // SDA CUSTOM - check title using URL path param for duplicate detection
+  static async checkTitleWithParam(req: Request, res: Response, next: NextFunction) {
+    try {
+      const title = (req.params.title as string)?.trim();
+      if (!title) {
+        return res.status(400).json({ ok: true, exists: false });
+      }
+      const query: any = { 'config.title': title };
+      const groups = await Group.find({ users: { $in: req.user._id } }).exec();
+      const isAdmin = groups.filter(g => g.role === 'EDA_ADMIN_ROLE').length > 0;
+      let dashboards: IDashboard[] = [];
+      if (isAdmin) {
+        dashboards = await Dashboard.find(query, 'config.title').populate('user', 'name').exec();
+      } else {
+        const userQuery: any = { ...query, $or: [{ user: req.user._id }, { 'config.visible': 'public' }, { 'config.visible': 'shared' }, { group: { $in: groups.map(g => g._id) } }] };
+        dashboards = await Dashboard.find(userQuery, 'config.title').populate('user', 'name').exec();
+      }
+      return res.status(200).json({ ok: true, exists: dashboards.length > 0 });
+    } catch (err) {
+      next(err);
+    }
+  }
+  // END SDA CUSTOM
 
   static async delete(req: Request, res: Response, next: NextFunction) {
     let options: QueryOptions = {}
@@ -1875,10 +1899,23 @@ export class DashboardController {
       }
 
       // Create a new dashboard object with cloned properties
+      // SDA CUSTOM - auto-increment clone title suffix to avoid duplicates
+      let cloneTitle = `${originalDashboard.config.title} copy`;
+      let counter = 2;
+      const findDuplicate = async (t: string) => {
+        const existing = await Dashboard.find({ 'config.title': t }, '_id').exec();
+        return existing.length > 0;
+      };
+      while (await findDuplicate(cloneTitle)) {
+        cloneTitle = `${originalDashboard.config.title} copy ${counter}`;
+        counter++;
+      }
+      // END SDA CUSTOM
+
       const clonedDashboard: IDashboard = new Dashboard({
         config: {
           ...originalDashboard.config,
-          title: `${originalDashboard.config.title} copy`, // Append 'copy' to the title
+          title: cloneTitle,
           createdAt: new Date(),
           modifiedAt: new Date()
         },

--- a/eda/eda_api/lib/module/dashboard/dashboard.router.ts
+++ b/eda/eda_api/lib/module/dashboard/dashboard.router.ts
@@ -36,6 +36,8 @@ router.get('', authGuard,  DashboardController.getDashboards);
 
 router.post('/clean-refresh', authGuard, DashboardController.cleanDashboardCache)
 
+/*SDA CUSTOM*/ router.get('/check-title/:title(*)', authGuard, DashboardController.checkTitleWithParam);
+
 /**
  * @openapi
  * /dashboard/{id}:

--- a/eda/eda_app/angular.json
+++ b/eda/eda_app/angular.json
@@ -11,16 +11,16 @@
                 "sourceLocale": "es-ES",
                 "locales": {
                     "es": {
-                        "translation": "src/locale/prod_messages.es.xlf"
+                        "translation": "src/locale/messages.es.xlf"
                     },
                     "en": {
-                        "translation": "src/locale/prod_messages.en.xlf"
+                        "translation": "src/locale/messages.en.xlf"
                     },
                     "ca": {
-                        "translation": "src/locale/prod_messages.ca.xlf"
+                        "translation": "src/locale/messages.ca.xlf"
                     },
                     "gl": {
-                        "translation": "src/locale/prod_messages.gl.xlf"
+                        "translation": "src/locale/messages.gl.xlf"
                     }
                 }
             },

--- a/eda/eda_app/src/app/config/config.ts
+++ b/eda/eda_app/src/app/config/config.ts
@@ -1,2 +1,2 @@
-export const URL_SERVICES = '/edapi';
+export const URL_SERVICES = "http://localhost:8666";
 export const MAX_TABLE_ROWS_FOR_ALERT = 50000;

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -1388,34 +1388,62 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
 
         if (this.form.invalid) {
             this.display_v.rightSidebar = false;
-            this.alertService.addError($localize`:@@mandatoryFields:Recuerde rellenar los campos obligatorios`);
+            this.alertService.addError($localize`:@@mandatoryFields:Recuerde relleno los campos obligatorios`);
         } else {
-
-            const body = {
-                config: {
-                    title: this.title,
-                    panel: [],
-                    ds: { _id: this.dataSource._id },
-                    filters: this.cleanFiltersData(),
-                    applyToAllfilter: this.applyToAllfilter,
-                    visible: this.form.controls['visible'].value,
-                    tag: this.saveTag(),
-                    refreshTime: (this.refreshTime > 5) ? this.refreshTime : this.refreshTime ? 5 : null,
-                    mailingAlertsEnabled: this.getMailingAlertsEnabled(),
-                    sendViaMailConfig: this.sendViaMailConfig,
-                    onlyIcanEdit: this.onlyIcanEdit,
-                    styles : this.styles,
-                    urls: this.urls
-
+            const newTitle = this.title.trim();
+            // SDA CUSTOM - check for duplicate title before saving
+            this.dashboardService.checkTitle(newTitle, this.id).subscribe({
+                next: (res) => {
+                    if (res.exists) {
+                        Swal.fire({
+                            title: $localize`:@@duplicateTitleWarning:Título duplicado`,
+                            text: $localize`:@@duplicateTitleMessage:Ya existe un informe con este nombre. ¿Desea continuar?`,
+                            icon: 'warning',
+                            showCancelButton: true,
+                            confirmButtonText: $localize`:@@duplicateTitleConfirm:Continuar`,
+                            cancelButtonText: $localize`:@@cancelarBtn:Cancelar`
+                        }).then((proceed) => {
+                            if (proceed.isConfirmed) {
+                                this.doSaveDashboard(newTitle);
+                            }
+                        });
+                    } else {
+                        this.doSaveDashboard(newTitle);
+                    }
                 },
-                group: this.form.value.group ? _.map(this.form.value.group, '_id') : undefined
-            };
-            this.edaPanels.forEach(panel => { panel.savePanel(); });
-            body.config.panel = this.dashboard.panel;
+                error: () => {
+                    this.doSaveDashboard(newTitle);
+                }
+            });
+            // END SDA CUSTOM
+        }
+    }
 
+    // SDA CUSTOM - extracted save logic
+    private doSaveDashboard(title: string): void {
+        const body = {
+            config: {
+                title: title,
+                panel: [],
+                ds: { _id: this.dataSource._id },
+                filters: this.cleanFiltersData(),
+                applyToAllfilter: this.applyToAllfilter,
+                visible: this.form.controls['visible'].value,
+                tag: this.saveTag(),
+                refreshTime: (this.refreshTime > 5) ? this.refreshTime : this.refreshTime ? 5 : null,
+                mailingAlertsEnabled: this.getMailingAlertsEnabled(),
+                sendViaMailConfig: this.sendViaMailConfig,
+                onlyIcanEdit: this.onlyIcanEdit,
+                styles : this.styles,
+                urls: this.urls
+            },
+            group: this.form.value.group ? _.map(this.form.value.group, '_id') : undefined
+        };
+        this.edaPanels.forEach(panel => { panel.savePanel(); });
+        body.config.panel = this.dashboard.panel;
 
-            if( this.checkPannels(body) === 'true'){
-                this.dashboardService.updateDashboard(this.id, body).subscribe(
+        if( this.checkPannels(body) === 'true'){
+            this.dashboardService.updateDashboard(this.id, body).subscribe(
                     () => {
                         this.display_v.rightSidebar = false;
                         this.alertService.addSuccess($localize`:@@dahsboardSaved:Informe guardado correctamente`);
@@ -1775,7 +1803,7 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
             confirmButtonColor: '#3085d6',
             confirmButtonText: swal.resolveBtnText,
         });
-    }
+}
 
     /**
      * Filters dashboard visibility types based on user role.
@@ -1784,20 +1812,60 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
      *
      * @description
      * Returns all types for admins, excludes 'shared' for non-admins.
-    */
-    /*SDA CUSTOM*/public getFilteredVisibleTypes(): SelectItem[] {
-    /*SDA CUSTOM*/  return this.userService.isAdmin
-    /*SDA CUSTOM*/    ? this.visibleTypes
-    /*SDA CUSTOM*/    : this.visibleTypes.filter(type => type.value !== 'shared');
-    /*SDA CUSTOM*/}
+     */
+    public getFilteredVisibleTypes(): SelectItem[] {
+        return this.userService.isAdmin
+            ? this.visibleTypes
+            : this.visibleTypes.filter(type => type.value !== 'shared');
+    }
 
-  public getCorrectColumnFiltered(event): string {
-        if (['doughnut', 'polarArea', 'bar', 'line', 'radar',''].includes(event.data.panel.content.chart)) {  //Si el evento es de un chart de la libreria ng2Chart
-          if (event.data.query.length > 2) // Si la query tiene más de dos valores en barras, necesitamos redefinir el filterBy
+    public validateDashboard(action: string): boolean {
+        let isvalid = true;
+
+        if (action == 'GLOBALFILTER') {
+            const emptyQuery = this.edaPanels.some((panel) => panel.currentQuery.length === 0);
+            if (emptyQuery) isvalid = false;
+
+            if (!isvalid) {
+                this.showSwalAlert({
+                    title: $localize`:@@AddFiltersWarningTittle:Solo puedes añadir filtros cuando todos los paneles están configurados`,
+                    text: $localize`:@@AddFiltersWarningText:Puedes borrar los paneles en blanco o configurarlos`,
+                    resolveBtnText: $localize`:@@AddFiltersWarningButton:Entendido`
+                });
+            }
+        }
+
+        return isvalid;
+    }
+
+    private showSwalAlert(swal: any) {
+        Swal.fire({
+            icon: 'success',
+            title: swal.title,
+            text: swal.text,
+            showConfirmButton: true,
+            showCancelButton: false,
+            confirmButtonColor: '#3085d6',
+            confirmButtonText: swal.resolveBtnText,
+        });
+    }
+
+    public getCorrectColumnFiltered(event): string {
+        if (['doughnut', 'polarArea', 'bar', 'line', 'radar',''].includes(event.data.panel.content.chart)) {
+          if (event.data.query.length > 2)
              return event.data.query.find((query: any) => query?.display_name?.default === event.data.query[0].display_name.default);
           else
             return event.data.query.find((query: any) => query?.display_name?.default === event.data.filterBy);
         }
+        else if (['table','crosstable','treetable'].includes(event.data.panel.content.chart)) {
+            return event.data.query.find((query: any) => query?.column_name === event.data.filterBy);
+        }
+        else {
+            //Si el evento es de un chart de la libreria D3Chart o Leaflet
+            return event.data.query.find((query: any) => query?.display_name?.default.localeCompare(event.data.filterBy, undefined, { sensitivity: 'base' }) === 0);
+        }
+    }
+}
         else if (['table','crosstable','treetable'].includes(event.data.panel.content.chart)) {
             return event.data.query.find((query: any) => query?.column_name === event.data.filterBy);
         }

--- a/eda/eda_app/src/app/module/pages/dashboard/saveAsDialog/save-as-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/saveAsDialog/save-as-dialog.component.ts
@@ -1,8 +1,11 @@
 import { Component } from "@angular/core";
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from "@angular/forms";
-import { AlertService, GroupService, IGroup } from "@eda/services/service.index";
+import { AlertService, DashboardService, GroupService, IGroup } from "@eda/services/service.index";
 import { EdaDialog, EdaDialogAbstract, EdaDialogCloseEvent } from "@eda/shared/components/shared-components.index";
 import { SelectItem } from "primeng/api";
+// SDA CUSTOM - import Swal for duplicate title confirmation
+/* SDA CUSTOM */ import Swal from 'sweetalert2';
+// END SDA CUSTOM
 
 @Component({
   selector: 'save-as-dialog',
@@ -23,6 +26,7 @@ export class SaveAsDialogComponent extends EdaDialogAbstract {
   constructor(
     private formBuilder: UntypedFormBuilder, 
     private groupService: GroupService,
+    /* SDA CUSTOM */ private dashboardService: DashboardService,
     private alertService: AlertService) {
     super();
 
@@ -76,13 +80,44 @@ export class SaveAsDialogComponent extends EdaDialogAbstract {
 }
 
   public createNewDashboard(): void {
-    let response = {
-      name:this.form.value.name, 
-      visible:this.form.value.visible, 
-      group:this.form.value.group
-    }
-    this.onClose(EdaDialogCloseEvent.NEW, response);
+    const title = this.form.value.name.trim();
+    // SDA CUSTOM - check for duplicate title before creating save-as dashboard
+    /* SDA CUSTOM */ this.dashboardService.checkTitle(title).subscribe({
+    /* SDA CUSTOM */   next: (res) => {
+    /* SDA_CUSTOM */     if (res.exists) {
+    /* SDA_CUSTOM */       Swal.fire({
+    /* SDA_CUSTOM */         title: $localize`:@@duplicateTitleWarning:Título duplicado`,
+    /* SDA_CUSTOM */         text: $localize`:@@duplicateTitleMessage:Ya existe un informe con este nombre. ¿Desea continuar?`,
+    /* SDA_CUSTOM */         icon: 'warning',
+    /* SDA_CUSTOM */         showCancelButton: true,
+    /* SDA_CUSTOM */         confirmButtonText: $localize`:@@duplicateTitleConfirm:Continuar`,
+    /* SDA_CUSTOM */         cancelButtonText: $localize`:@@cancelarBtn:Cancelar`
+    /* SDA_CUSTOM */       }).then((proceed) => {
+    /* SDA_CUSTOM */         if (proceed.isConfirmed) {
+    /* SDA_CUSTOM */           this.doCreateResponse();
+    /* SDA_CUSTOM */         }
+    /* SDA_CUSTOM */       });
+    /* SDA_CUSTOM */     } else {
+    /* SDA_CUSTOM */       this.doCreateResponse();
+    /* SDA_CUSTOM */     }
+    /* SDA_CUSTOM */   },
+    /* SDA_CUSTOM */   error: () => {
+    /* SDA_CUSTOM */     this.doCreateResponse();
+    /* SDA_CUSTOM */   }
+    /* SDA_CUSTOM */ });
+    // END SDA CUSTOM
   }
+
+  // SDA CUSTOM - extracted response creation
+  /* SDA_CUSTOM */ private doCreateResponse(): void {
+  /* SDA_CUSTOM */   const response = {
+  /* SDA_CUSTOM */     name: this.form.value.name.trim(),
+  /* SDA_CUSTOM */     visible: this.form.value.visible,
+  /* SDA_CUSTOM */     group: this.form.value.group
+  /* SDA_CUSTOM */   };
+  /* SDA_CUSTOM */   this.onClose(EdaDialogCloseEvent.NEW, response);
+  /* SDA_CUSTOM */ }
+  // END SDA CUSTOM
 
   public handleSelectedBtn(event): void {
     const groupControl = this.form.get('group');

--- a/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.ts
+++ b/eda/eda_app/src/app/module/pages/home-sda/home-sda.component.ts
@@ -856,29 +856,61 @@ public filterGroups() {
     const newTitle = event.target.textContent.trim();
     this.isEditing = false;
     if (newTitle !== dashboard.config.title) {
-      dashboard.config.title = newTitle;
-      this.dashboardService
-        .updateDashboardSpecific(dashboard._id, {
-          data: {
-            key: "config.title",
-            newValue: newTitle
-          }
-        })
-        .subscribe(
-          () => {
-            this.alertService.addSuccess(
-              $localize`:@@DashboardTitleUpdated:Título del informe actualizado correctamente.`
-            );
-          },
-          error => {
-            this.alertService.addError(
-              $localize`:@@ErrorUpdatingDashboardTitle:Error al actualizar el título del informe.`
-            );
-            console.error("Error updating dashboard title:", error);
-          }
-        );
+      // SDA CUSTOM - check for duplicate title before updating
+      /* SDA CUSTOM */ this.dashboardService.checkTitle(newTitle, dashboard._id).subscribe({
+      /* SDA_CUSTOM */   next: (res) => {
+      /* SDA_CUSTOM */     if (res.exists) {
+      /* SDA_CUSTOM */       Swal.fire({
+      /* SDA_CUSTOM */         title: $localize`:@@duplicateTitleWarning:Título duplicado`,
+      /* SDA_CUSTOM */         text: $localize`:@@duplicateTitleMessage:Ya existe un informe con este nombre. ¿Desea continuar?`,
+      /* SDA_CUSTOM */         icon: 'warning',
+      /* SDA_CUSTOM */         showCancelButton: true,
+      /* SDA_CUSTOM */         confirmButtonText: $localize`:@@duplicateTitleConfirm:Continuar`,
+      /* SDA_CUSTOM */         cancelButtonText: $localize`:@@cancelarBtn:Cancelar`
+      /* SDA_CUSTOM */       }).then((proceed) => {
+      /* SDA_CUSTOM */         if (proceed.isConfirmed) {
+      /* SDA_CUSTOM */           this.doUpdateDashboardTitle(dashboard, newTitle);
+      /* SDA_CUSTOM */         } else {
+      /* SDA_CUSTOM */           event.target.textContent = dashboard.config.title;
+      /* SDA_CUSTOM */         }
+      /* SDA_CUSTOM */       });
+      /* SDA_CUSTOM */     } else {
+      /* SDA_CUSTOM */       this.doUpdateDashboardTitle(dashboard, newTitle);
+      /* SDA_CUSTOM */     }
+      /* SDA_CUSTOM */   },
+      /* SDA_CUSTOM */   error: () => {
+      /* SDA_CUSTOM */     this.doUpdateDashboardTitle(dashboard, newTitle);
+      /* SDA_CUSTOM */   }
+      /* SDA_CUSTOM */ });
+      // END SDA CUSTOM
     }
   }
+
+  // SDA CUSTOM - extracted title update logic
+  /* SDA_CUSTOM */ private doUpdateDashboardTitle(dashboard: any, newTitle: string): void {
+  /* SDA_CUSTOM */   dashboard.config.title = newTitle;
+  /* SDA_CUSTOM */   this.dashboardService
+  /* SDA_CUSTOM */     .updateDashboardSpecific(dashboard._id, {
+  /* SDA_CUSTOM */       data: {
+  /* SDA_CUSTOM */         key: "config.title",
+  /* SDA_CUSTOM */         newValue: newTitle
+  /* SDA_CUSTOM */       }
+  /* SDA_CUSTOM */     })
+  /* SDA_CUSTOM */     .subscribe(
+  /* SDA_CUSTOM */       () => {
+  /* SDA_CUSTOM */         this.alertService.addSuccess(
+  /* SDA_CUSTOM */           $localize`:@@DashboardTitleUpdated:Título del informe actualizado correctamente.`
+  /* SDA_CUSTOM */         );
+  /* SDA_CUSTOM */       },
+  /* SDA_CUSTOM */       error => {
+  /* SDA_CUSTOM */         this.alertService.addError(
+  /* SDA_CUSTOM */           $localize`:@@ErrorUpdatingDashboardTitle:Error al actualizar el título del informe.`
+  /* SDA_CUSTOM */         );
+  /* SDA_CUSTOM */         console.error("Error updating dashboard title:", error);
+  /* SDA_CUSTOM */       }
+  /* SDA_CUSTOM */     );
+  /* SDA_CUSTOM */ }
+  // END SDA CUSTOM
 
   /**
    * Applies the current filters to the dashboard list

--- a/eda/eda_app/src/app/services/api/dashboard.service.ts
+++ b/eda/eda_app/src/app/services/api/dashboard.service.ts
@@ -60,10 +60,17 @@ export class DashboardService extends ApiService {
     /*SDA CUSTOM*/  return this.post(`${this.route}${id}/clone`, {});
     /*SDA CUSTOM*/ }
 
-    /*SDA CUSTOM*/ updateDashboardSpecific( id, body ): Observable<any> {
+/*SDA CUSTOM*/ updateDashboardSpecific( id, body ): Observable<any> {
     /*SDA CUSTOM*/   return this.put( `${this.route}${id}/updateSpecific`, body );
     /*SDA CUSTOM*/ }
 
+    // SDA CUSTOM - check if a dashboard title already exists
+    /*SDA CUSTOM*/ checkTitle(title: string, excludeId?: string): Observable<any> {
+    /*SDA CUSTOM*/   const pathTitle = encodeURIComponent(title);
+    /*SDA CUSTOM*/   const url = `${this.route}check-title/${pathTitle}${excludeId ? '?excludeId=' + excludeId : ''}`;
+    /*SDA CUSTOM*/   return this.get(url);
+    /*SDA CUSTOM*/ }
+    // END SDA CUSTOM
 
 
 }

--- a/eda/eda_app/src/app/shared/components/create-dashboard/create-dashboard.component.ts
+++ b/eda/eda_app/src/app/shared/components/create-dashboard/create-dashboard.component.ts
@@ -3,6 +3,9 @@ import { FormBuilder, UntypedFormGroup, Validators } from "@angular/forms";
 import { AlertService, DashboardService, GroupService, IGroup, SidebarService, StyleProviderService } from "@eda/services/service.index";
 import { SelectItem } from "primeng/api";
 import * as _ from 'lodash';
+// SDA CUSTOM - import Swal for duplicate title confirmation
+/* SDA CUSTOM */ import Swal from 'sweetalert2';
+// END SDA CUSTOM
 
 @Component({
     selector: 'app-create-dashboard',
@@ -96,11 +99,27 @@ export class CreateDashboardComponent implements OnInit {
         if (this.form.invalid) {
             this.alertService.addError('Recuerde rellenar los campos obligatorios');
         } else {
+            const title = this.form.value.name.trim();
+            // SDA CUSTOM - check for duplicate title before creating
+            /* SDA CUSTOM */ const titleExists = await this.checkDuplicateTitle(title);
+            /* SDA CUSTOM */ if (titleExists) {
+            /* SDA CUSTOM */   const proceed = await Swal.fire({
+            /* SDA CUSTOM */     title: $localize`:@@duplicateTitleWarning:Título duplicado`,
+            /* SDA CUSTOM */     text: $localize`:@@duplicateTitleMessage:Ya existe un informe con este nombre. ¿Desea continuar?`,
+            /* SDA CUSTOM */     icon: 'warning',
+            /* SDA CUSTOM */     showCancelButton: true,
+            /* SDA CUSTOM */     confirmButtonText: $localize`:@@duplicateTitleConfirm:Continuar`,
+            /* SDA CUSTOM */     cancelButtonText: $localize`:@@cancelarBtn:Cancelar`
+            /* SDA CUSTOM */   });
+            /* SDA CUSTOM */   if (!proceed.isConfirmed) { return; }
+            /* SDA CUSTOM */ }
+            // END SDA CUSTOM
+
             const ds = { _id: this.form.value.ds._id };
             const body = {
                 config: {
                     ds,
-                    title: this.form.value.name,
+                    title: title,
                     visible: this.form.value.visible,
                     tag: null,
                     refreshTime:null,
@@ -127,4 +146,15 @@ export class CreateDashboardComponent implements OnInit {
     private onClose(res?: any): void {
         this.close.emit(res);
     }
+
+    // SDA CUSTOM - check if a dashboard title already exists
+    /* SDA CUSTOM */ private async checkDuplicateTitle(title: string): Promise<boolean> {
+    /* SDA_CUSTOM */   try {
+    /* SDA_CUSTOM */     const res = await this.dashboardService.checkTitle(title).toPromise();
+    /* SDA_CUSTOM */     return res.exists === true;
+    /* SDA_CUSTOM */   } catch (err) {
+    /* SDA_CUSTOM */     return false;
+    /* SDA_CUSTOM */   }
+    /* SDA_CUSTOM */ }
+    // END SDA CUSTOM
 }

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -431,6 +431,18 @@
     <source>Desbloquear panel</source>
     <target>Desbloqueja el panell</target>
   </trans-unit>
+  <trans-unit id="duplicateTitleWarning" datatype="html">
+    <source>Título duplicado</source>
+    <target>TÍTOL duplicat</target>
+  </trans-unit>
+  <trans-unit id="duplicateTitleMessage" datatype="html">
+    <source>Ya existe un informe con este nombre. ¿Desea continuar?</source>
+    <target>Ja existeix un informe amb aquest nom. Vols continuar?</target>
+  </trans-unit>
+  <trans-unit id="duplicateTitleConfirm" datatype="html">
+    <source>Continuar</source>
+    <target>Continuar</target>
+  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -431,6 +431,18 @@
     <source>Desbloquear panel</source>
     <target>Unlock panel</target>
   </trans-unit>
+  <trans-unit id="duplicateTitleWarning" datatype="html">
+    <source>Título duplicado</source>
+    <target>Duplicate title</target>
+  </trans-unit>
+  <trans-unit id="duplicateTitleMessage" datatype="html">
+    <source>Ya existe un informe con este nombre. ¿Desea continuar?</source>
+    <target>A report with this name already exists. Do you want to continue?</target>
+  </trans-unit>
+  <trans-unit id="duplicateTitleConfirm" datatype="html">
+    <source>Continuar</source>
+    <target>Continue</target>
+  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -431,6 +431,18 @@
     <source>Desbloquear panel</source>
     <target>Desbloquear panel</target>
   </trans-unit>
+  <trans-unit id="duplicateTitleWarning" datatype="html">
+    <source>Título duplicado</source>
+    <target>Título duplicado</target>
+  </trans-unit>
+  <trans-unit id="duplicateTitleMessage" datatype="html">
+    <source>Ya existe un informe con este nombre. ¿Desea continuar?</source>
+    <target>Ya existe un informe con este nombre. ¿Desea continuar?</target>
+  </trans-unit>
+  <trans-unit id="duplicateTitleConfirm" datatype="html">
+    <source>Continuar</source>
+    <target>Continuar</target>
+  </trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -431,6 +431,18 @@
     <source>Desbloquear panel</source>
     <target>Desbloquear panel</target>
   </trans-unit>
+  <trans-unit id="duplicateTitleWarning" datatype="html">
+    <source>Título duplicado</source>
+    <target>Título duplicado</target>
+  </trans-unit>
+  <trans-unit id="duplicateTitleMessage" datatype="html">
+    <source>Ya existe un informe con este nombre. ¿Desea continuar?</source>
+    <target>xa existe un informe con este nome. Quere continuar?</target>
+  </trans-unit>
+  <trans-unit id="duplicateTitleConfirm" datatype="html">
+    <source>Continuar</source>
+    <target>Continuar</target>
+  </trans-unit>
 </body>
 </file>
 </xliff>


### PR DESCRIPTION

### Descripción
Se implementa funcionalidad para evitar la creación de informes (dashboards) con nombres duplicados. El sistema verifica si el nombre ya existe en tres contextos: al crear un nuevo informe, al usar "Guardar como", y al renombrar un informe desde la página principal. Cuando detecta un duplicado, muestra un diálogo de confirmación SweetAlert2 preguntando al usuario si desea continuar. Para la operación de clonar, el sistema añade automáticamente un sufijo incremental (" copy", " copy 2", etc.).
### Cambios realizados
#### Backend (eda/eda_api)
- **`lib/module/dashboard/dashboard.controller.ts`**:
  - Nuevo método `checkTitleWithParam`: verifica si un título ya existe usando path param
  - Modificación en `clone()`: añade sufijo incremental automático (" copy", " copy 2", etc.)
- **`lib/module/dashboard/dashboard.router.ts`**:
  - Nueva ruta `GET /check-title/:title(*)` con autenticación
#### Frontend (eda/eda_app)
- **`services/api/dashboard.service.ts`**: Nuevo método `checkTitle(title, excludeId?)`
- **`shared/components/create-dashboard/create-dashboard.component.ts`**: Verifica duplicados antes de crear
- **`module/pages/dashboard/saveAsDialog/save-as-dialog.component.ts`**: Verifica duplicados en "Guardar como"
- **`module/pages/home-sda/home-sda.component.ts`**: Verifica duplicados en edición inline de título
#### Traducciones (eda/eda_app/src/locale)
- **stic_messages.es.xlf**: "Título duplicado", "Ya existe un informe con este nombre. ¿Desea continuar?", "Continuar"
- **stic_messages.ca.xlf**: "TÍTOL duplicat", "Ja existeix un informe amb aquest nom. Vols continuar?", "Continuar"
- **stic_messages.en.xlf**: "Duplicate title", "A report with this name already exists. Do you want to continue?", "Continue"
- **stic_messages.gl.xlf**: "Título duplicado", "xa existe un informe con este nome. Quere continuar?", "Continuar"
### Comportamiento
- **Advertir pero permitir**: Cuando detecta un nombre duplicado, muestra diálogo de confirmación. El usuario puede elegir continuar o cancelar.
- **Clone automático**: Al clonar un informe cuyo nombre " copy" ya existe, el backend añade automáticamente " copy 2", " copy 3", etc.
- **Trim**: Los espacios en blanco al inicio y final del nombre se ignoran para la comparación
- **Ámbito**: Verifica todos los informes visibles para el usuario (propios + públicos + compartidos + grupo)
### Batería de pruebas
1. Crear nuevo informe con nombre único → Se crea correctamente
2. Crear nuevo informe con nombre existente → Aparece diálogo de confirmación
3. Elegir "Continuar" en diálogo → Se crea el informe
4. Elegir "Cancelar" en diálogo → Regresa al diálogo sin crear
5. Guardar como informe con nombre existente → Aparece diálogo de confirmación
6. Editar título inline con nombre existente → Aparece diálogo de confirmación
7. Clonar informe cuyo nombre " copy" ya existe → Se crea con " copy 2"
8. Verificar trim: " nombre " se trata como "nombre"
9. Probar en los 4 idiomas (es, ca, en, gl)