### PR TITLE
Enhancement - Mapas -  Eliminar límite de campos en mapa de coordenadas

### DIFF
--- a/eda/eda_app/src/app/services/utils/chart-utils.service.ts
+++ b/eda/eda_app/src/app/services/utils/chart-utils.service.ts
@@ -692,8 +692,9 @@ export class ChartUtilsService {
             notAllowed.splice(notAllowed.indexOf('crosstable'), 1);
         }
 
-        //Coordinates map Map (two coordinates and two aditional fields at max)
-        if (dataDescription.coordinateColumns === 2 && dataDescription.totalColumns < 5) {
+        //Coordinates map (two coordinates, no field limit)
+        /* SDA CUSTOM if (dataDescription.coordinateColumns === 2 && dataDescription.totalColumns < 5) {
+        /* SDA CUSTOM*/ if (dataDescription.coordinateColumns === 2) {
             notAllowed.splice(notAllowed.indexOf('coordinatesMap'), 1);
         }
 

--- a/eda/eda_app/src/app/services/utils/map-util.service.ts
+++ b/eda/eda_app/src/app/services/utils/map-util.service.ts
@@ -127,11 +127,13 @@ export class MapUtilsService extends ApiService {
   private makePopup = (data: any, labels: Array<string>): string => {
     const me = this;
     let div = "";
-    for (let i = 2; i < 4; i++) {
+    /* SDA CUSTOM*   for (let i = 2; i < 4; i++) {
+    /* SDA CUSTOM*/ for (let i = 2; i < data.length; i++) {
       if (data[i] !== undefined) {
+        /* SDA CUSTOM*/ const label = labels[i] !== undefined ? labels[i] : `Field ${i-1}`;
         div += `<div> ${me._sanitizer.sanitize(
           SecurityContext.HTML,
-          labels[i]
+          /* SDA CUSTOM*/ label
         )} :  ${data[i]} </div>`;
       }
     }


### PR DESCRIPTION
## Descripción del Cambio
 Eliminar límite de campos en el mapa de coordenadas (antes máximo 4 campos, latitud, longitud y dos campos de etiquetas). El popup ahora muestra todos los campos disponibles en las etiquetas

## Pruebas a realizar para validar el cambio
- Crear un nuevo Panel sobre Organizaciones.
- Incluir los campos de longitud y latitud y añadir tantos campos como se quiera 
- Ver que el mapa se forma y que los campos añadidos esta disponibles en el popup informativo.
