### PR TITLE
Enhancement - General - Gestión automática de releases

### DIFF
--- a/.github/workflows/Projects_ChangeStatusReadyForNextRelease.yml
+++ b/.github/workflows/Projects_ChangeStatusReadyForNextRelease.yml
@@ -1,0 +1,91 @@
+name: Projects - Change Status Ready for Next Release
+on:
+  pull_request_target:
+      types:
+         - closed
+      branches:    
+      - 'master'
+jobs:
+  if_merged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get project data
+        env:
+            GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+            ORGANIZATION: SinergiaTIC
+            PROJECT_NUMBER: 23
+            PR_ID: ${{ github.event.pull_request.node_id }}
+        run: |
+            gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectV2(number: $number) {
+                  id
+                  fields(first:20) {
+                    nodes {
+                      ... on ProjectV2Field {
+                        id
+                        name
+                      }
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                  items(first:100) {
+                    nodes {
+                      ... on ProjectV2Item {
+                        id
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+            echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
+            echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
+            echo 'STATUS_VALUE='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name=="Ready for next release") |.id' project_data.json) >> $GITHUB_ENV
+      - name: Get PR Item ID
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          PR_ID: ${{ github.event.pull_request.node_id }}
+        run: |
+          item_id="$( gh api graphql -f query='
+            mutation($project:ID!, $pr:ID!) {
+              addProjectV2ItemById(input: {projectId: $project, contentId: $pr}) {
+                item {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f pr=$PR_ID --jq '.data.addProjectV2ItemById.item.id')"
+            echo 'ITEM_ID='$item_id >> $GITHUB_ENV
+      - name: Change Status
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+           gh api graphql -f query='
+              mutation (
+                $project: ID!
+                $item: ID!
+                $status_field: ID!
+                $status_value: String!
+              ) {
+                set_status: updateProjectV2ItemFieldValue(input: {
+                  projectId: $project
+                  itemId: $item
+                  fieldId: $status_field
+                  value: { 
+                    singleSelectOptionId: $status_value
+                    }
+                }) {
+                  projectV2Item {
+                    id
+                    }
+                }
+              }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.STATUS_VALUE }} --silent

--- a/.github/workflows/Projects_MoveToRelease.yml
+++ b/.github/workflows/Projects_MoveToRelease.yml
@@ -1,0 +1,190 @@
+
+name: Projects - Move to release
+on:
+  release:
+      types: [published]
+jobs:
+  move_to_release_project:
+    name: Move to release project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Get project Updates data
+        env:
+            GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+            ORGANIZATION: SinergiaTIC
+            PROJECT_NUMBER: 23
+        run: |
+            gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+                organization(login: $org){
+                    projectV2(number: $number) {
+                        id
+                        fields(first:20) {
+                            nodes {
+                                ... on ProjectV2Field {
+                                    id
+                                    name
+                                }
+                                ... on ProjectV2SingleSelectField {
+                                    id
+                                    name
+                                    options {
+                                        id
+                                        name
+                                    }
+                                }
+                            }
+                        }
+                        items(first:100) {
+                            nodes {
+                                ... on ProjectV2Item {
+                                    id
+                                    fieldValues(first:100) {
+                                        nodes {
+                                            ... on ProjectV2ItemFieldSingleSelectValue {
+                                                name
+                                                item {
+                                                    id
+                                                    content{
+                                                        ... on PullRequest{
+                                                            id
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+            echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
+            echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
+            echo 'STATUS_VALUE='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name=="Ready for next release") |.id' project_data.json) >> $GITHUB_ENV
+            PROJECT_ITEMS=$(jq '.data.organization.projectV2.items' project_data.json)
+            echo 'FILTERED_ITEMS='$(echo $PROJECT_ITEMS | jq -r '.nodes[] | .fieldValues.nodes[] | select(.name=="Ready for next release") | .') >> $GITHUB_ENV
+      - name: Get project Release data
+        env:
+            GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+            ORGANIZATION: SinergiaTIC
+            PROJECT_RELEASE: 21
+        run: |
+            gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+                organization(login: $org){
+                    projectV2(number: $number) {
+                        id
+                        fields(first:20) {
+                            nodes {
+                                ... on ProjectV2Field {
+                                    id
+                                    name
+                                }
+                                ... on ProjectV2SingleSelectField {
+                                    id
+                                    name
+                                    options {
+                                        id
+                                        name
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_RELEASE > project_data.json
+            echo 'PROJECT_ID_RELEASE='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
+            echo 'VERSION_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Version") | .id' project_data.json) >> $GITHUB_ENV
+            echo 'DATE_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Date") | .id' project_data.json) >> $GITHUB_ENV
+            echo 'CURRENT_DATE='$(date +'%Y-%m-%d') >> $GITHUB_ENV
+      - name: Add PRs to release and add version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          VERSION_NUMBER: ${{ env.RELEASE_VERSION }}
+        run: |
+          FILTERED_ITEMS_CONTENT_ID=$(echo $FILTERED_ITEMS | jq -r '.item.content.id')
+          for PR_ITEM_CONTENT_ID in $FILTERED_ITEMS_CONTENT_ID; do 
+            ITEM_ID="$( gh api graphql -f query='
+                    mutation($project:ID!, $pr:ID!) {
+                      addProjectV2ItemById(input: {projectId: $project, contentId: $pr}) {
+                        item {
+                          id
+                        }
+                      }
+                    }' -f project=$PROJECT_ID_RELEASE -f pr=$PR_ITEM_CONTENT_ID --jq '.data.addProjectV2ItemById.item.id')"
+            echo $ITEM_ID
+            gh api graphql -f query='
+                mutation (
+                    $project: ID!
+                    $item: ID!
+                    $version_field: ID!
+                    $version_value: String!
+                ) {
+                set_version: updateProjectV2ItemFieldValue(input: {
+                    projectId: $project
+                    itemId: $item
+                    fieldId: $version_field
+                    value: { 
+                        text: $version_value
+                    }
+                }) {
+                    projectV2Item {
+                        id
+                    }
+                }
+                }' -f project=$PROJECT_ID_RELEASE -f item=$ITEM_ID -f version_field=$VERSION_FIELD_ID -f version_value=$VERSION_NUMBER --silent
+            gh api graphql -f query='
+                mutation (
+                    $project: ID!
+                    $item: ID!
+                    $date_field: ID!
+                    $date_value: Date!
+                ) {
+                set_date: updateProjectV2ItemFieldValue(input: {
+                    projectId: $project
+                    itemId: $item
+                    fieldId: $date_field
+                    value: { 
+                        date: $date_value
+                    }
+                })
+                    {
+                    projectV2Item {
+                        id
+                    }
+                }
+                }' -f project=$PROJECT_ID_RELEASE -f item=$ITEM_ID -f date_field=$DATE_FIELD_ID -f date_value=$CURRENT_DATE --silent
+          done
+      - name: Remove PRs from updates
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          FILTERED_ITEMS_ITEM_ID=$(echo $FILTERED_ITEMS | jq -r '.item.id')
+          for PR_ITEM_ID in $FILTERED_ITEMS_ITEM_ID; do 
+            gh api graphql -f query='
+                      mutation (
+                        $project: ID!
+                        $item: ID!
+                      ) {
+                        delete_item: deleteProjectV2Item(input: {
+                          projectId: $project
+                          itemId: $item
+                        }) {
+                            deletedItemId
+                        }
+                      }' -f project=$PROJECT_ID -f item=$PR_ITEM_ID -f status_field=$STATUS_FIELD_ID --silent
+          done
+    #   - name: Add PR Number as Tag
+    #     uses: actions/github-script@v6
+    #     with:
+    #       script: |
+    #         github.rest.git.createRef({
+    #           owner: context.repo.owner,
+    #           repo: context.repo.repo,
+    #           ref: 'refs/tags/v${{ github.event.pull_request.number }}',
+    #           sha: context.sha
+    #         })


### PR DESCRIPTION

## Descripción del Cambio
Se añaden los dos workflows de GitHub Actions adaptados del repositorio SinergiaCRM para automatizar la gestión de releases en SinergiaDA.

 **Workflows incluidos:**

**1. `change-status.yml` - Projects: Change Status Ready for Next Release**
Se dispara cuando se mergea un PR a `master`. Añade automáticamente el PR al proyecto **SinergiaDA Updates** (nº 23) y cambia su estado a `Ready for next release`.

**2. `move-to-release.yml` - Projects: Move to Release**
Se dispara cuando se publica una release. Recoge todos los PRs con estado `Ready for next release` del proyecto Updates y los mueve al proyecto **SinergiaDA Releases**, rellenando automáticamente los campos `Version` y `Date`.
