### PR TITLE
Hotfix - Idiomas - Se corrige error de sintaxis

### DIFF
--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -555,7 +555,6 @@
     <target>Fondo de etiquetas</target>
   </trans-unit>
   <!-- END SDA CUSTOM -->
-  </body>
   <!-- SDA CUSTOM - Logs viewer labels -->
   <trans-unit id="LogsViewer" datatype="html">
     <source>Visor de logs</source>


### PR DESCRIPTION
## Descripción
Se corrige un fichero de idioma con un error de sintaxis

## Pruebas
- Por inspección de código