### PR TITLE
Hotfix - Filtros - Filtros de URL no funcionan con listas desplegables

### DIFF
--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
@@ -541,7 +541,7 @@ export class GlobalFilterComponent implements OnInit {
 
                 globalFilter.selectedItems = globalFilter.selectedIdValues?.map(siv => {
                     const value = data.filter(d => d.id === siv);
-                    return value[0].value;
+/*SDA CUSTOM*/      return value[0]?.value ?? siv;
                 })
 
 
@@ -599,6 +599,13 @@ export class GlobalFilterComponent implements OnInit {
 
                     if (columnName === paramColumn) {
                         filter.selectedItems = _.split(urlParams[param], '|');
+/*SDA CUSTOM*/          if (filter.selectedColumn?.valueListSource) {
+/*SDA CUSTOM*/          // IDs differ from labels: set nulls so loadGlobalFiltersData resolves labels → ids
+/*SDA CUSTOM*/              filter.selectedIdValues = [... _.split(urlParams[param], '|')];
+/*SDA CUSTOM*/          } else {
+/*SDA CUSTOM*/              // No valueListSource: label and id are the same value
+/*SDA CUSTOM*/              filter.selectedIdValues = [...filter.selectedItems];
+/*SDA CUSTOM*/          }
 
                         filter.panelList
                             .map(id => this.dashboard.panels.find(p => p.id === id))


### PR DESCRIPTION
Este PR se hace como continuación del pr https://github.com/SinergiaTIC/SinergiaDA/pull/463 porque se cerró la rama y se volvió a crear y se ha tenido que recrear el PR. 

Descripción del Cambio
Se implementa el código para que se puedan gestionar los filtros por url para campos del tipo value list source

Issue(s) resuelto(s)
solves https://github.com/SinergiaTIC/SinergiaDA/issues/388
Pruebas a realizar para validar el cambio
Hacer un informe con un filtro del tipo value list source y comprobar que el filtro se aplica.
Hacer también un filtro "normal" para comprobar que se mantiene la funcionalidad habitual.