### PR TITLE
Hotfix - Informes - Recuperar exportación en informes públicos

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
@@ -19,14 +19,14 @@
             </div>
         </ng-container>
 
-<!-- SDA CUSTOM -->    <div *ngIf="getEditMode()" class="d-flex align-items-center">
+<!-- SDA CUSTOM -->    <div class="d-flex align-items-center">
 <!-- SDA CUSTOM -->      <div *ngIf="inject.canSave" class="mr-2 pointer" (click)="toggleLock()" [attr.title]="panel.locked ? unlockPanelTooltip : lockPanelTooltip">
 <!-- SDA CUSTOM -->        <i [className]="panel.locked ? 'fa fa-lock' : 'fa fa-unlock'" [style.color]="panel.locked ? 'red' : 'green'"></i>
 <!-- SDA CUSTOM -->      </div>
 
-        <div id="edit" [ngClass]="{'edit-blink': lodash.isEmpty(panel.content) }" style="width: 25px;">
-            <i class="fa fa-ellipsis-v btn" (click)="contextMenu.showContextMenu($event)"></i>
-        </div>
+<!-- SDA CUSTOM -->      <div id="edit" [ngClass]="{'edit-blink': lodash.isEmpty(panel.content) }" style="width: 25px;">
+<!-- SDA CUSTOM -->          <i class="fa fa-ellipsis-v btn" (click)="contextMenu.showContextMenu($event)"></i>
+<!-- SDA CUSTOM -->      </div>
 <!-- SDA CUSTOM -->    </div>
     </div>
 </div>

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.html
@@ -19,7 +19,7 @@
             </div>
         </ng-container>
 
-<!-- SDA CUSTOM -->    <div class="d-flex align-items-center">
+<!-- SDA CUSTOM -->    <div *ngIf="getEditMode() || isAnonymousUser()" class="d-flex align-items-center">
 <!-- SDA CUSTOM -->      <div *ngIf="inject.canSave" class="mr-2 pointer" (click)="toggleLock()" [attr.title]="panel.locked ? unlockPanelTooltip : lockPanelTooltip">
 <!-- SDA CUSTOM -->        <i [className]="panel.locked ? 'fa fa-lock' : 'fa fa-unlock'" [style.color]="panel.locked ? 'red' : 'green'"></i>
 <!-- SDA CUSTOM -->      </div>

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -397,6 +397,15 @@ export class EdaBlankPanelComponent implements OnInit {
         return (userName !== 'edaanonim' && !this.inject.isObserver);
     }
 
+/* SDA CUSTOM */    public isAnonymousUser(): boolean {
+/* SDA CUSTOM */        const user = localStorage.getItem('user');
+/* SDA CUSTOM */        if (!user) {
+/* SDA CUSTOM */            return false;
+/* SDA CUSTOM */        }
+/* SDA CUSTOM */        const userName = JSON.parse(user).name;
+/* SDA CUSTOM */        return userName === 'edaanonim';
+/* SDA CUSTOM */    }
+
     public showWhatIfSection(): boolean {
         return this.currentQuery.some((query: any) => query.whatif_column);
     }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-menu-options.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-menu-options.ts
