### PR TITLE
Enhancement - Informes - Incluir agregación "no agrupación"

### DIFF
--- a/eda/eda_api/lib/services/query-builder/qb-systems/bigquery-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/bigquery-builder.service.ts
@@ -9,7 +9,7 @@ export class BigQueryBuilderService extends QueryBuilderService {
   }
 
   public normalQuery(columns: string[], origin: string, dest: any[], joinTree: any[], grouping: any[], filters: any[], havingFilters: any[], 
-    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any ) {
+    /* SDA CUSTOM */ tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any ) {
     let o = tables.filter(table => table.name === origin).map(table => { return table.query ? table.query : table.name })[0];
     let myQuery = '';
 

--- a/eda/eda_api/lib/services/query-builder/qb-systems/bigquery-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/bigquery-builder.service.ts
@@ -9,7 +9,7 @@ export class BigQueryBuilderService extends QueryBuilderService {
   }
 
   public normalQuery(columns: string[], origin: string, dest: any[], joinTree: any[], grouping: any[], filters: any[], havingFilters: any[], 
-    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any> ,schema: string, database: string, forSelector: any ) {
+    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any ) {
     let o = tables.filter(table => table.name === origin).map(table => { return table.query ? table.query : table.name })[0];
     let myQuery = '';
 

--- a/eda/eda_api/lib/services/query-builder/qb-systems/mongodb-builder-service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/mongodb-builder-service.ts
@@ -250,7 +250,7 @@ export class MongoDBBuilderService {
 
 
     public normalQuery(columns: string[], origin: string, dest: any[], joinTree: any[], grouping: any[], filters: any[], havingFilters: any[],
-        tables: Array<any>, limit: number, joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any) {
+        /* SDA CUSTOM */ tables: Array<any>, limit: number, joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any) {
 
     }
 

--- a/eda/eda_api/lib/services/query-builder/qb-systems/mongodb-builder-service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/mongodb-builder-service.ts
@@ -250,7 +250,7 @@ export class MongoDBBuilderService {
 
 
     public normalQuery(columns: string[], origin: string, dest: any[], joinTree: any[], grouping: any[], filters: any[], havingFilters: any[],
-        tables: Array<any>, limit: number, joinType: string, valueListJoins: Array<any>, schema: string, database: string, forSelector: any) {
+        tables: Array<any>, limit: number, joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any) {
 
     }
 

--- a/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
@@ -210,7 +210,7 @@ export class MySqlBuilderService extends QueryBuilderService {
   }
 
   public normalQuery(columns: string[], origin: string, dest: any[], joinTree: any[], grouping: any[], filters: any[], havingFilters: any[], 
-    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any> ,schema: string, database: string, forSelector: any, sortedFilters: any[]) {
+    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean ,schema: string, database: string, forSelector: any, sortedFilters: any[]) {
 
     let o = tables.filter(table => table.name === origin).map(table => { return table.query ? table.query : table.name })[0];
     let myQuery = `SELECT ${columns.join(', ')} \nFROM ${o}`;
@@ -262,7 +262,7 @@ export class MySqlBuilderService extends QueryBuilderService {
     }
 
     // GroupBy
-    if (grouping.length > 0) {
+    if (grouping.length > 0 && ((groupByEnabled))) {
       myQuery += '\ngroup by ' + grouping.join(', ');
     }
 

--- a/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
@@ -262,9 +262,9 @@ export class MySqlBuilderService extends QueryBuilderService {
     }
 
     // GroupBy
-    if (grouping.length > 0 && ((groupByEnabled))) {
-      myQuery += '\ngroup by ' + grouping.join(', ');
-    }
+    /* SDA CUSTOM */ if (grouping.length > 0 && ((groupByEnabled))) {
+    /* SDA CUSTOM */   myQuery += '\ngroup by ' + grouping.join(', ');
+    /* SDA CUSTOM */ }
 
     //HAVING 
     myQuery += this.getHavingFilters(havingFilters);

--- a/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
@@ -210,7 +210,7 @@ export class MySqlBuilderService extends QueryBuilderService {
   }
 
   public normalQuery(columns: string[], origin: string, dest: any[], joinTree: any[], grouping: any[], filters: any[], havingFilters: any[], 
-    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean ,schema: string, database: string, forSelector: any, sortedFilters: any[]) {
+    /* SDA CUSTOM */ tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean ,schema: string, database: string, forSelector: any, sortedFilters: any[]) {
 
     let o = tables.filter(table => table.name === origin).map(table => { return table.query ? table.query : table.name })[0];
     let myQuery = `SELECT ${columns.join(', ')} \nFROM ${o}`;

--- a/eda/eda_api/lib/services/query-builder/qb-systems/oracle-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/oracle-builder.service.ts
@@ -8,7 +8,7 @@ export class OracleBuilderService extends QueryBuilderService {
     }
 
   public normalQuery(columns: string[], origin: string, dest: any[], joinTree: any[], grouping: any[], filters: any[], havingFilters: any[], 
-    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any ) {
+    /* SDA CUSTOM */ tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any ) {
       
     let o = tables.filter(table => table.name === origin)
       .map(table => { return table.query ? this.cleanViewString(table.query) : table.name })[0];

--- a/eda/eda_api/lib/services/query-builder/qb-systems/oracle-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/oracle-builder.service.ts
@@ -8,7 +8,7 @@ export class OracleBuilderService extends QueryBuilderService {
     }
 
   public normalQuery(columns: string[], origin: string, dest: any[], joinTree: any[], grouping: any[], filters: any[], havingFilters: any[], 
-    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any> ,schema: string, database: string, forSelector: any ) {
+    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any ) {
       
     let o = tables.filter(table => table.name === origin)
       .map(table => { return table.query ? this.cleanViewString(table.query) : table.name })[0];

--- a/eda/eda_api/lib/services/query-builder/qb-systems/pg-builder-service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/pg-builder-service.ts
@@ -168,7 +168,7 @@ export class PgBuilderService extends QueryBuilderService {
   }
 
   public normalQuery(columns: string[], origin: string, dest: any[], joinTree: any[], grouping: any[], filters: any[], havingFilters: any[], 
-    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any ) {
+    /* SDA CUSTOM */ tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any ) {
 
     if (schema === 'null' || schema === '') {
       schema = 'public';

--- a/eda/eda_api/lib/services/query-builder/qb-systems/pg-builder-service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/pg-builder-service.ts
@@ -168,7 +168,7 @@ export class PgBuilderService extends QueryBuilderService {
   }
 
   public normalQuery(columns: string[], origin: string, dest: any[], joinTree: any[], grouping: any[], filters: any[], havingFilters: any[], 
-    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any> ,schema: string, database: string, forSelector: any ) {
+    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any ) {
 
     if (schema === 'null' || schema === '') {
       schema = 'public';

--- a/eda/eda_api/lib/services/query-builder/qb-systems/snowflake-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/snowflake-builder.service.ts
@@ -8,7 +8,7 @@ export class SnowFlakeBuilderService extends QueryBuilderService {
     }
 
   public normalQuery(columns: string[], origin: string, dest: any[], joinTree: any[], grouping: any[], filters: any[], havingFilters: any[], 
-    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any> ,schema: string, database: string, forSelector: any ) {
+    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any ) {
       
     let SCHEMA = `${schema}`;
 

--- a/eda/eda_api/lib/services/query-builder/qb-systems/snowflake-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/snowflake-builder.service.ts
@@ -8,7 +8,7 @@ export class SnowFlakeBuilderService extends QueryBuilderService {
     }
 
   public normalQuery(columns: string[], origin: string, dest: any[], joinTree: any[], grouping: any[], filters: any[], havingFilters: any[], 
-    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any ) {
+    /* SDA CUSTOM */ tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any ) {
       
     let SCHEMA = `${schema}`;
 

--- a/eda/eda_api/lib/services/query-builder/qb-systems/sqlserver-builder-service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/sqlserver-builder-service.ts
@@ -8,7 +8,7 @@ export class SQLserviceBuilderService extends QueryBuilderService {
     }
 
   public normalQuery(columns: string[], origin: string, dest: any[], joinTree: any[], grouping: any[], filters: any[], havingFilters: any[], 
-    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any ) {
+    /* SDA CUSTOM */ tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any ) {
       
     let SCHEMA = `${schema}`;
 

--- a/eda/eda_api/lib/services/query-builder/qb-systems/sqlserver-builder-service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/sqlserver-builder-service.ts
@@ -8,7 +8,7 @@ export class SQLserviceBuilderService extends QueryBuilderService {
     }
 
   public normalQuery(columns: string[], origin: string, dest: any[], joinTree: any[], grouping: any[], filters: any[], havingFilters: any[], 
-    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any> ,schema: string, database: string, forSelector: any ) {
+    tables: Array<any>, limit: number,  joinType: string, valueListJoins: Array<any>, groupByEnabled:boolean, schema: string, database: string, forSelector: any ) {
       
     let SCHEMA = `${schema}`;
 

--- a/eda/eda_api/lib/services/query-builder/query-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/query-builder.service.ts
@@ -58,7 +58,7 @@ export abstract class QueryBuilderService {
     abstract processFilter(filter: any, columnType: string);
     abstract normalQuery(columns: string[], origin: string, dest: any[], joinTree: any[],
         grouping: any[], filters: any[], havingFilters: any[], tables: Array<any>, limit: number, 
-        joinType: string, valueListJoins:any[], groupByEnabled?:boolean, Schema?: string, database?: string, forSelector?: any, sortedFilters?: any[] );
+        /* SDA CUSTOM */ joinType: string, valueListJoins:any[], groupByEnabled?:boolean, Schema?: string, database?: string, forSelector?: any, sortedFilters?: any[] );
     abstract sqlQuery(query: string, filters: any[], filterMarks: string[]): string;
     abstract buildPermissionJoin(origin: string, join: string[], permissions: any[], schema?: string);
     abstract parseSchema(tables: string[], schema?: string, database?: string);
@@ -368,7 +368,7 @@ export abstract class QueryBuilderService {
                 .map(table => { return { name: table.table_name, query: table.query } });
 
             this.query = this.normalQuery(columns, origin, dest, joinTree, grouping,  filters, havingFilters,  tables,
-                this.queryTODO.queryLimit,   this.queryTODO.joinType, valueListJoins, groupByEnabled, this.dataModel.ds.connection.schema, 
+                /* SDA CUSTOM */ this.queryTODO.queryLimit,   this.queryTODO.joinType, valueListJoins, groupByEnabled, this.dataModel.ds.connection.schema, 
                 this.dataModel.ds.connection.database, this.queryTODO.forSelector, this.queryTODO.sortedFilters);
             
             return this.query;

--- a/eda/eda_api/lib/services/query-builder/query-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/query-builder.service.ts
@@ -350,7 +350,7 @@ export abstract class QueryBuilderService {
         const tables = this.dataModel.ds.model.tables.map(table => ({ name: table.table_name, query: table.query }));
         const joinType = this.queryTODO.joinType;
         const queryLimit = this.queryTODO.queryLimit;
-        const groupByEnabled = this.queryTODO.groupByEnabled !== undefined ? this.queryTODO.groupByEnabled : true;
+        /* SDA CUSTOM */ const groupByEnabled = this.queryTODO.groupByEnabled !== undefined ? this.queryTODO.groupByEnabled : true;
         const schema = this.dataModel.ds.connection.schema || 'public'; 
         const database = this.dataModel.ds.connection.database; 
         const forSelector = this.queryTODO.forSelector; 

--- a/eda/eda_api/lib/services/query-builder/query-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/query-builder.service.ts
@@ -58,7 +58,7 @@ export abstract class QueryBuilderService {
     abstract processFilter(filter: any, columnType: string);
     abstract normalQuery(columns: string[], origin: string, dest: any[], joinTree: any[],
         grouping: any[], filters: any[], havingFilters: any[], tables: Array<any>, limit: number, 
-        joinType: string,valueListJoins:any[], Schema?: string, database?: string, forSelector?: any, sortedFilters?: any[] );
+        joinType: string, valueListJoins:any[], groupByEnabled?:boolean, Schema?: string, database?: string, forSelector?: any, sortedFilters?: any[] );
     abstract sqlQuery(query: string, filters: any[], filterMarks: string[]): string;
     abstract buildPermissionJoin(origin: string, join: string[], permissions: any[], schema?: string);
     abstract parseSchema(tables: string[], schema?: string, database?: string);
@@ -350,6 +350,7 @@ export abstract class QueryBuilderService {
         const tables = this.dataModel.ds.model.tables.map(table => ({ name: table.table_name, query: table.query }));
         const joinType = this.queryTODO.joinType;
         const queryLimit = this.queryTODO.queryLimit;
+        const groupByEnabled = this.queryTODO.groupByEnabled !== undefined ? this.queryTODO.groupByEnabled : true;
         const schema = this.dataModel.ds.connection.schema || 'public'; 
         const database = this.dataModel.ds.connection.database; 
         const forSelector = this.queryTODO.forSelector; 
@@ -367,7 +368,7 @@ export abstract class QueryBuilderService {
                 .map(table => { return { name: table.table_name, query: table.query } });
 
             this.query = this.normalQuery(columns, origin, dest, joinTree, grouping,  filters, havingFilters,  tables,
-                this.queryTODO.queryLimit,   this.queryTODO.joinType, valueListJoins, this.dataModel.ds.connection.schema, 
+                this.queryTODO.queryLimit,   this.queryTODO.joinType, valueListJoins, groupByEnabled, this.dataModel.ds.connection.schema, 
                 this.dataModel.ds.connection.database, this.queryTODO.forSelector, this.queryTODO.sortedFilters);
             
             return this.query;

--- a/eda/eda_app/src/app/config/config.ts
+++ b/eda/eda_app/src/app/config/config.ts
@@ -1,3 +1,2 @@
-export const URL_SERVICES = 'http://localhost:8666';
-
+export const URL_SERVICES = '/edapi';
 export const MAX_TABLE_ROWS_FOR_ALERT = 50000;

--- a/eda/eda_app/src/app/config/config.ts
+++ b/eda/eda_app/src/app/config/config.ts
@@ -1,2 +1,3 @@
-export const URL_SERVICES = '/edapi';
+export const URL_SERVICES = 'http://localhost:8666';
+
 export const MAX_TABLE_ROWS_FOR_ALERT = 50000;

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.html
@@ -34,11 +34,8 @@
             <hr>
 
             <div class="aggregation-list" >
-                <div class="aggregation-box" *ngFor="let aggregation of aggregationsTypes"
-                    (click)="allowedAggregations && addAggregation(aggregation)"
-                    [ngStyle]="{'cursor': !allowedAggregations ? 'not-allowed' : 'pointer'}"
-                    [ngClass]="aggregation.selected === true ? 'aggregation-active' : ''">
-                    <span>{{getAggName(aggregation.value)}}</span>
+<!--SDA CUSTOM-->                <div class="aggregation-box" *ngFor="let aggregation of aggregationsTypes" (click)="allowedAggregations && groupByEnabled && addAggregation(aggregation)" [ngStyle]="{'cursor': (!allowedAggregations || !groupByEnabled) ? 'not-allowed' : 'pointer'}" [ngClass]="aggregation.selected === true ? 'aggregation-active' : ''">
+<!--SDA CUSTOM-->                 <span>{{getAggName(aggregation.value)}}</span>
                 </div>
             </div>
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/column-dialog/column-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output, ViewChild } from '@angular/core';
+/* SDA CUSTOM */ import { Component, EventEmitter, Output, ViewChild, Input } from '@angular/core';
 import { SelectItem } from 'primeng/api';
 import { EdaDialog, EdaDialogCloseEvent, EdaDialogAbstract, EdaDatePickerComponent } from '@eda/shared/components/shared-components.index';
 import {
@@ -24,6 +24,8 @@ import { aggTypes } from 'app/config/aggretation-types';
 export class ColumnDialogComponent extends EdaDialogAbstract {
 
     @ViewChild('myCalendar', { static: false }) datePicker: EdaDatePickerComponent;
+/* SDA CUSTOM */    @Input() groupByEnabled: boolean;
+/* SDA CUSTOM */    @Output() groupByEnabledChange: EventEmitter<boolean> = new EventEmitter<boolean>();
     @Output() updateSortedFiltersColumnDialog: EventEmitter<any> = new EventEmitter<any>();
 
     public dialog: EdaDialog;

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
@@ -403,7 +403,7 @@
 <!-- SDA CUSTOM -->                     <i *ngIf="atLeastThereIsOneWithAggregation" class="pi pi-exclamation-circle" [pTooltip]="groupByDisabledReasonMessage" tooltipPosition="left" style="color: #ff9800; cursor: help; font-size: 1.1em; margin-right: 4px;"></i>
 <!-- SDA CUSTOM -->                     <!-- Info icon when in Do not group mode -->
 <!-- SDA CUSTOM -->                     <i *ngIf="!groupByEnabled && !atLeastThereIsOneWithAggregation" class="pi pi-info-circle" [pTooltip]="groupByDisabledAggregationsMessage" tooltipPosition="left" style="color: #2196f3; cursor: help; font-size: 1.1em; margin-right: 4px;"></i>
-<!-- SDA CUSTOM -->                     <p-inputSwitch (onChange)="groupByEnabledButton()" [(ngModel)]="groupByEnabled" [disabled]="atLeastThereIsOneWithAggregation"></p-inputSwitch>
+<!-- SDA CUSTOM -->                     <p-inputSwitch [(ngModel)]="groupByEnabled" [disabled]="atLeastThereIsOneWithAggregation"></p-inputSwitch>
 <!-- SDA CUSTOM -->             </div>
 
                                 <div class="col-3 md:col-12 buttonAndOr d-flex justify-content-end">

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
@@ -402,9 +402,9 @@
                                     <button pButton (click)="onWhatIfDialog()" icon="pi pi-question-circle" class="p-button-info p-button-outlined button-whatif ml-2" label="What IF"></button>
                                 </div-->
 
-                                <div class="col-3 md:col-12 buttonAndOr d-flex justify-content-end">
-                                    <button pButton (click)="groupByEnabledButton()" class="p-button-outlined ml-2" style="min-width: 120px; justify-content: center;">{{groupByEnabledMessage}}</button>
-                                </div>
+                                <!-- SDA CUSTOM --> <div class="col-3 md:col-12 buttonAndOr d-flex justify-content-end">
+                                <!-- SDA CUSTOM -->     <button pButton (click)="groupByEnabledButton()" class="p-button-outlined ml-2" style="min-width: 120px; justify-content: center;">{{groupByEnabledMessage}}</button>
+                                <!-- SDA CUSTOM --> </div>
 
                                 <div class="col-3 md:col-12 buttonAndOr d-flex justify-content-end">
                                     <button pButton (click)="filterAndOrDialog()" icon="pi pi-filter" class="p-button-outlined ml-2" i18n-label="@@filterSettings" label="Configuración de filtros"></button>

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
@@ -404,9 +404,13 @@
 
 <!-- SDA CUSTOM -->             <div class="col-3 md:col-12 buttonAndOr d-flex justify-content-end">
 <!-- SDA CUSTOM -->                 <!-- <button pButton (click)="groupByEnabledButton()" class="p-button-outlined ml-2" style="width: 165px; justify-content: center;">{{groupByEnabledMessage}}</button> -->
-<!-- SDA CUSTOM -->                 <div class="flex flex-row align-items-center justify-content gap-2">
+<!-- SDA CUSTOM -->                 <div class="flex flex-row align-items-center justify-content gap-2" style="width: 100%;">
 <!-- SDA CUSTOM -->                     <p-inputSwitch (onChange)="groupByEnabledButton()" [(ngModel)]="groupByEnabled" [disabled]="atLeastThereIsOneWithAggregation"></p-inputSwitch>
 <!-- SDA CUSTOM -->                     <h5 class="title-datamodel" style="min-width: 120px; margin: 0;">{{groupByEnabledMessage}}</h5>
+<!-- SDA CUSTOM -->                     <!-- Info icon when switch is disabled -->
+<!-- SDA CUSTOM -->                     <i *ngIf="atLeastThereIsOneWithAggregation" class="pi pi-exclamation-circle" [pTooltip]="groupByDisabledReasonMessage" tooltipPosition="left" style="color: #ff9800; cursor: help; font-size: 1.1em;"></i>
+<!-- SDA CUSTOM -->                     <!-- Info icon when in Do not group mode -->
+<!-- SDA CUSTOM -->                     <i *ngIf="!groupByEnabled && !atLeastThereIsOneWithAggregation" class="pi pi-info-circle" [pTooltip]="groupByDisabledAggregationsMessage" tooltipPosition="left" style="color: #2196f3; cursor: help; font-size: 1.1em;"></i>
 <!-- SDA CUSTOM -->                 </div>
 <!-- SDA CUSTOM -->             </div>
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
@@ -403,7 +403,7 @@
                                 </div-->
 
                                 <!-- SDA CUSTOM --> <div class="col-3 md:col-12 buttonAndOr d-flex justify-content-end">
-                                <!-- SDA CUSTOM -->     <button pButton (click)="groupByEnabledButton()" class="p-button-outlined ml-2" style="min-width: 120px; justify-content: center;">{{groupByEnabledMessage}}</button>
+                                <!-- SDA CUSTOM -->     <button pButton (click)="groupByEnabledButton()" class="p-button-outlined ml-2" style="width: 165px; justify-content: center;">{{groupByEnabledMessage}}</button>
                                 <!-- SDA CUSTOM --> </div>
 
                                 <div class="col-3 md:col-12 buttonAndOr d-flex justify-content-end">

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
@@ -402,9 +402,13 @@
                                     <button pButton (click)="onWhatIfDialog()" icon="pi pi-question-circle" class="p-button-info p-button-outlined button-whatif ml-2" label="What IF"></button>
                                 </div-->
 
-                                <!-- SDA CUSTOM --> <div class="col-3 md:col-12 buttonAndOr d-flex justify-content-end">
-                                <!-- SDA CUSTOM -->     <button pButton (click)="groupByEnabledButton()" class="p-button-outlined ml-2" style="width: 165px; justify-content: center;">{{groupByEnabledMessage}}</button>
-                                <!-- SDA CUSTOM --> </div>
+<!-- SDA CUSTOM -->             <div class="col-3 md:col-12 buttonAndOr d-flex justify-content-end">
+<!-- SDA CUSTOM -->                 <!-- <button pButton (click)="groupByEnabledButton()" class="p-button-outlined ml-2" style="width: 165px; justify-content: center;">{{groupByEnabledMessage}}</button> -->
+<!-- SDA CUSTOM -->                 <div class="flex flex-row align-items-center justify-content gap-2">
+<!-- SDA CUSTOM -->                     <p-inputSwitch (onChange)="groupByEnabledButton()" [(ngModel)]="groupByEnabled" [disabled]="atLeastThereIsOneWithAggregation"></p-inputSwitch>
+<!-- SDA CUSTOM -->                     <h5 class="title-datamodel" style="min-width: 120px; margin: 0;">{{groupByEnabledMessage}}</h5>
+<!-- SDA CUSTOM -->                 </div>
+<!-- SDA CUSTOM -->             </div>
 
                                 <div class="col-3 md:col-12 buttonAndOr d-flex justify-content-end">
                                     <button pButton (click)="filterAndOrDialog()" icon="pi pi-filter" class="p-button-outlined ml-2" i18n-label="@@filterSettings" label="Configuración de filtros"></button>
@@ -626,7 +630,7 @@
 
 </eda-page-dialog>
 
-<app-column-dialog *ngIf="configController" [controller]="configController" (updateSortedFiltersColumnDialog)="updateSortedFiltersColumnDialogFunction($event)"></app-column-dialog>
+<!-- SDA CUSTOM --> <app-column-dialog *ngIf="configController" [controller]="configController" (updateSortedFiltersColumnDialog)="updateSortedFiltersColumnDialogFunction($event)" [(groupByEnabled)]="groupByEnabled"></app-column-dialog>
 
 <app-filter-dialog *ngIf="filterController" [controller]="filterController" (updateSortedFiltersFilterDialog)="updateSortedFiltersFilterDialogFunction($event)"></app-filter-dialog>
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
@@ -386,7 +386,7 @@
                                 </div>
                                 <!-- SDA CUSTOM div class="col-4 md:col-12 flex infoJoin" -->
                                 <!-- SDA CUSTOM-->
-                                 <div class="col-6 md:col-12 flex infoJoin" >
+                                 <div class="col-3 md:col-12 flex infoJoin" >
 
                                     <span i18n="@@joinTypeH4">
                                         Tipo de intersección: &nbsp;
@@ -401,6 +401,10 @@
                                 <!-- div class="col-2 col-offset-3 md:col-12 infoFiltres d-flex justify-content-end">
                                     <button pButton (click)="onWhatIfDialog()" icon="pi pi-question-circle" class="p-button-info p-button-outlined button-whatif ml-2" label="What IF"></button>
                                 </div-->
+
+                                <div class="col-3 md:col-12 buttonAndOr d-flex justify-content-end">
+                                    <button pButton (click)="groupByEnabledButton()" class="p-button-outlined ml-2" style="min-width: 120px; justify-content: center;">{{groupByEnabledMessage}}</button>
+                                </div>
 
                                 <div class="col-3 md:col-12 buttonAndOr d-flex justify-content-end">
                                     <button pButton (click)="filterAndOrDialog()" icon="pi pi-filter" class="p-button-outlined ml-2" i18n-label="@@filterSettings" label="Configuración de filtros"></button>

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
@@ -377,7 +377,7 @@
 
                             </div>
 
-                            <div class="grid">
+<div class="grid">
                                 <div class="col-3 md:col-12 infoFiltres">
                                     <span i18n="@@topQueryH4">
                                         Mostrar Top: &nbsp;
@@ -397,21 +397,13 @@
                                         </ng-template>
                                     </p-selectButton>
                                 </div>
-
-                                <!-- div class="col-2 col-offset-3 md:col-12 infoFiltres d-flex justify-content-end">
-                                    <button pButton (click)="onWhatIfDialog()" icon="pi pi-question-circle" class="p-button-info p-button-outlined button-whatif ml-2" label="What IF"></button>
-                                </div-->
-
-<!-- SDA CUSTOM -->             <div class="col-3 md:col-12 buttonAndOr d-flex justify-content-end">
-<!-- SDA CUSTOM -->                 <!-- <button pButton (click)="groupByEnabledButton()" class="p-button-outlined ml-2" style="width: 165px; justify-content: center;">{{groupByEnabledMessage}}</button> -->
-<!-- SDA CUSTOM -->                 <div class="flex flex-row align-items-center justify-content gap-2" style="width: 100%;">
-<!-- SDA CUSTOM -->                     <p-inputSwitch (onChange)="groupByEnabledButton()" [(ngModel)]="groupByEnabled" [disabled]="atLeastThereIsOneWithAggregation"></p-inputSwitch>
-<!-- SDA CUSTOM -->                     <h5 class="title-datamodel" style="min-width: 120px; margin: 0;">{{groupByEnabledMessage}}</h5>
+<!-- SDA CUSTOM -->             <div class="col-3 md:col-12 flex infoJoin">
+<!-- SDA CUSTOM -->                 <h5 class="title-datamodel" style="margin: 0; margin-right: 4px; margin-top: 2px;">{{groupByLabel}}</h5>
 <!-- SDA CUSTOM -->                     <!-- Info icon when switch is disabled -->
-<!-- SDA CUSTOM -->                     <i *ngIf="atLeastThereIsOneWithAggregation" class="pi pi-exclamation-circle" [pTooltip]="groupByDisabledReasonMessage" tooltipPosition="left" style="color: #ff9800; cursor: help; font-size: 1.1em;"></i>
+<!-- SDA CUSTOM -->                     <i *ngIf="atLeastThereIsOneWithAggregation" class="pi pi-exclamation-circle" [pTooltip]="groupByDisabledReasonMessage" tooltipPosition="left" style="color: #ff9800; cursor: help; font-size: 1.1em; margin-right: 4px;"></i>
 <!-- SDA CUSTOM -->                     <!-- Info icon when in Do not group mode -->
-<!-- SDA CUSTOM -->                     <i *ngIf="!groupByEnabled && !atLeastThereIsOneWithAggregation" class="pi pi-info-circle" [pTooltip]="groupByDisabledAggregationsMessage" tooltipPosition="left" style="color: #2196f3; cursor: help; font-size: 1.1em;"></i>
-<!-- SDA CUSTOM -->                 </div>
+<!-- SDA CUSTOM -->                     <i *ngIf="!groupByEnabled && !atLeastThereIsOneWithAggregation" class="pi pi-info-circle" [pTooltip]="groupByDisabledAggregationsMessage" tooltipPosition="left" style="color: #2196f3; cursor: help; font-size: 1.1em; margin-right: 4px;"></i>
+<!-- SDA CUSTOM -->                     <p-inputSwitch (onChange)="groupByEnabledButton()" [(ngModel)]="groupByEnabled" [disabled]="atLeastThereIsOneWithAggregation"></p-inputSwitch>
 <!-- SDA CUSTOM -->             </div>
 
                                 <div class="col-3 md:col-12 buttonAndOr d-flex justify-content-end">

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -158,12 +158,12 @@ export class EdaBlankPanelComponent implements OnInit {
     public joinType: string = 'inner';
     public sortedFilters: any[] = [];
     public temporalSortedFilters: any[] = [];
-    public groupByEnabled: boolean = true;
-    public groupByEnabledMessage: string = "Mostrar Repetidos";
-    public groupByEnabledMessages: any = [
-        {value: true, message: "Mostrar Repetidos"},
-        {value: false, message: "Ocultar Repetidos"},
-    ];
+    /* SDA CUSTOM */ public groupByEnabled: boolean = true;
+    /* SDA CUSTOM */ public groupByEnabledMessage: string = "Mostrar Repetidos";
+    /* SDA CUSTOM */ public groupByEnabledMessages: any = [
+    /* SDA CUSTOM */     {value: true, message: "Mostrar Repetidos"},
+    /* SDA CUSTOM */     {value: false, message: "Ocultar Repetidos"},
+    /* SDA CUSTOM */ ];
 
     public queryModes: any[] = [
         /* SDA CUSTOM */ { label: $localize`:@@PanelModeSelectorEDA:Modo EDA`, value: 'EDA', disabled: true},
@@ -500,10 +500,11 @@ export class EdaBlankPanelComponent implements OnInit {
      */
 
     public async buildGlobalconfiguration(panelContent: any) {
-
         const modeSQL = panelContent.query.query.modeSQL;
+        /* SDA CUSTOM */ const groupByEnabled = panelContent.query.query.groupByEnabled;
         const queryMode = this.selectedQueryMode;
         /*SDA CUSTOM*/ this.showHiddenColumn = true;
+        console.log()
 
         const currentQuery = panelContent.query.query.fields;
 
@@ -540,7 +541,8 @@ export class EdaBlankPanelComponent implements OnInit {
 
 
         this.queryLimit = panelContent.query.query.queryLimit;
-/*SDA CUSTOM*/ this.joinType = panelContent.query.query.joinType || 'inner';
+        /*SDA CUSTOM*/ this.joinType = panelContent.query.query.joinType || 'inner';
+        /* SDA CUSTOM */ this.groupByEnabled = groupByEnabled;
         PanelInteractionUtils.handleFilters(this, panelContent.query.query);
         PanelInteractionUtils.handleFilterColumns(this, panelContent.query.query.filters, panelContent.query.query.fields);
         this.chartForm.patchValue({chart: this.chartUtils.chartTypes.find(o => o.subValue === panelContent.edaChart)});
@@ -1978,12 +1980,13 @@ export class EdaBlankPanelComponent implements OnInit {
         }
     }
 
-    groupByEnabledButton() {
-        if(this.groupByEnabledMessage === 'Mostrar Repetidos') {
-            this.groupByEnabledMessage = this.groupByEnabledMessages[1].message;
-        } else {
-            this.groupByEnabledMessage = this.groupByEnabledMessages[0].message;
-        }
-    }
+    /* SDA CUSTOM */ groupByEnabledButton() {
+    /* SDA CUSTOM */     this.groupByEnabled = !this.groupByEnabled;
+    /* SDA CUSTOM */     if(this.groupByEnabledMessage === 'Mostrar Repetidos') {
+    /* SDA CUSTOM */         this.groupByEnabledMessage = this.groupByEnabledMessages[1].message;
+    /* SDA CUSTOM */     } else {
+    /* SDA CUSTOM */         this.groupByEnabledMessage = this.groupByEnabledMessages[0].message;
+    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */ }
 
 }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -1566,6 +1566,20 @@ export class EdaBlankPanelComponent implements OnInit {
     * Runs actual query when execute button is pressed to check for heavy queries
     */
     public runManualQuery = () => {
+
+        /* SDA CUSTOM */ if(!this.groupByEnabled) {
+        /* SDA CUSTOM */     let isAnAggregation: boolean = false;
+        /* SDA CUSTOM */     isAnAggregation = this.currentQuery.some((column: any) =>
+        /* SDA CUSTOM */         column.aggregation_type.some((at: any) =>
+        /* SDA CUSTOM */             at.selected && at.display_name !== 'None'
+        /* SDA CUSTOM */         )
+        /* SDA CUSTOM */     );
+        /* SDA CUSTOM */     if(isAnAggregation) {
+        /* SDA CUSTOM */         this.alertService.addWarning($localize`:@@mustAddTheGroupingsToRunWithAggregations:Debe activar las agrupaciones para ejecutar con agregaciones configuradas en los atributos`);
+        /* SDA CUSTOM */         return;
+        /* SDA CUSTOM */     }
+        /* SDA CUSTOM */ }
+
         this.hiddenButtonExecuter = true;
         // isNewAxes --> Verify if the axes construction is new.
         QueryUtils.runManualQuery(this);
@@ -1643,6 +1657,19 @@ export class EdaBlankPanelComponent implements OnInit {
     }
 
     public async getQuery($event) {
+
+        /* SDA CUSTOM */ if(!this.groupByEnabled) {
+        /* SDA CUSTOM */     let isAnAggregation: boolean = false;
+        /* SDA CUSTOM */     isAnAggregation = this.currentQuery.some((column: any) =>
+        /* SDA CUSTOM */         column.aggregation_type.some((at: any) =>
+        /* SDA CUSTOM */             at.selected && at.display_name !== 'None'
+        /* SDA CUSTOM */         )
+        /* SDA CUSTOM */     );
+        /* SDA CUSTOM */     if(isAnAggregation) {
+        /* SDA CUSTOM */         this.alertService.addWarning($localize`:@@mustAddTheGroupingsToRunWithAggregations:Debe activar las agrupaciones para ejecutar con agregaciones configuradas en los atributos`);
+        /* SDA CUSTOM */         return;
+        /* SDA CUSTOM */     }
+        /* SDA CUSTOM */ }
 
         this.display_v.minispinnerSQL = true;
         this.queryFromServer = null;
@@ -1979,9 +2006,32 @@ export class EdaBlankPanelComponent implements OnInit {
         }
     }
 
-    /* SDA CUSTOM */ groupByEnabledButton() {
-    /* SDA CUSTOM */     this.groupByEnabled = !this.groupByEnabled;
-    /* SDA CUSTOM */     this.groupByEnabledMessage = this.groupByEnabledMessages.find((m: {value: boolean, message: string}) => m.value === this.groupByEnabled).message;
-    /* SDA CUSTOM */ }
+/* SDA CUSTOM */ groupByEnabledButton() {
+/* SDA CUSTOM */
+/* SDA CUSTOM */        if(this.groupByEnabled) {
+/* SDA CUSTOM */            const currentQueryLength = this.currentQuery.length
+/* SDA CUSTOM */            let isAnAggregation: boolean = false;
+/* SDA CUSTOM */
+/* SDA CUSTOM */            isAnAggregation = this.currentQuery.some((column: any) =>
+/* SDA CUSTOM */                column.aggregation_type.some((at: any) =>
+/* SDA CUSTOM */                    at.selected && at.display_name !== 'None'
+/* SDA CUSTOM */                )
+/* SDA CUSTOM */            );
+/* SDA CUSTOM */
+/* SDA CUSTOM */            if(currentQueryLength !== 0){
+/* SDA CUSTOM */                if(isAnAggregation) {
+/* SDA CUSTOM */                    this.alertService.addWarning($localize`:@@noAttributeShouldHaveAggregation:Ningún Atributo debe tener agregación`);
+/* SDA CUSTOM */                    return;
+/* SDA CUSTOM */                }
+/* SDA CUSTOM */            } else {
+/* SDA CUSTOM */                this.alertService.addWarning($localize`:@@mustConfigureAtLeastOneAttribute:Debe configurar un atributo como mínimo para habilitar esta opción`);
+/* SDA CUSTOM */                return
+/* SDA CUSTOM */            }
+/* SDA CUSTOM */
+/* SDA CUSTOM */        }
+/* SDA CUSTOM */
+/* SDA CUSTOM */        this.groupByEnabled = !this.groupByEnabled;
+/* SDA CUSTOM */        this.groupByEnabledMessage = this.groupByEnabledMessages.find((m: {value: boolean, message: string}) => m.value === this.groupByEnabled).message;
+/* SDA CUSTOM */     }
 
 }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -504,7 +504,6 @@ export class EdaBlankPanelComponent implements OnInit {
         /* SDA CUSTOM */ const groupByEnabled = panelContent.query.query.groupByEnabled;
         const queryMode = this.selectedQueryMode;
         /*SDA CUSTOM*/ this.showHiddenColumn = true;
-        console.log()
 
         const currentQuery = panelContent.query.query.fields;
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -158,10 +158,11 @@ export class EdaBlankPanelComponent implements OnInit {
     public joinType: string = 'inner';
     public sortedFilters: any[] = [];
     public temporalSortedFilters: any[] = [];
+    /* SDA CUSTOM */ public atLeastThereIsOneWithAggregation: boolean = false;
     /* SDA CUSTOM */ public groupByEnabled: boolean = true;
     /* SDA CUSTOM */ public groupByEnabledMessages: {value: boolean, message: string}[] = [
-    /* SDA CUSTOM */     {value: true, message: $localize`:@@groupByEnabledHide:Ocultar Repetidos`},
-    /* SDA CUSTOM */     {value: false, message: $localize`:@@groupByEnabledShow:Mostrar Repetidos`},
+    /* SDA CUSTOM */     {value: true, message: $localize`:@@groupByEnabledHide:Agrupar`},
+    /* SDA CUSTOM */     {value: false, message: $localize`:@@groupByEnabledShow:No agrupar`},
     /* SDA CUSTOM */ ];
     /* SDA CUSTOM */ public groupByEnabledMessage: string = this.groupByEnabledMessages[0].message;
 
@@ -541,7 +542,7 @@ export class EdaBlankPanelComponent implements OnInit {
 
         this.queryLimit = panelContent.query.query.queryLimit;
         /*SDA CUSTOM*/ this.joinType = panelContent.query.query.joinType || 'inner';
-        /* SDA CUSTOM */ this.groupByEnabled = groupByEnabled;
+        /* SDA CUSTOM */ this.groupByEnabled = groupByEnabled ?? true;
         PanelInteractionUtils.handleFilters(this, panelContent.query.query);
         PanelInteractionUtils.handleFilterColumns(this, panelContent.query.query.filters, panelContent.query.query.fields);
         this.chartForm.patchValue({chart: this.chartUtils.chartTypes.find(o => o.subValue === panelContent.edaChart)});
@@ -901,6 +902,10 @@ export class EdaBlankPanelComponent implements OnInit {
             this.configController = new EdaDialogController({
                 params: p,
                 close: (event, response) => {
+
+                    /* SDA CUSTOM  */ const currenQuery = this.currentQuery;
+                    /* SDA CUSTOM  */ this.atLeastThereIsOneWithAggregation = this.checkAtLeastOneWithAggregation(currenQuery);
+
                     if (response.duplicated) {
                         this.currentQuery.push(response.column);
                         this.configController = undefined;
@@ -970,6 +975,14 @@ export class EdaBlankPanelComponent implements OnInit {
         }
 
     }
+
+/* SDA CUSTOM  */    checkAtLeastOneWithAggregation(currentQuery: any) {
+/* SDA CUSTOM  */        return currentQuery.some(column => {
+/* SDA CUSTOM  */            return column.aggregation_type.some((at: any) => {
+/* SDA CUSTOM  */                return (at.selected && (at.display_name !== 'None'))
+/* SDA CUSTOM  */            })
+/* SDA CUSTOM  */        })
+/* SDA CUSTOM  */    }
 
     /**
      * find table by name
@@ -1566,20 +1579,6 @@ export class EdaBlankPanelComponent implements OnInit {
     * Runs actual query when execute button is pressed to check for heavy queries
     */
     public runManualQuery = () => {
-
-        /* SDA CUSTOM */ if(!this.groupByEnabled) {
-        /* SDA CUSTOM */     let isAnAggregation: boolean = false;
-        /* SDA CUSTOM */     isAnAggregation = this.currentQuery.some((column: any) =>
-        /* SDA CUSTOM */         column.aggregation_type.some((at: any) =>
-        /* SDA CUSTOM */             at.selected && at.display_name !== 'None'
-        /* SDA CUSTOM */         )
-        /* SDA CUSTOM */     );
-        /* SDA CUSTOM */     if(isAnAggregation) {
-        /* SDA CUSTOM */         this.alertService.addWarning($localize`:@@mustAddTheGroupingsToRunWithAggregations:Debe activar las agrupaciones para ejecutar con agregaciones configuradas en los atributos`);
-        /* SDA CUSTOM */         return;
-        /* SDA CUSTOM */     }
-        /* SDA CUSTOM */ }
-
         this.hiddenButtonExecuter = true;
         // isNewAxes --> Verify if the axes construction is new.
         QueryUtils.runManualQuery(this);
@@ -1619,6 +1618,9 @@ export class EdaBlankPanelComponent implements OnInit {
 /**SDA CUSTOM  */           event.stopPropagation();
 /**SDA CUSTOM  */           this.alertService.addError($localize`:@@cannotRemoveLastColumn:No se puede eliminar todas las columnas de la tabla raíz sin eliminar las columnas dependientes.`);
 /**SDA CUSTOM  */       }
+
+/* SDA CUSTOM  */       const currenQuery = this.currentQuery;
+/* SDA CUSTOM  */       this.atLeastThereIsOneWithAggregation = this.checkAtLeastOneWithAggregation(currenQuery);
                    }
 
     public getOptionDescription = (value: string): string => EbpUtils.getOptionDescription(value);
@@ -1657,20 +1659,6 @@ export class EdaBlankPanelComponent implements OnInit {
     }
 
     public async getQuery($event) {
-
-        /* SDA CUSTOM */ if(!this.groupByEnabled) {
-        /* SDA CUSTOM */     let isAnAggregation: boolean = false;
-        /* SDA CUSTOM */     isAnAggregation = this.currentQuery.some((column: any) =>
-        /* SDA CUSTOM */         column.aggregation_type.some((at: any) =>
-        /* SDA CUSTOM */             at.selected && at.display_name !== 'None'
-        /* SDA CUSTOM */         )
-        /* SDA CUSTOM */     );
-        /* SDA CUSTOM */     if(isAnAggregation) {
-        /* SDA CUSTOM */         this.alertService.addWarning($localize`:@@mustAddTheGroupingsToRunWithAggregations:Debe activar las agrupaciones para ejecutar con agregaciones configuradas en los atributos`);
-        /* SDA CUSTOM */         return;
-        /* SDA CUSTOM */     }
-        /* SDA CUSTOM */ }
-
         this.display_v.minispinnerSQL = true;
         this.queryFromServer = null;
 
@@ -2006,32 +1994,10 @@ export class EdaBlankPanelComponent implements OnInit {
         }
     }
 
-/* SDA CUSTOM */ groupByEnabledButton() {
-/* SDA CUSTOM */
-/* SDA CUSTOM */        if(this.groupByEnabled) {
-/* SDA CUSTOM */            const currentQueryLength = this.currentQuery.length
-/* SDA CUSTOM */            let isAnAggregation: boolean = false;
-/* SDA CUSTOM */
-/* SDA CUSTOM */            isAnAggregation = this.currentQuery.some((column: any) =>
-/* SDA CUSTOM */                column.aggregation_type.some((at: any) =>
-/* SDA CUSTOM */                    at.selected && at.display_name !== 'None'
-/* SDA CUSTOM */                )
-/* SDA CUSTOM */            );
-/* SDA CUSTOM */
-/* SDA CUSTOM */            if(currentQueryLength !== 0){
-/* SDA CUSTOM */                if(isAnAggregation) {
-/* SDA CUSTOM */                    this.alertService.addWarning($localize`:@@noAttributeShouldHaveAggregation:Ningún Atributo debe tener agregación`);
-/* SDA CUSTOM */                    return;
-/* SDA CUSTOM */                }
-/* SDA CUSTOM */            } else {
-/* SDA CUSTOM */                this.alertService.addWarning($localize`:@@mustConfigureAtLeastOneAttribute:Debe configurar un atributo como mínimo para habilitar esta opción`);
-/* SDA CUSTOM */                return
-/* SDA CUSTOM */            }
-/* SDA CUSTOM */
-/* SDA CUSTOM */        }
-/* SDA CUSTOM */
-/* SDA CUSTOM */        this.groupByEnabled = !this.groupByEnabled;
-/* SDA CUSTOM */        this.groupByEnabledMessage = this.groupByEnabledMessages.find((m: {value: boolean, message: string}) => m.value === this.groupByEnabled).message;
-/* SDA CUSTOM */     }
+/* SDA CUSTOM  */    groupByEnabledButton() {
+/* SDA CUSTOM  */        
+/* SDA CUSTOM  */        this.groupByEnabledMessage = this.groupByEnabledMessages.find((m: {value: boolean, message: string}) => m.value === this.groupByEnabled).message;
+/* SDA CUSTOM  */
+/* SDA CUSTOM  */    }
 
 }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -159,11 +159,11 @@ export class EdaBlankPanelComponent implements OnInit {
     public sortedFilters: any[] = [];
     public temporalSortedFilters: any[] = [];
     /* SDA CUSTOM */ public groupByEnabled: boolean = true;
-    /* SDA CUSTOM */ public groupByEnabledMessage: string = "Mostrar Repetidos";
-    /* SDA CUSTOM */ public groupByEnabledMessages: any = [
+    /* SDA CUSTOM */ public groupByEnabledMessages: {value: boolean, message: string}[] = [
     /* SDA CUSTOM */     {value: true, message: $localize`:@@groupByEnabledShow:Mostrar Repetidos`},
     /* SDA CUSTOM */     {value: false, message: $localize`:@@groupByEnabledHide:Ocultar Repetidos`},
     /* SDA CUSTOM */ ];
+    /* SDA CUSTOM */ public groupByEnabledMessage: string = this.groupByEnabledMessages[0].message;
 
     public queryModes: any[] = [
         /* SDA CUSTOM */ { label: $localize`:@@PanelModeSelectorEDA:Modo EDA`, value: 'EDA', disabled: true},
@@ -1981,11 +1981,7 @@ export class EdaBlankPanelComponent implements OnInit {
 
     /* SDA CUSTOM */ groupByEnabledButton() {
     /* SDA CUSTOM */     this.groupByEnabled = !this.groupByEnabled;
-    /* SDA CUSTOM */     if(this.groupByEnabledMessage === 'Mostrar Repetidos') {
-    /* SDA CUSTOM */         this.groupByEnabledMessage = this.groupByEnabledMessages[1].message;
-    /* SDA CUSTOM */     } else {
-    /* SDA CUSTOM */         this.groupByEnabledMessage = this.groupByEnabledMessages[0].message;
-    /* SDA CUSTOM */     }
+    /* SDA CUSTOM */     this.groupByEnabledMessage = this.groupByEnabledMessages.find((m: {value: boolean, message: string}) => m.value === this.groupByEnabled).message;
     /* SDA CUSTOM */ }
 
 }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -162,7 +162,7 @@ export class EdaBlankPanelComponent implements OnInit {
     /* SDA CUSTOM */ public groupByEnabled: boolean = true;
     /* SDA CUSTOM */ public groupByLabel: string = $localize`:@@groupBy:Agrupar`;
     /* SDA CUSTOM */ public groupByDisabledReasonMessage: string = $localize`:@@groupByDisabledReason:No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.`;
-    /* SDA CUSTOM */ public groupByDisabledAggregationsMessage: string = $localize`:@@groupByDisabledAggregations:En modo No agrupar, las agregaciones en los campos están deshabilitadas automáticamente.`;
+    /* SDA CUSTOM */ public groupByDisabledAggregationsMessage: string = $localize`:@@groupByDisabledAggregations:En modo agrupar desactivado, las agregaciones en los campos están deshabilitadas automáticamente.`;
 
     public queryModes: any[] = [
         /* SDA CUSTOM */ { label: $localize`:@@PanelModeSelectorEDA:Modo EDA`, value: 'EDA', disabled: true},

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -158,6 +158,12 @@ export class EdaBlankPanelComponent implements OnInit {
     public joinType: string = 'inner';
     public sortedFilters: any[] = [];
     public temporalSortedFilters: any[] = [];
+    public groupByEnabled: boolean = true;
+    public groupByEnabledMessage: string = "Mostrar Repetidos";
+    public groupByEnabledMessages: any = [
+        {value: true, message: "Mostrar Repetidos"},
+        {value: false, message: "Ocultar Repetidos"},
+    ];
 
     public queryModes: any[] = [
         /* SDA CUSTOM */ { label: $localize`:@@PanelModeSelectorEDA:Modo EDA`, value: 'EDA', disabled: true},
@@ -1969,6 +1975,14 @@ export class EdaBlankPanelComponent implements OnInit {
                 this.alertService.addWarning($localize`:@@filterSettingsReboot:La configuración de filtros se ha reiniciado`);
             }
             this.sortedFilters = [];
+        }
+    }
+
+    groupByEnabledButton() {
+        if(this.groupByEnabledMessage === 'Mostrar Repetidos') {
+            this.groupByEnabledMessage = this.groupByEnabledMessages[1].message;
+        } else {
+            this.groupByEnabledMessage = this.groupByEnabledMessages[0].message;
         }
     }
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -160,8 +160,8 @@ export class EdaBlankPanelComponent implements OnInit {
     public temporalSortedFilters: any[] = [];
     /* SDA CUSTOM */ public groupByEnabled: boolean = true;
     /* SDA CUSTOM */ public groupByEnabledMessages: {value: boolean, message: string}[] = [
-    /* SDA CUSTOM */     {value: true, message: $localize`:@@groupByEnabledShow:Mostrar Repetidos`},
-    /* SDA CUSTOM */     {value: false, message: $localize`:@@groupByEnabledHide:Ocultar Repetidos`},
+    /* SDA CUSTOM */     {value: true, message: $localize`:@@groupByEnabledHide:Ocultar Repetidos`},
+    /* SDA CUSTOM */     {value: false, message: $localize`:@@groupByEnabledShow:Mostrar Repetidos`},
     /* SDA CUSTOM */ ];
     /* SDA CUSTOM */ public groupByEnabledMessage: string = this.groupByEnabledMessages[0].message;
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -161,8 +161,8 @@ export class EdaBlankPanelComponent implements OnInit {
     /* SDA CUSTOM */ public groupByEnabled: boolean = true;
     /* SDA CUSTOM */ public groupByEnabledMessage: string = "Mostrar Repetidos";
     /* SDA CUSTOM */ public groupByEnabledMessages: any = [
-    /* SDA CUSTOM */     {value: true, message: "Mostrar Repetidos"},
-    /* SDA CUSTOM */     {value: false, message: "Ocultar Repetidos"},
+    /* SDA CUSTOM */     {value: true, message: $localize`:@@groupByEnabledShow:Mostrar Repetidos`},
+    /* SDA CUSTOM */     {value: false, message: $localize`:@@groupByEnabledHide:Ocultar Repetidos`},
     /* SDA CUSTOM */ ];
 
     public queryModes: any[] = [

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -506,7 +506,9 @@ export class EdaBlankPanelComponent implements OnInit {
         const queryMode = this.selectedQueryMode;
         /*SDA CUSTOM*/ this.showHiddenColumn = true;
 
+
         const currentQuery = panelContent.query.query.fields;
+
 
         if ((queryMode && queryMode != 'SQL') || modeSQL === false) {
 
@@ -537,9 +539,10 @@ export class EdaBlankPanelComponent implements OnInit {
                 console.error(e);
                 throw e;
             }
+
+            
         }
-
-
+        
         this.queryLimit = panelContent.query.query.queryLimit;
         /*SDA CUSTOM*/ this.joinType = panelContent.query.query.joinType || 'inner';
         /* SDA CUSTOM */ this.groupByEnabled = groupByEnabled ?? true;
@@ -562,6 +565,10 @@ export class EdaBlankPanelComponent implements OnInit {
 
         // Verify if it is a cross table to show it on home screen
         this.dragAndDropAvailable = !this.chartTypes.filter( grafico => grafico.subValue === 'crosstable')[0].ngIf;
+
+
+        const currentQueryCheck = this.currentQuery;
+        this.atLeastThereIsOneWithAggregation = this.checkAtLeastOneWithAggregation(currentQueryCheck);
     }
 
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -160,11 +160,7 @@ export class EdaBlankPanelComponent implements OnInit {
     public temporalSortedFilters: any[] = [];
     /* SDA CUSTOM */ public atLeastThereIsOneWithAggregation: boolean = false;
     /* SDA CUSTOM */ public groupByEnabled: boolean = true;
-    /* SDA CUSTOM */ public groupByEnabledMessages: {value: boolean, message: string}[] = [
-    /* SDA CUSTOM */     {value: true, message: $localize`:@@groupByEnabledHide:Agrupar`},
-    /* SDA CUSTOM */     {value: false, message: $localize`:@@groupByEnabledShow:No agrupar`},
-    /* SDA CUSTOM */ ];
-    /* SDA CUSTOM */ public groupByEnabledMessage: string = this.groupByEnabledMessages[0].message;
+    /* SDA CUSTOM */ public groupByLabel: string = $localize`:@@groupBy:Agrupar`;
     /* SDA CUSTOM */ public groupByDisabledReasonMessage: string = $localize`:@@groupByDisabledReason:No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.`;
     /* SDA CUSTOM */ public groupByDisabledAggregationsMessage: string = $localize`:@@groupByDisabledAggregations:En modo No agrupar, las agregaciones en los campos están deshabilitadas automáticamente.`;
 
@@ -2004,11 +2000,5 @@ export class EdaBlankPanelComponent implements OnInit {
             this.sortedFilters = [];
         }
     }
-
-/* SDA CUSTOM  */    groupByEnabledButton() {
-/* SDA CUSTOM  */
-/* SDA CUSTOM  */        this.groupByEnabledMessage = this.groupByEnabledMessages.find((m: {value: boolean, message: string}) => m.value === this.groupByEnabled).message;
-/* SDA CUSTOM  */
-/* SDA CUSTOM  */    }
 
 }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -165,6 +165,8 @@ export class EdaBlankPanelComponent implements OnInit {
     /* SDA CUSTOM */     {value: false, message: $localize`:@@groupByEnabledShow:No agrupar`},
     /* SDA CUSTOM */ ];
     /* SDA CUSTOM */ public groupByEnabledMessage: string = this.groupByEnabledMessages[0].message;
+    /* SDA CUSTOM */ public groupByDisabledReasonMessage: string = $localize`:@@groupByDisabledReason:No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.`;
+    /* SDA CUSTOM */ public groupByDisabledAggregationsMessage: string = $localize`:@@groupByDisabledAggregations:En modo No agrupar, las agregaciones en los campos están deshabilitadas automáticamente.`;
 
     public queryModes: any[] = [
         /* SDA CUSTOM */ { label: $localize`:@@PanelModeSelectorEDA:Modo EDA`, value: 'EDA', disabled: true},
@@ -540,9 +542,9 @@ export class EdaBlankPanelComponent implements OnInit {
                 throw e;
             }
 
-            
+
         }
-        
+
         this.queryLimit = panelContent.query.query.queryLimit;
         /*SDA CUSTOM*/ this.joinType = panelContent.query.query.joinType || 'inner';
         /* SDA CUSTOM */ this.groupByEnabled = groupByEnabled ?? true;
@@ -2004,7 +2006,7 @@ export class EdaBlankPanelComponent implements OnInit {
     }
 
 /* SDA CUSTOM  */    groupByEnabledButton() {
-/* SDA CUSTOM  */        
+/* SDA CUSTOM  */
 /* SDA CUSTOM  */        this.groupByEnabledMessage = this.groupByEnabledMessages.find((m: {value: boolean, message: string}) => m.value === this.groupByEnabled).message;
 /* SDA CUSTOM  */
 /* SDA CUSTOM  */    }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
@@ -457,7 +457,7 @@ export const PanelInteractionUtils = {
     const displayName = column.display_name.default
     const initializeAgregations = (column, tmpAggTypes) => {
       column.aggregation_type.forEach((agg) => {
-        tmpAggTypes.push({ display_name: agg.display_name, value: agg.value, selected: agg.value === 'sum' });
+        /* SDA CUSTOM */ tmpAggTypes.push({ display_name: agg.display_name, value: agg.value, selected: ebp.groupByEnabled ? agg.value === 'sum' : agg.value === 'none' });
       });
     }
 
@@ -494,6 +494,10 @@ export const PanelInteractionUtils = {
     if (findColumn) {
       findColumn.aggregation_type = _.cloneDeep(ebp.aggregationsTypes);
     }
+
+/* SDA CUSTOM */    const currenQuery = ebp.currentQuery;
+/* SDA CUSTOM */    ebp.atLeastThereIsOneWithAggregation = ebp.checkAtLeastOneWithAggregation(currenQuery);
+
   },
 
   

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
@@ -361,6 +361,7 @@ export const QueryUtils = {
       queryLimit: ebp.queryLimit,
       joinType: ebp.joinType,
       rootTable: ebp.rootTable?.table_name,
+      /* SDA CUSTOM */ groupByEnabled: ebp.groupByEnabled,
       connectionProperties: ebp.connectionProperties,
       sortedFilters: ebp.sortedFilters,
     };

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
@@ -497,7 +497,7 @@ export class GlobalFilterComponent implements OnInit {
             dataSource: this.dashboard.dataSource._id,
             dashboard: '',
             panel: '',
-            groupByEnabled: true,
+            /* SDA CUSTOM */ groupByEnabled: true,
             filters: []
         };
 

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
@@ -497,9 +497,9 @@ export class GlobalFilterComponent implements OnInit {
             dataSource: this.dashboard.dataSource._id,
             dashboard: '',
             panel: '',
+            groupByEnabled: true,
             filters: []
         };
-
 
         try {
             const query = this.queryBuilderService.normalQuery([targetColumn], queryParams);

--- a/eda/eda_app/src/app/services/utils/query-builder.service.ts
+++ b/eda/eda_app/src/app/services/utils/query-builder.service.ts
@@ -12,6 +12,7 @@ export interface QueryParams {
     config?: any;
     queryLimit? : number;
     joinType?:string;
+    groupByEnabled?: boolean,
     forSelector?: boolean;
     connectionProperties?: any;
     rootTable?: string;
@@ -67,6 +68,7 @@ export class QueryBuilderService extends ApiService {
                 queryMode: 'EDA',
                 SQLexpression : null,
                 queryLimit : null,
+                groupByEnabled: true,
                 joinType: 'left', //puede que necesite el joinType
                 rootTable: null,
                 sortedFilters: [],
@@ -138,6 +140,7 @@ export class QueryBuilderService extends ApiService {
                 // modeSQL : modeSQL,
                 SQLexpression : SQLexpression,
                 queryLimit : params.queryLimit,
+                groupByEnabled: params.groupByEnabled,
                 joinType: params.joinType,
                 forSelector: params.forSelector,
                 rootTable: params.rootTable,

--- a/eda/eda_app/src/app/services/utils/query-builder.service.ts
+++ b/eda/eda_app/src/app/services/utils/query-builder.service.ts
@@ -12,7 +12,7 @@ export interface QueryParams {
     config?: any;
     queryLimit? : number;
     joinType?:string;
-    groupByEnabled?: boolean,
+    /* SDA CUSTOM */ groupByEnabled?: boolean,
     forSelector?: boolean;
     connectionProperties?: any;
     rootTable?: string;
@@ -68,7 +68,7 @@ export class QueryBuilderService extends ApiService {
                 queryMode: 'EDA',
                 SQLexpression : null,
                 queryLimit : null,
-                groupByEnabled: true,
+                /* SDA CUSTOM */ groupByEnabled: true,
                 joinType: 'left', //puede que necesite el joinType
                 rootTable: null,
                 sortedFilters: [],
@@ -140,7 +140,7 @@ export class QueryBuilderService extends ApiService {
                 // modeSQL : modeSQL,
                 SQLexpression : SQLexpression,
                 queryLimit : params.queryLimit,
-                groupByEnabled: params.groupByEnabled,
+                /* SDA CUSTOM */ groupByEnabled: params.groupByEnabled,
                 joinType: params.joinType,
                 forSelector: params.forSelector,
                 rootTable: params.rootTable,

--- a/eda/eda_app/src/app/shared/models/dashboard-models/query.model.ts
+++ b/eda/eda_app/src/app/shared/models/dashboard-models/query.model.ts
@@ -20,6 +20,7 @@ export interface Query {
         // modeSQL: boolean, Deprecated use queryMode instead
         SQLexpression : string,
         queryLimit : number,
+        groupByEnabled: boolean,
         joinType: string,
         forSelector?: boolean,
         rootTable: string,

--- a/eda/eda_app/src/app/shared/models/dashboard-models/query.model.ts
+++ b/eda/eda_app/src/app/shared/models/dashboard-models/query.model.ts
@@ -20,7 +20,7 @@ export interface Query {
         // modeSQL: boolean, Deprecated use queryMode instead
         SQLexpression : string,
         queryLimit : number,
-        groupByEnabled: boolean,
+        /* SDA CUSTOM */ groupByEnabled: boolean,
         joinType: string,
         forSelector?: boolean,
         rootTable: string,

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4598,18 +4598,6 @@ Un cop configurada podreu invocar-la des del botó sempre que calgui.</target>
         <source>Agrupar</source>
         <target>Agrupar</target>
       </trans-unit>
-      <trans-unit id="noAttributeShouldHaveAggregation">
-        <source>Ningún Atributo debe tener agregación</source>
-        <target>Cap atribut ha de tenir agregació</target>
-      </trans-unit>
-      <trans-unit id="mustConfigureAtLeastOneAttribute">
-        <source>Debe configurar un atributo como mínimo para habilitar esta opción</source>
-        <target>Cal configurar com a mínim un atribut per habilitar aquesta opció</target>
-      </trans-unit>
-      <trans-unit id="mustAddTheGroupingsToRunWithAggregations">
-        <source>Debe activar las agrupaciones para ejecutar con agregaciones configuradas en los atributos</source>
-        <target>Cal activar les agrupacions per executar amb agregacions configurades als atributs</target>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4592,19 +4592,19 @@ Un cop configurada podreu invocar-la des del botó sempre que calgui.</target>
       </trans-unit>
       <trans-unit id="groupByEnabledShow">
         <source>No agrupar</source>
-        <target>No agrupar</target>
+        <target>No agrupis</target>
       </trans-unit>
       <trans-unit id="groupByEnabledHide">
         <source>Agrupar</source>
-        <target>Agrupar</target>
+        <target>Agrupa</target>
       </trans-unit>
       <trans-unit id="groupByDisabledReason">
         <source>No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.</source>
-        <target>No es pot canviar l'agrupació perquè hi ha camps amb agregacions configurades. Elimina les agregacions primer.</target>
+        <target>Abans de poder canviar l'agrupació cal que elimineu les agregacions configurades als camps.</target>
       </trans-unit>
       <trans-unit id="groupByDisabledAggregations">
         <source>En modo No agrupar, las agregaciones en los campos están deshabilitadas automáticamente.</source>
-        <target>En mode No agrupar, les agregacions als camps estan deshabilitades automàticament.</target>
+        <target>En el mode "No agrupis" les agregacions als camps es deshabiliten automàticament.</target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4598,6 +4598,18 @@ Un cop configurada podreu invocar-la des del botó sempre que calgui.</target>
         <source>Ocultar Repetidos</source>
         <target>Ocultar Repetits</target>
       </trans-unit>
+      <trans-unit id="noAttributeShouldHaveAggregation">
+        <source>Ningún Atributo debe tener agregación</source>
+        <target>Cap atribut ha de tenir agregació</target>
+      </trans-unit>
+      <trans-unit id="mustConfigureAtLeastOneAttribute">
+        <source>Debe configurar un atributo como mínimo para habilitar esta opción</source>
+        <target>Cal configurar com a mínim un atribut per habilitar aquesta opció</target>
+      </trans-unit>
+      <trans-unit id="mustAddTheGroupingsToRunWithAggregations">
+        <source>Debe activar las agrupaciones para ejecutar con agregaciones configuradas en los atributos</source>
+        <target>Cal activar les agrupacions per executar amb agregacions configurades als atributs</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4590,6 +4590,14 @@ Un cop configurada podreu invocar-la des del botó sempre que calgui.</target>
         <source>elementos seleccionados</source>
         <target>elements seleccionats</target>
       </trans-unit>
+      <trans-unit id="groupByEnabledShow">
+        <source>Mostrar Repetidos</source>
+        <target>Mostrar repetits</target>
+      </trans-unit>
+      <trans-unit id="groupByEnabledHide">
+        <source>Ocultar Repetidos</source>
+        <target>Ocultar Repetits</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4590,10 +4590,6 @@ Un cop configurada podreu invocar-la des del botó sempre que calgui.</target>
         <source>elementos seleccionados</source>
         <target>elements seleccionats</target>
       </trans-unit>
-      <trans-unit id="groupByEnabledShow">
-        <source>No agrupar</source>
-        <target>No agrupis</target>
-      </trans-unit>
       <trans-unit id="groupByEnabledHide">
         <source>Agrupar</source>
         <target>Agrupa</target>
@@ -4603,8 +4599,8 @@ Un cop configurada podreu invocar-la des del botó sempre que calgui.</target>
         <target>Abans de poder canviar l'agrupació cal que elimineu les agregacions configurades als camps.</target>
       </trans-unit>
       <trans-unit id="groupByDisabledAggregations">
-        <source>En modo No agrupar, las agregaciones en los campos están deshabilitadas automáticamente.</source>
-        <target>En el mode "No agrupis" les agregacions als camps es deshabiliten automàticament.</target>
+        <source>En modo agrupar desactivado, las agregaciones en los campos están deshabilitadas automáticamente.</source>
+        <target>En mode d'agrupació desactivat, les agregacions en els camps estan deshabilitades automàticament.</target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -3135,11 +3135,11 @@ Entrar<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/>
   </trans-unit>
 
   <trans-unit id="topQueryH4" datatype="html">
-    <source> Mostrar Top:  
+    <source> Mostrar Top:
       <x id="START_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;p-inputNumber&gt;"/>
       <x id="CLOSE_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;/p-inputNumber&gt;"/>
     </source>
-    <target> Mostrar Top:  
+    <target> Mostrar Top:
       <x id="START_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;p-inputNumber&gt;"/>
       <x id="CLOSE_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;/p-inputNumber&gt;"/>
     </target>
@@ -4597,6 +4597,14 @@ Un cop configurada podreu invocar-la des del botó sempre que calgui.</target>
       <trans-unit id="groupByEnabledHide">
         <source>Agrupar</source>
         <target>Agrupar</target>
+      </trans-unit>
+      <trans-unit id="groupByDisabledReason">
+        <source>No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.</source>
+        <target>No es pot canviar l'agrupació perquè hi ha camps amb agregacions configurades. Elimina les agregacions primer.</target>
+      </trans-unit>
+      <trans-unit id="groupByDisabledAggregations">
+        <source>En modo No agrupar, las agregaciones en los campos están deshabilitadas automáticamente.</source>
+        <target>En mode No agrupar, les agregacions als camps estan deshabilitades automàticament.</target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4600,7 +4600,7 @@ Un cop configurada podreu invocar-la des del botó sempre que calgui.</target>
       </trans-unit>
       <trans-unit id="groupByDisabledAggregations">
         <source>En modo agrupar desactivado, las agregaciones en los campos están deshabilitadas automáticamente.</source>
-        <target>En mode d'agrupació desactivat, les agregacions en els camps estan deshabilitades automàticament.</target>
+        <target>Si el mode d'agrupació està desactivat les agregacions als camps es deshabiliten automàticament.</target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -4591,12 +4591,12 @@ Un cop configurada podreu invocar-la des del botó sempre que calgui.</target>
         <target>elements seleccionats</target>
       </trans-unit>
       <trans-unit id="groupByEnabledShow">
-        <source>Mostrar Repetidos</source>
-        <target>Mostrar repetits</target>
+        <source>No agrupar</source>
+        <target>No agrupar</target>
       </trans-unit>
       <trans-unit id="groupByEnabledHide">
-        <source>Ocultar Repetidos</source>
-        <target>Ocultar Repetits</target>
+        <source>Agrupar</source>
+        <target>Agrupar</target>
       </trans-unit>
       <trans-unit id="noAttributeShouldHaveAggregation">
         <source>Ningún Atributo debe tener agregación</source>

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -2164,6 +2164,18 @@
         <source>Tipo de intersección:</source>
         <target>Tipus d'intersecció:</target>
       </trans-unit>
+      <trans-unit id="groupByEnabledHide">
+        <source>Agrupar</source>
+        <target>Agrupa</target>
+      </trans-unit>
+      <trans-unit id="groupByDisabledReason">
+        <source>No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.</source>
+        <target>Abans de poder canviar l'agrupació cal que elimineu les agregacions configurades als camps.</target>
+      </trans-unit>
+      <trans-unit id="groupByDisabledAggregations">
+        <source>En modo agrupar desactivado, las agregaciones en los campos están deshabilitadas automáticamente.</source>
+        <target>Si el mode d'agrupació està desactivat les agregacions als camps es deshabiliten automàticament.</target>
+      </trans-unit>
       <trans-unit id="addCSV">
         <source>Añadir tabla desde CSV</source>
         <target>Afegeix una taula des d'un fitxer CSV</target>
@@ -2406,88 +2418,88 @@
         <source>Estoy de acuerdo con los <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;" />
  términos<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;" />
       </source>
-        <target>Estic d'acord amb els <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>
+      <target>Estic d'acord amb els <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>
  termes<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>
     </target>
-      </trans-unit>
-      <trans-unit id="haveAccount" datatype="html">
-        <source>¿Tienes una cuenta? <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;" />
+  </trans-unit>
+  <trans-unit id="haveAccount" datatype="html">
+    <source>¿Tienes una cuenta? <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;" />
     <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;" />
 Ingresa ahora<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;" />
   <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;" />
 </source>
-        <target>Teniu un compte? <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>
+<target>Teniu un compte? <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>
 <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>
  Entreu<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/>
 <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>
 </target>
-      </trans-unit>
-      <trans-unit id="indicaciones6" datatype="html">
-        <source>Para hacerlo sólo tienes que añadir: <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;" />
+</trans-unit>
+<trans-unit id="indicaciones6" datatype="html">
+<source>Para hacerlo sólo tienes que añadir: <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;" />
  AND <x id="INTERPOLATION" equiv-text="{{&apos; ${alias_tabla.columna_filtrada} &apos;}}" />
 <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;" />
  en la cláusula &apos;WHERE&apos; de la consulta donde quieras inyectar el filtro</source>
-        <target>Per fer-ho només heu d'afegir: <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>
+<target>Per fer-ho només heu d'afegir: <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>
  AND <x id="INTERPOLATION" equiv-text="{{&apos; ${alias_taula.columna_filtrada} &apos;}}"/>
 <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/>
  a la clàusula &apos;WHERE&apos; de la consulta on voleu injectar el filtre</target>
-      </trans-unit>
-      <trans-unit id="indicaciones7" datatype="html">
-        <source>Si no has añadido ninguna cláusula WHERE, añádela a la consulta y haz los joins necesarios, junto con el filtro en el formato <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;" />
+</trans-unit>
+<trans-unit id="indicaciones7" datatype="html">
+<source>Si no has añadido ninguna cláusula WHERE, añádela a la consulta y haz los joins necesarios, junto con el filtro en el formato <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;" />
 <x id="INTERPOLATION" equiv-text="{{&apos; ${alias_tabla.columna_filtrada} &apos;}}" />
 <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;" />
 </source>
-        <target>Si no heu afegit cap clàusula WHERE, afegiu-la a la consulta i feu els JOIN necessaris, juntament amb el el filtre en el format <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>
+<target>Si no heu afegit cap clàusula WHERE, afegiu-la a la consulta i feu els JOIN necessaris, juntament amb el el filtre en el format <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>
 <x id="INTERPOLATION" equiv-text="{{&apos; ${alias_taula.columna_filtrada} &apos;}}"/>
 <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/>
 </target>
-      </trans-unit>
-      <trans-unit id="vistaSeleccionador" datatype="html">
-        <source>
+</trans-unit>
+<trans-unit id="vistaSeleccionador" datatype="html">
+<source>
 <x id="INTERPOLATION" equiv-text="{{!modeSQL ? editQuery : editSQLQuery}}" />
 </source>
-        <target>
+<target>
 <x id="INTERPOLATION" equiv-text="{{!modeSQL ? editQuery : editSQLQuery}}"/>
 </target>
-      </trans-unit>
-      <trans-unit id="editModelHeaders" datatype="html">
-        <source>Editar <x id="INTERPOLATION" equiv-text="{{tablePanel.type ? tablePanel.name : &apos;&apos;}}" />
+</trans-unit>
+<trans-unit id="editModelHeaders" datatype="html">
+<source>Editar <x id="INTERPOLATION" equiv-text="{{tablePanel.type ? tablePanel.name : &apos;&apos;}}" />
 </source>
-        <target>Edita <x id="INTERPOLATION" equiv-text="{{tablePanel.type ? tablePanel.name : &apos;&apos;}}"/>
+<target>Edita <x id="INTERPOLATION" equiv-text="{{tablePanel.type ? tablePanel.name : &apos;&apos;}}"/>
 </target>
-      </trans-unit>
-      <trans-unit id="registers1" datatype="html">
-        <source>
+</trans-unit>
+<trans-unit id="registers1" datatype="html">
+<source>
 <x id="INTERPOLATION" equiv-text="{{ table.filteredValue.length }}" />
  registros</source>
-        <target>
+<target>
 <x id="INTERPOLATION" equiv-text="{{ table.filteredValue.length }}"/>
  registres</target>
-      </trans-unit>
-      <trans-unit id="registers2" datatype="html">
-        <source>
+</trans-unit>
+<trans-unit id="registers2" datatype="html">
+<source>
 <x id="INTERPOLATION" equiv-text="{{ table.value.length }}" />
  registros</source>
-        <target>
+<target>
 <x id="INTERPOLATION" equiv-text="{{ table.value.length }}"/>
  registres</target>
-      </trans-unit>
-      <trans-unit id="topQueryH4" datatype="html">
-        <source>Mostrar Top: <x id="START_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;p-inputNumber&gt;" />
+</trans-unit>
+<trans-unit id="topQueryH4" datatype="html">
+<source>Mostrar Top: <x id="START_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;p-inputNumber&gt;" />
 <x id="CLOSE_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;/p-inputNumber&gt;" />
 </source>
-        <target>Mostra els Top: <x id="START_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;p-inputNumber&gt;"/>
+<target>Mostra els Top: <x id="START_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;p-inputNumber&gt;"/>
 <x id="CLOSE_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;/p-inputNumber&gt;"/>
 </target>
-      </trans-unit>
-      <trans-unit id="atributosH4interpolation" datatype="html">
-        <source>
+</trans-unit>
+<trans-unit id="atributosH4interpolation" datatype="html">
+<source>
 <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
 </source>
-        <target>
+<target>
 <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
 </target>
-      </trans-unit>
-    </body>
-  </file>
+</trans-unit>
+</body>
+</file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -2163,6 +2163,18 @@
         <source>Tipo de intersección:</source>
         <target>Join type:</target>
       </trans-unit>
+      <trans-unit id="groupByEnabledHide">
+        <source>Agrupar</source>
+        <target>Group</target>
+      </trans-unit>
+      <trans-unit id="groupByDisabledReason">
+        <source>No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.</source>
+        <target>Before you can change the grouping, you must remove the aggregations configured on the fields.</target>
+      </trans-unit>
+      <trans-unit id="groupByDisabledAggregations">
+        <source>En modo agrupar desactivado, las agregaciones en los campos están deshabilitadas automáticamente.</source>
+        <target>If grouping mode is disabled, aggregations in fields are automatically disabled.</target>
+      </trans-unit>
       <trans-unit id="addCSV">
         <source>Añadir tabla desde CSV</source>
         <target>Add table from CSV</target>
@@ -2405,88 +2417,88 @@
         <source>Estoy de acuerdo con los <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;" />
  términos<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;" />
       </source>
-        <target>I'm agree with <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>
+      <target>I'm agree with <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>
  terms<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>
     </target>
-      </trans-unit>
-      <trans-unit id="haveAccount" datatype="html">
-        <source>¿Tienes una cuenta? <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;" />
+  </trans-unit>
+  <trans-unit id="haveAccount" datatype="html">
+    <source>¿Tienes una cuenta? <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;" />
     <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;" />
 Ingresa ahora<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;" />
   <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;" />
 </source>
-        <target>Have an account? <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>
+<target>Have an account? <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>
 <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>
  Login<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/>
 <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>
 </target>
-      </trans-unit>
-      <trans-unit id="indicaciones6" datatype="html">
-        <source>Para hacerlo sólo tienes que añadir: <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;" />
+</trans-unit>
+<trans-unit id="indicaciones6" datatype="html">
+<source>Para hacerlo sólo tienes que añadir: <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;" />
  AND <x id="INTERPOLATION" equiv-text="{{&apos; ${alias_tabla.columna_filtrada} &apos;}}" />
 <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;" />
  en la cláusula &apos;WHERE&apos; de la consulta donde quieras inyectar el filtro</source>
-        <target>To do it you just have to add:: <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>
+<target>To do it you just have to add:: <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>
  AND <x id="INTERPOLATION" equiv-text="{{&apos; ${alias_tabla.columna_filtrada} &apos;}}"/>
 <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/>
  in &apos;WHERE&apos; clause from query</target>
-      </trans-unit>
-      <trans-unit id="indicaciones7" datatype="html">
-        <source>Si no has añadido ninguna cláusula WHERE, añádela a la consulta y haz los joins necesarios, junto con el filtro en el formato <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;" />
+</trans-unit>
+<trans-unit id="indicaciones7" datatype="html">
+<source>Si no has añadido ninguna cláusula WHERE, añádela a la consulta y haz los joins necesarios, junto con el filtro en el formato <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;" />
 <x id="INTERPOLATION" equiv-text="{{&apos; ${alias_tabla.columna_filtrada} &apos;}}" />
 <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;" />
 </source>
-        <target>If you haven't added any WHERE clause, add it to the query and make the necessary joins, together with the filter in the format <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>
+<target>If you haven't added any WHERE clause, add it to the query and make the necessary joins, together with the filter in the format <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>
 <x id="INTERPOLATION" equiv-text="{{&apos; ${alias_tabla.columna_filtrada} &apos;}}"/>
 <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/>
 </target>
-      </trans-unit>
-      <trans-unit id="vistaSeleccionador" datatype="html">
-        <source>
+</trans-unit>
+<trans-unit id="vistaSeleccionador" datatype="html">
+<source>
 <x id="INTERPOLATION" equiv-text="{{!modeSQL ? editQuery : editSQLQuery}}" />
 </source>
-        <target>
+<target>
 <x id="INTERPOLATION" equiv-text="{{!modeSQL ? editQuery : editSQLQuery}}"/>
 </target>
-      </trans-unit>
-      <trans-unit id="editModelHeaders" datatype="html">
-        <source>Editar <x id="INTERPOLATION" equiv-text="{{tablePanel.type ? tablePanel.name : &apos;&apos;}}" />
+</trans-unit>
+<trans-unit id="editModelHeaders" datatype="html">
+<source>Editar <x id="INTERPOLATION" equiv-text="{{tablePanel.type ? tablePanel.name : &apos;&apos;}}" />
 </source>
-        <target>Edit <x id="INTERPOLATION" equiv-text="{{tablePanel.type ? tablePanel.name : &apos;&apos;}}"/>
+<target>Edit <x id="INTERPOLATION" equiv-text="{{tablePanel.type ? tablePanel.name : &apos;&apos;}}"/>
 </target>
-      </trans-unit>
-      <trans-unit id="registers1" datatype="html">
-        <source>
+</trans-unit>
+<trans-unit id="registers1" datatype="html">
+<source>
 <x id="INTERPOLATION" equiv-text="{{ table.filteredValue.length }}" />
  registros</source>
-        <target>
+<target>
 <x id="INTERPOLATION" equiv-text="{{ table.filteredValue.length }}"/>
  records</target>
-      </trans-unit>
-      <trans-unit id="registers2" datatype="html">
-        <source>
+</trans-unit>
+<trans-unit id="registers2" datatype="html">
+<source>
 <x id="INTERPOLATION" equiv-text="{{ table.value.length }}" />
  registros</source>
-        <target>
+<target>
 <x id="INTERPOLATION" equiv-text="{{ table.value.length }}"/>
  registres</target>
-      </trans-unit>
-      <trans-unit id="topQueryH4" datatype="html">
-        <source>Mostrar Top: <x id="START_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;p-inputNumber&gt;" />
+</trans-unit>
+<trans-unit id="topQueryH4" datatype="html">
+<source>Mostrar Top: <x id="START_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;p-inputNumber&gt;" />
 <x id="CLOSE_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;/p-inputNumber&gt;" />
 </source>
-        <target>Show Top: <x id="START_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;p-inputNumber&gt;"/>
+<target>Show Top: <x id="START_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;p-inputNumber&gt;"/>
 <x id="CLOSE_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;/p-inputNumber&gt;"/>
 </target>
-      </trans-unit>
-      <trans-unit id="atributosH4interpolation" datatype="html">
-        <source>
+</trans-unit>
+<trans-unit id="atributosH4interpolation" datatype="html">
+<source>
 <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
 </source>
-        <target>
+<target>
 <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
 </target>
-      </trans-unit>
-    </body>
-  </file>
+</trans-unit>
+</body>
+</file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4705,11 +4705,11 @@ Once configured you can invoke it whenever you want from the button.</target>
       </trans-unit>
       <trans-unit id="groupByDisabledReason">
         <source>No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.</source>
-        <target>Cannot change grouping because there are fields with aggregations configured. Remove aggregations first.</target>
+        <target>Before you can change the grouping, you must remove the aggregations configured on the fields.</target>
       </trans-unit>
       <trans-unit id="groupByDisabledAggregations">
         <source>En modo No agrupar, las agregaciones en los campos están deshabilitadas automáticamente.</source>
-        <target>In Do not group mode, field aggregations are automatically disabled.</target>
+        <target>In "Do not group" mode, aggregations on fields are automatically disabled.</target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -2922,7 +2922,7 @@ Login<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/>
   <target>This quarter</target>
 </trans-unit>
 <trans-unit id="DatePickerLastQuarter">
-  <source>Último trimestre</source> 
+  <source>Último trimestre</source>
   <target>Last quarter</target>
 </trans-unit>
 <trans-unit id="DatePickerBeforeTodayIncluded">
@@ -4702,18 +4702,6 @@ Once configured you can invoke it whenever you want from the button.</target>
       <trans-unit id="groupByEnabledHide">
         <source>Agrupar</source>
         <target>Group</target>
-      </trans-unit>
-      <trans-unit id="noAttributeShouldHaveAggregation">
-        <source>Ningún Atributo debe tener agregación</source>
-        <target>No attribute should have aggregation</target>
-      </trans-unit>
-      <trans-unit id="mustConfigureAtLeastOneAttribute">
-        <source>Debe configurar un atributo como mínimo para habilitar esta opción</source>
-        <target>You must configure at least one attribute to enable this option</target>
-      </trans-unit>
-      <trans-unit id="mustAddTheGroupingsToRunWithAggregations">
-        <source>Debe activar las agrupaciones para ejecutar con agregaciones configuradas en los atributos</source>
-        <target>You must enable groupings to execute with aggregations configured on the attributes</target>
       </trans-unit>
         </body>
   </file>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4695,6 +4695,14 @@ Once configured you can invoke it whenever you want from the button.</target>
         <source>elementos seleccionados</source>
         <target>selected items</target>
       </trans-unit>
+      <trans-unit id="groupByEnabledShow">
+        <source>Mostrar Repetidos</source>
+        <target>Show Duplicates</target>
+      </trans-unit>
+      <trans-unit id="groupByEnabledHide">
+        <source>Ocultar Repetidos</source>
+        <target>Hide Duplicates</target>
+      </trans-unit>
         </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4703,6 +4703,14 @@ Once configured you can invoke it whenever you want from the button.</target>
         <source>Agrupar</source>
         <target>Group</target>
       </trans-unit>
-        </body>
+      <trans-unit id="groupByDisabledReason">
+        <source>No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.</source>
+        <target>Cannot change grouping because there are fields with aggregations configured. Remove aggregations first.</target>
+      </trans-unit>
+      <trans-unit id="groupByDisabledAggregations">
+        <source>En modo No agrupar, las agregaciones en los campos están deshabilitadas automáticamente.</source>
+        <target>In Do not group mode, field aggregations are automatically disabled.</target>
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4705,7 +4705,7 @@ Once configured you can invoke it whenever you want from the button.</target>
       </trans-unit>
       <trans-unit id="groupByDisabledAggregations">
         <source>En modo agrupar desactivado, las agregaciones en los campos están deshabilitadas automáticamente.</source>
-        <target>IIn disabled grouping mode, aggregations on fields are automatically disabled.</target>
+        <target>If grouping mode is disabled, aggregations in fields are automatically disabled.</target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4703,6 +4703,18 @@ Once configured you can invoke it whenever you want from the button.</target>
         <source>Ocultar Repetidos</source>
         <target>Hide Duplicates</target>
       </trans-unit>
+      <trans-unit id="noAttributeShouldHaveAggregation">
+        <source>Ningún Atributo debe tener agregación</source>
+        <target>No attribute should have aggregation</target>
+      </trans-unit>
+      <trans-unit id="mustConfigureAtLeastOneAttribute">
+        <source>Debe configurar un atributo como mínimo para habilitar esta opción</source>
+        <target>You must configure at least one attribute to enable this option</target>
+      </trans-unit>
+      <trans-unit id="mustAddTheGroupingsToRunWithAggregations">
+        <source>Debe activar las agrupaciones para ejecutar con agregaciones configuradas en los atributos</source>
+        <target>You must enable groupings to execute with aggregations configured on the attributes</target>
+      </trans-unit>
         </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4696,12 +4696,12 @@ Once configured you can invoke it whenever you want from the button.</target>
         <target>selected items</target>
       </trans-unit>
       <trans-unit id="groupByEnabledShow">
-        <source>Mostrar Repetidos</source>
-        <target>Show Duplicates</target>
+        <source>No agrupar</source>
+        <target>Do not group</target>
       </trans-unit>
       <trans-unit id="groupByEnabledHide">
-        <source>Ocultar Repetidos</source>
-        <target>Hide Duplicates</target>
+        <source>Agrupar</source>
+        <target>Group</target>
       </trans-unit>
       <trans-unit id="noAttributeShouldHaveAggregation">
         <source>Ningún Atributo debe tener agregación</source>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -4695,10 +4695,6 @@ Once configured you can invoke it whenever you want from the button.</target>
         <source>elementos seleccionados</source>
         <target>selected items</target>
       </trans-unit>
-      <trans-unit id="groupByEnabledShow">
-        <source>No agrupar</source>
-        <target>Do not group</target>
-      </trans-unit>
       <trans-unit id="groupByEnabledHide">
         <source>Agrupar</source>
         <target>Group</target>
@@ -4708,8 +4704,8 @@ Once configured you can invoke it whenever you want from the button.</target>
         <target>Before you can change the grouping, you must remove the aggregations configured on the fields.</target>
       </trans-unit>
       <trans-unit id="groupByDisabledAggregations">
-        <source>En modo No agrupar, las agregaciones en los campos están deshabilitadas automáticamente.</source>
-        <target>In "Do not group" mode, aggregations on fields are automatically disabled.</target>
+        <source>En modo agrupar desactivado, las agregaciones en los campos están deshabilitadas automáticamente.</source>
+        <target>IIn disabled grouping mode, aggregations on fields are automatically disabled.</target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4584,10 +4584,6 @@
         <source>elementos seleccionados</source>
         <target>elementos seleccionados</target>
       </trans-unit>
-      <trans-unit id="groupByEnabledShow">
-        <source>No agrupar</source>
-        <target>No agrupar</target>
-      </trans-unit>
       <trans-unit id="groupByEnabledHide">
         <source>Agrupar</source>
         <target>Agrupar</target>
@@ -4597,8 +4593,8 @@
         <target>Antes de cambiar la agrupación, debe eliminar las agregaciones configuradas en los campos.</target>
       </trans-unit>
       <trans-unit id="groupByDisabledAggregations">
-        <source>En modo No agrupar, las agregaciones en los campos están deshabilitadas automáticamente.</source>
-        <target>En el modo "No agrupar" las agregaciones a los campos se deshabilitan automáticamente.</target>
+        <source>En modo agrupar desactivado, las agregaciones en los campos están deshabilitadas automáticamente.</source>
+        <target>En modo agrupar desactivado,las agregaciones a los campos se deshabilitan automáticamente.</target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4585,12 +4585,12 @@
         <target>elementos seleccionados</target>
       </trans-unit>
       <trans-unit id="groupByEnabledShow">
-        <source>Mostrar Repetidos</source>
-        <target>Mostrar Repetidos</target>
+        <source>No agrupar</source>
+        <target>No agrupar</target>
       </trans-unit>
       <trans-unit id="groupByEnabledHide">
-        <source>Ocultar Repetidos</source>
-        <target>Ocultar Repetidos</target>
+        <source>Agrupar</source>
+        <target>Agrupar</target>
       </trans-unit>
       <trans-unit id="noAttributeShouldHaveAggregation">
         <source>Ningún Atributo debe tener agregación</source>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4584,6 +4584,14 @@
         <source>elementos seleccionados</source>
         <target>elementos seleccionados</target>
       </trans-unit>
+      <trans-unit id="groupByEnabledShow">
+        <source>Mostrar Repetidos</source>
+        <target>Mostrar Repetidos</target>
+      </trans-unit>
+      <trans-unit id="groupByEnabledHide">
+        <source>Ocultar Repetidos</source>
+        <target>Ocultar Repetidos</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4592,6 +4592,18 @@
         <source>Ocultar Repetidos</source>
         <target>Ocultar Repetidos</target>
       </trans-unit>
+      <trans-unit id="noAttributeShouldHaveAggregation">
+        <source>Ningún Atributo debe tener agregación</source>
+        <target>Ningún Atributo debe tener agregación</target>
+      </trans-unit>
+      <trans-unit id="mustConfigureAtLeastOneAttribute">
+        <source>Debe configurar un atributo como mínimo para habilitar esta opción</source>
+        <target>Debe configurar un atributo como mínimo para habilitar esta opción</target>
+      </trans-unit>
+      <trans-unit id="mustAddTheGroupingsToRunWithAggregations">
+        <source>Debe activar las agrupaciones para ejecutar con agregaciones configuradas en los atributos</source>
+        <target>Debe activar las agrupaciones para ejecutar con agregaciones configuradas en los atributos</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4592,6 +4592,14 @@
         <source>Agrupar</source>
         <target>Agrupar</target>
       </trans-unit>
+      <trans-unit id="groupByDisabledReason">
+        <source>No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.</source>
+        <target>No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.</target>
+      </trans-unit>
+      <trans-unit id="groupByDisabledAggregations">
+        <source>En modo No agrupar, las agregaciones en los campos están deshabilitadas automáticamente.</source>
+        <target>En modo No agrupar, las agregaciones en los campos están deshabilitadas automáticamente.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -2163,6 +2163,18 @@
         <source>Tipo de intersección:</source>
         <target>Tipo de intersección:</target>
       </trans-unit>
+      <trans-unit id="groupByEnabledHide">
+        <source>Agrupar</source>
+        <target>Agrupar</target>
+      </trans-unit>
+      <trans-unit id="groupByDisabledReason">
+        <source>No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.</source>
+        <target>Antes de cambiar la agrupación, debe eliminar las agregaciones configuradas en los campos.</target>
+      </trans-unit>
+      <trans-unit id="groupByDisabledAggregations">
+        <source>En modo agrupar desactivado, las agregaciones en los campos están deshabilitadas automáticamente.</source>
+        <target>Si el modo agrupar está desactivado las agregaciones en los campos se deshabilitan automáticamente.</target>
+      </trans-unit>
       <trans-unit id="addCSV">
         <source>Añadir tabla desde CSV</source>
         <target>Añadir tabla desde CSV</target>
@@ -2405,100 +2417,88 @@
         <source>Estoy de acuerdo con los <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;" />
  términos<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;" />
       </source>
-        <target>Estoy de acuerdo con los <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;" />
+      <target>Estoy de acuerdo con los <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;" />
  términos<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;" />
     </target>
-      </trans-unit>
-      <trans-unit id="haveAccount" datatype="html">
-        <source>¿Tienes una cuenta? <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;" />
+  </trans-unit>
+  <trans-unit id="haveAccount" datatype="html">
+    <source>¿Tienes una cuenta? <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;" />
     <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;" />
 Ingresa ahora<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;" />
   <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;" />
 </source>
-        <target>¿Tienes una cuenta? <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;" />
+<target>¿Tienes una cuenta? <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;" />
 <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;" />
 Ingresa ahora<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;" />
 <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;" />
 </target>
-      </trans-unit>
-      <trans-unit id="indicaciones6" datatype="html">
-        <source>Para hacerlo sólo tienes que añadir: <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;" />
+</trans-unit>
+<trans-unit id="indicaciones6" datatype="html">
+<source>Para hacerlo sólo tienes que añadir: <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;" />
  AND <x id="INTERPOLATION" equiv-text="{{&apos; ${alias_tabla.columna_filtrada} &apos;}}" />
 <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;" />
  en la cláusula &apos;WHERE&apos; de la consulta donde quieras inyectar el filtro</source>
-        <target>Para hacerlo, sólo tienes que añadir: <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;" />
+<target>Para hacerlo, sólo tienes que añadir: <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;" />
  AND <x id="INTERPOLATION" equiv-text="{{&apos; ${alias_tabla.columna_filtrada} &apos;}}" />
 <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;" />
  en la cláusula &apos;WHERE&apos; de la consulta donde quieras inyectar el filtro</target>
-      </trans-unit>
-      <trans-unit id="indicaciones7" datatype="html">
-        <source>Si no has añadido ninguna cláusula WHERE, añádela a la consulta y haz los joins necesarios, junto con el filtro en el formato <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;" />
+</trans-unit>
+<trans-unit id="indicaciones7" datatype="html">
+<source>Si no has añadido ninguna cláusula WHERE, añádela a la consulta y haz los joins necesarios, junto con el filtro en el formato <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;" />
 <x id="INTERPOLATION" equiv-text="{{&apos; ${alias_tabla.columna_filtrada} &apos;}}" />
 <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;" />
 </source>
-        <target>Si no has añadido ninguna cláusula WHERE, añádela a la consulta y haz los joins necesarios, junto con el filtro en el formato <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;" />
+<target>Si no has añadido ninguna cláusula WHERE, añádela a la consulta y haz los joins necesarios, junto con el filtro en el formato <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;" />
 <x id="INTERPOLATION" equiv-text="{{&apos; ${alias_tabla.columna_filtrada} &apos;}}" />
 <x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;" />
 </target>
-      </trans-unit>
-      <trans-unit id="vistaSeleccionador" datatype="html">
-        <source>
+</trans-unit>
+<trans-unit id="vistaSeleccionador" datatype="html">
+<source>
 <x id="INTERPOLATION" equiv-text="{{!modeSQL ? editQuery : editSQLQuery}}" />
 </source>
-        <target>
+<target>
 <x id="INTERPOLATION" equiv-text="{{!modeSQL ? editQuery : editSQLQuery}}" />
 </target>
-      </trans-unit>
-      <trans-unit id="editModelHeaders" datatype="html">
-        <source>Editar <x id="INTERPOLATION" equiv-text="{{tablePanel.type ? tablePanel.name : &apos;&apos;}}" />
+</trans-unit>
+<trans-unit id="editModelHeaders" datatype="html">
+<source>Editar <x id="INTERPOLATION" equiv-text="{{tablePanel.type ? tablePanel.name : &apos;&apos;}}" />
 </source>
-        <target>Editar <x id="INTERPOLATION" equiv-text="{{tablePanel.type ? tablePanel.name : &apos;&apos;}}" />
+<target>Editar <x id="INTERPOLATION" equiv-text="{{tablePanel.type ? tablePanel.name : &apos;&apos;}}" />
 </target>
-      </trans-unit>
-      <trans-unit id="registers1" datatype="html">
-        <source>
+</trans-unit>
+<trans-unit id="registers1" datatype="html">
+<source>
 <x id="INTERPOLATION" equiv-text="{{ table.filteredValue.length }}" />
  registros</source>
-        <target>
+<target>
 <x id="INTERPOLATION" equiv-text="{{ table.filteredValue.length }}" />
  registros</target>
-      </trans-unit>
-      <trans-unit id="registers2" datatype="html">
-        <source>
+</trans-unit>
+<trans-unit id="registers2" datatype="html">
+<source>
 <x id="INTERPOLATION" equiv-text="{{ table.value.length }}" />
  registros</source>
-        <target>
+<target>
 <x id="INTERPOLATION" equiv-text="{{ table.value.length }}" />
  registros</target>
-      </trans-unit>
-      <trans-unit id="topQueryH4" datatype="html">
-        <source>Mostrar Top: <x id="START_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;p-inputNumber&gt;" />
+</trans-unit>
+<trans-unit id="topQueryH4" datatype="html">
+<source>Mostrar Top: <x id="START_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;p-inputNumber&gt;" />
 <x id="CLOSE_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;/p-inputNumber&gt;" />
 </source>
-        <target>Mostrar Top: <x id="START_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;p-inputNumber&gt;" />
+<target>Mostrar Top: <x id="START_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;p-inputNumber&gt;" />
 <x id="CLOSE_TAG_P-INPUTNUMBER" ctype="x-p-inputNumber" equiv-text="&lt;/p-inputNumber&gt;" />
 </target>
-      </trans-unit>
-      <trans-unit id="atributosH4interpolation" datatype="html">
-        <source>
+</trans-unit>
+<trans-unit id="atributosH4interpolation" datatype="html">
+<source>
 <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
 </source>
-        <target>
+<target>
 <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
 </target>
-      </trans-unit>
-      <trans-unit id="groupByEnabledHide">
-        <source>Agrupar</source>
-        <target>Agrupar</target>
-      </trans-unit>
-      <trans-unit id="groupByDisabledReason">
-        <source>No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.</source>
-        <target>Antes de cambiar la agrupación, debe eliminar las agregaciones configuradas en los campos.</target>
-      </trans-unit>
-      <trans-unit id="groupByDisabledAggregations">
-        <source>En modo agrupar desactivado, las agregaciones en los campos están deshabilitadas automáticamente.</source>
-        <target>Si el modo agrupar está desactivado las agregaciones en los campos se deshabilitan automáticamente.</target>
-      </trans-unit>
-    </body>
-  </file>
+</trans-unit>
+</body>
+</file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -3083,7 +3083,7 @@
       <trans-unit id="DatePickerLastQuarter">
         <source>Último trimestre</source>
         <target>El trimestre pasado</target>
-      </trans-unit>  
+      </trans-unit>
       <trans-unit id="DatePickerBeforeTodayIncluded">
         <source>Todo hasta hoy</source>
         <target>Todo hasta hoy</target>
@@ -3092,7 +3092,7 @@
         <source>Mañana</source>
         <target>Mañana</target>
       </trans-unit>
-      
+
       <trans-unit id="DatePickerPastTomorrow">
         <source>Pasado mañana</source>
         <target>Pasado mañana</target>
@@ -4591,18 +4591,6 @@
       <trans-unit id="groupByEnabledHide">
         <source>Agrupar</source>
         <target>Agrupar</target>
-      </trans-unit>
-      <trans-unit id="noAttributeShouldHaveAggregation">
-        <source>Ningún Atributo debe tener agregación</source>
-        <target>Ningún Atributo debe tener agregación</target>
-      </trans-unit>
-      <trans-unit id="mustConfigureAtLeastOneAttribute">
-        <source>Debe configurar un atributo como mínimo para habilitar esta opción</source>
-        <target>Debe configurar un atributo como mínimo para habilitar esta opción</target>
-      </trans-unit>
-      <trans-unit id="mustAddTheGroupingsToRunWithAggregations">
-        <source>Debe activar las agrupaciones para ejecutar con agregaciones configuradas en los atributos</source>
-        <target>Debe activar las agrupaciones para ejecutar con agregaciones configuradas en los atributos</target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4594,11 +4594,11 @@
       </trans-unit>
       <trans-unit id="groupByDisabledReason">
         <source>No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.</source>
-        <target>No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.</target>
+        <target>Antes de cambiar la agrupación, debe eliminar las agregaciones configuradas en los campos.</target>
       </trans-unit>
       <trans-unit id="groupByDisabledAggregations">
         <source>En modo No agrupar, las agregaciones en los campos están deshabilitadas automáticamente.</source>
-        <target>En modo No agrupar, las agregaciones en los campos están deshabilitadas automáticamente.</target>
+        <target>En el modo "No agrupar" las agregaciones a los campos se deshabilitan automáticamente.</target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -4594,7 +4594,7 @@
       </trans-unit>
       <trans-unit id="groupByDisabledAggregations">
         <source>En modo agrupar desactivado, las agregaciones en los campos están deshabilitadas automáticamente.</source>
-        <target>En modo agrupar desactivado,las agregaciones a los campos se deshabilitan automáticamente.</target>
+        <target>Si el modo agrupar está desactivado las agregaciones en los campos se deshabilitan automáticamente.</target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -2163,6 +2163,18 @@
         <source>Tipo de intersección:</source>
         <target>Tipo de intersección:</target>
       </trans-unit>
+      <trans-unit id="groupByEnabledHide">
+        <source>Agrupar</source>
+        <target>Agrupar</target>
+      </trans-unit>
+      <trans-unit id="groupByDisabledReason">
+        <source>No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.</source>
+        <target>Antes de cambiar la agrupación, debe eliminar las agregaciones configuradas en los campos.</target>
+      </trans-unit>
+      <trans-unit id="groupByDisabledAggregations">
+        <source>En modo agrupar desactivado, las agregaciones en los campos están deshabilitadas automáticamente.</source>
+        <target>Si el modo agrupar está desactivado las agregaciones en los campos se deshabilitan automáticamente.</target>
+      </trans-unit>
       <trans-unit id="addCSV">
         <source>Añadir tabla desde CSV</source>
         <target>Añadir tabla desde CSV</target>
@@ -2486,18 +2498,6 @@ Ingresa ahora<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;" />
         <target>
 <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
 </target>
-      </trans-unit>
-      <trans-unit id="groupByEnabledHide">
-        <source>Agrupar</source>
-        <target>Agrupar</target>
-      </trans-unit>
-      <trans-unit id="groupByDisabledReason">
-        <source>No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.</source>
-        <target>Non se pode cambiar a agrupación porque hai campos con agregacións configuradas. Elimina as agregacións primeiro.</target>
-      </trans-unit>
-      <trans-unit id="groupByDisabledAggregations">
-        <source>En modo agrupar desactivado, las agregaciones en los campos están deshabilitadas automáticamente.</source>
-        <target>Si el modo agrupar está desactivado las agregaciones en los campos se deshabilitan automáticamente.</target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -4593,6 +4593,14 @@
         <source>Agrupar</source>
         <target>Agrupar</target>
       </trans-unit>
+      <trans-unit id="groupByDisabledReason">
+        <source>No se puede cambiar el agrupamiento porque hay campos con agregaciones configuradas. Elimina las agregaciones primero.</source>
+        <target>Non se pode cambiar a agrupación porque hai campos con agregacións configuradas. Elimina as agregacións primeiro.</target>
+      </trans-unit>
+      <trans-unit id="groupByDisabledAggregations">
+        <source>En modo No agrupar, las agregaciones en los campos están deshabilitadas automáticamente.</source>
+        <target>En modo Non agrupar, as agregacións nos campos están deshabilitadas automáticamente.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -4595,7 +4595,7 @@
       </trans-unit>
       <trans-unit id="groupByDisabledAggregations">
         <source>En modo agrupar desactivado, las agregaciones en los campos están deshabilitadas automáticamente.</source>
-        <target>En modo agrupar desactivado, as agregacións nos campos están deshabilitadas automáticamente.</target>
+        <target>Si el modo agrupar está desactivado las agregaciones en los campos se deshabilitan automáticamente.</target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -4586,12 +4586,12 @@
         <target>elementos seleccionados</target>
       </trans-unit>
       <trans-unit id="groupByEnabledShow">
-        <source>Mostrar Repetidos</source>
-        <target>Mostrar repetidos</target>
+        <source>Non agrupar</source>
+        <target>Non agrupar</target>
       </trans-unit>
       <trans-unit id="groupByEnabledHide">
-        <source>Ocultar Repetidos</source>
-        <target>Ocultar Repetidos</target>
+        <source>Agrupar</source>
+        <target>Agrupar</target>
       </trans-unit>
       <trans-unit id="noAttributeShouldHaveAggregation">
         <source>Ningún Atributo debe tener agregación</source>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -4585,10 +4585,6 @@
         <source>elementos seleccionados</source>
         <target>elementos seleccionados</target>
       </trans-unit>
-      <trans-unit id="groupByEnabledShow">
-        <source>Non agrupar</source>
-        <target>Non agrupar</target>
-      </trans-unit>
       <trans-unit id="groupByEnabledHide">
         <source>Agrupar</source>
         <target>Agrupar</target>
@@ -4598,8 +4594,8 @@
         <target>Non se pode cambiar a agrupación porque hai campos con agregacións configuradas. Elimina as agregacións primeiro.</target>
       </trans-unit>
       <trans-unit id="groupByDisabledAggregations">
-        <source>En modo No agrupar, las agregaciones en los campos están deshabilitadas automáticamente.</source>
-        <target>En modo Non agrupar, as agregacións nos campos están deshabilitadas automáticamente.</target>
+        <source>En modo agrupar desactivado, las agregaciones en los campos están deshabilitadas automáticamente.</source>
+        <target>En modo agrupar desactivado, as agregacións nos campos están deshabilitadas automáticamente.</target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -4585,6 +4585,14 @@
         <source>elementos seleccionados</source>
         <target>elementos seleccionados</target>
       </trans-unit>
+      <trans-unit id="groupByEnabledShow">
+        <source>Mostrar Repetidos</source>
+        <target>Mostrar repetidos</target>
+      </trans-unit>
+      <trans-unit id="groupByEnabledHide">
+        <source>Ocultar Repetidos</source>
+        <target>Ocultar Repetidos</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -3041,7 +3041,7 @@
         <source>El año pasado, completo</source>
         <target>El año pasado, completo</target>
       </trans-unit>
-      
+
       <trans-unit id="DatePickerLast3">
         <source> Últimos 3 días </source>
         <target>Últimos 3 días</target>
@@ -3092,7 +3092,7 @@
         <source>Mañana</source>
         <target>Mañana</target>
       </trans-unit>
-      
+
       <trans-unit id="DatePickerPastTomorrow">
         <source>Pasado mañana</source>
         <target>Pasado mañana</target>
@@ -3112,7 +3112,7 @@
         <source>Próximos 3 días</source>
         <target>Próximos 3 días</target>
       </trans-unit>
-          
+
       <trans-unit id="DatePickerNext7">
         <source>Próximos 7 días</source>
         <target>Próximos 7 días</target>
@@ -4592,18 +4592,6 @@
       <trans-unit id="groupByEnabledHide">
         <source>Agrupar</source>
         <target>Agrupar</target>
-      </trans-unit>
-      <trans-unit id="noAttributeShouldHaveAggregation">
-        <source>Ningún Atributo debe tener agregación</source>
-        <target>Ningún atributo debe ter agregación</target>
-      </trans-unit>
-      <trans-unit id="mustConfigureAtLeastOneAttribute">
-        <source>Debe configurar un atributo como mínimo para habilitar esta opción</source>
-        <target>Debe configurar polo menos un atributo para habilitar esta opción</target>
-      </trans-unit>
-      <trans-unit id="mustAddTheGroupingsToRunWithAggregations">
-        <source>Debe activar las agrupaciones para ejecutar con agregaciones configuradas en los atributos</source>
-        <target>Debe activar as agrupacións para executar con agregacións configuradas nos atributos</target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -4593,6 +4593,18 @@
         <source>Ocultar Repetidos</source>
         <target>Ocultar Repetidos</target>
       </trans-unit>
+      <trans-unit id="noAttributeShouldHaveAggregation">
+        <source>Ningún Atributo debe tener agregación</source>
+        <target>Ningún atributo debe ter agregación</target>
+      </trans-unit>
+      <trans-unit id="mustConfigureAtLeastOneAttribute">
+        <source>Debe configurar un atributo como mínimo para habilitar esta opción</source>
+        <target>Debe configurar polo menos un atributo para habilitar esta opción</target>
+      </trans-unit>
+      <trans-unit id="mustAddTheGroupingsToRunWithAggregations">
+        <source>Debe activar las agrupaciones para ejecutar con agregaciones configuradas en los atributos</source>
+        <target>Debe activar as agrupacións para executar con agregacións configuradas nos atributos</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION


## Descripción del Cambio
- solves #118 
Se incorpora la opción de no agregación en las consultas. Esto se hace mediante la incorporación de la opción  "ocultar repetidos"  / "mostrar repetidos"  en el momento de definición de la consulta.   El texto es susceptible de cambios. 

<img width="1886" height="741" alt="image" src="https://github.com/user-attachments/assets/bcd8332d-1f2d-4ef8-8c4e-129e5f821033" />


El desarrollo se ha hecho importando los desarrollos que ya habían  para tal funcionalidad en Edalitics 3 
 

El cambio supone que se quita el group by de las consultas. 


Si hay agrupaciones en la consulta. Al marcar "mstrar repetidos" se quitan. 