@@ -283,8 +283,13 @@ export const PanelOptions = {
 },
   generateMenu : (panelComponent : EdaBlankPanelComponent ) => {
     const menu = [];
-    const editmode = panelComponent.getEditMode();
+/* SDA CUSTOM */    const editmode = !!panelComponent.inject?.canSave;
     const type = panelComponent.getChartType();
+
+/* SDA CUSTOM */    if (!editmode) {
+/* SDA CUSTOM */      menu.push(PanelOptions.exportExcel(panelComponent));
+/* SDA CUSTOM */      return menu;
+/* SDA CUSTOM */    }
     
     if (editmode) {
         menu.push(PanelOptions.editQuery(panelComponent));

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-menu-options.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-menu-options.ts
@@ -4,6 +4,16 @@ import * as _ from 'lodash';
 import { EdaContextMenuItem, EdaDialogController } from "@eda/shared/components/shared-components.index";
 
 export const PanelOptions = {
+/* SDA CUSTOM */  isAnonymousUser: (): boolean => {
+/* SDA CUSTOM */    try {
+/* SDA CUSTOM */      const user = localStorage.getItem('user');
+/* SDA CUSTOM */      if (!user) return false;
+/* SDA CUSTOM */      const parsedUser = JSON.parse(user);
+/* SDA CUSTOM */      return parsedUser?.name === 'edaanonim';
+/* SDA CUSTOM */    } catch (_e) {
+/* SDA CUSTOM */      return false;
+/* SDA CUSTOM */    }
+/* SDA CUSTOM */  },
   editQuery: (panelComponent: EdaBlankPanelComponent) => {
     return new EdaContextMenuItem({
       label: $localize`:@@panelOptions1:Editar consulta`,
@@ -36,13 +46,13 @@ export const PanelOptions = {
       command: () => {
 
         if (Object.entries(panelComponent.graficos).length !== 0 && panelComponent.chartData.length !== 0) {
-          
+
           if (['line', 'area', 'doughnut', 'polarArea', 'bar', 'horizontalBar', 'barline', 'histogram', 'pyramid', 'radar'].includes(panelComponent.graficos.chartType)) {
 
             panelComponent.contextMenu.hideContextMenu();
             panelComponent.chartController = new EdaDialogController({
               params: {
-                panelId: _.get(panelComponent.panel, 'id'), 
+                panelId: _.get(panelComponent.panel, 'id'),
                 chart: panelComponent.graficos,
                 config: panelComponent.panelChartConfig
             },
@@ -102,7 +112,7 @@ export const PanelOptions = {
               close: (event, response) => { panelComponent.onCloseKpiProperties(event, response) }
             });
 
-          } 
+          }
           else if (panelComponent.graficos.chartType === 'dynamicText') {
 
             panelComponent.contextMenu.hideContextMenu();
@@ -115,7 +125,7 @@ export const PanelOptions = {
               close: (event, response) => { panelComponent.onClosedynamicTextProperties(event, response) }
             });
 
-          } 
+          }
           else if (panelComponent.graficos.chartType === 'parallelSets') {
             panelComponent.contextMenu.hideContextMenu();
             panelComponent.sankeyController = new EdaDialogController({
@@ -126,7 +136,7 @@ export const PanelOptions = {
               close: (event, response) => { panelComponent.onCloseSankeyProperties(event, response) }
             });
 
-          } 
+          }
           else if(panelComponent.graficos.chartType === 'treeMap'){
             panelComponent.contextMenu.hideContextMenu();
             panelComponent.treeMapController = new EdaDialogController({
@@ -283,23 +293,23 @@ export const PanelOptions = {
 },
   generateMenu : (panelComponent : EdaBlankPanelComponent ) => {
     const menu = [];
-/* SDA CUSTOM */    const editmode = !!panelComponent.inject?.canSave;
+    const editmode = panelComponent.getEditMode();
     const type = panelComponent.getChartType();
 
-/* SDA CUSTOM */    if (!editmode) {
+  /* SDA CUSTOM */    if (PanelOptions.isAnonymousUser()) {
 /* SDA CUSTOM */      menu.push(PanelOptions.exportExcel(panelComponent));
 /* SDA CUSTOM */      return menu;
 /* SDA CUSTOM */    }
-    
+
     if (editmode) {
         menu.push(PanelOptions.editQuery(panelComponent));
     }
 
     menu.push(PanelOptions.editChart(panelComponent));
-    
+
     if (editmode && type) {
         if (![ "crosstable", "kpi", "dynamicText"].includes(type) && !type.includes('kpi')) {
-            menu.push(PanelOptions.linkPanel(panelComponent)); 
+            menu.push(PanelOptions.linkPanel(panelComponent));
         }
     }
 


### PR DESCRIPTION
## Descripción

Este PR corrige una regresión en informes públicos compartidos: el menú de panel no era accesible para el usuario anónimo, por lo que no podía descargar datos a Excel.

### Qué se cambió

- Se habilitó la visualización del icono de menú del panel también para usuario anónimo.
- Se añadió una detección explícita de usuario anónimo para controlar el comportamiento del menú.
- Se restringió el menú en modo anónimo a una única acción segura: Exportar a Excel.
- Se mantiene el comportamiento previo para usuarios autenticados (edición, duplicado, borrado, etc. según permisos).

### Impacto funcional esperado

- Usuario anónimo en URL pública compartida:
- Ve el icono de menú.
- Solo ve Exportar a Excel.
- Usuarios autenticados:
- Sin cambios de permisos respecto al comportamiento existente.
- Se conservan opciones de edición según rol.

---

## Pruebas a realizar

### 1. Informe público compartido (usuario anónimo)

- Abrir una URL pública compartida.
- Verificar que aparece el icono de menú en cada panel de datos.
- Abrir menú y comprobar que solo aparece Exportar a Excel.
- Ejecutar Exportar a Excel y validar que se descarga el archivo correctamente.
- Verificar que no aparecen Editar consulta, Editar opciones del gráfico, Duplicar panel ni Eliminar panel.

### 2. Usuario autenticado con permisos de edición

- Abrir el mismo informe con usuario editor/admin.
- Verificar que aparece el menú completo habitual.
- Validar que siguen disponibles acciones de edición, duplicado y borrado (según rol).
- Ejecutar Exportar a Excel y comprobar descarga correcta.