### PR TITLE
Hotfix - Informes - Corrección de filtros avanzados de campos desplegables 

### DIFF
--- a/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/qb-systems/mySql-builder.service.ts
@@ -547,6 +547,11 @@ export class MySqlBuilderService extends QueryBuilderService {
 
       // variable to find filters with valueListSource
       let validador = (valueListSource !== undefined && valueListSource !== null);
+      /* SDA CUSTOM */ // SDA CUSTOM - Keep value-list filters on internal code column for nested AND/OR conditions
+      /* SDA CUSTOM */ const valueListFilterColumn = validador
+      /* SDA CUSTOM */   ? ((filter_codes?.length !== undefined && valueListSource.target_id_column) ? valueListSource.target_id_column : valueListSource.target_description_column)
+      /* SDA CUSTOM */   : filter_column;
+      /* SDA CUSTOM */ // END SDA CUSTOM
       // Result of the whole string 
 
       let resultado = '';
@@ -554,7 +559,7 @@ export class MySqlBuilderService extends QueryBuilderService {
       if(computed_column==='computed') {
         resultado = `${['null_or_empty', 'not_null_nor_empty'].includes(filter_type) || (filter_type==='in' && sqlOptional !== undefined) ? ' (' : ''} ${sqlOptional !== undefined ? sqlOptional : ''} (${SQLexpression}) ${filter_type_value}${filter_elements_value}`;
       } else {
-        resultado = `${['null_or_empty', 'not_null_nor_empty'].includes(filter_type) || (filter_type==='in' && sqlOptional !== undefined) ? ' (' : ''} ${sqlOptional !== undefined ? sqlOptional : ''} \`${ validador ? valueListSource.target_table : filter_table}\`.\`${ validador ? valueListSource.target_description_column : filter_column}\` ${filter_type_value}${filter_elements_value}`;
+        /* SDA CUSTOM */ resultado = `${['null_or_empty', 'not_null_nor_empty'].includes(filter_type) || (filter_type==='in' && sqlOptional !== undefined) ? ' (' : ''} ${sqlOptional !== undefined ? sqlOptional : ''} \`${ validador ? valueListSource.target_table : filter_table}\`.\`${valueListFilterColumn}\` ${filter_type_value}${filter_elements_value}`;
       }
 
 
@@ -563,7 +568,7 @@ export class MySqlBuilderService extends QueryBuilderService {
         if(computed_column==='computed') {
           resultado = `${resultado} (${SQLexpression}) != '')`;
         } else {
-          resultado = `${resultado} \`${ validador ? valueListSource.target_table : filter_table}\`.\`${ validador ? valueListSource.target_description_column : filter_column}\` != '')`;
+          /* SDA CUSTOM */ resultado = `${resultado} \`${ validador ? valueListSource.target_table : filter_table}\`.\`${valueListFilterColumn}\` != '')`;
         }
       }
 
@@ -572,7 +577,7 @@ export class MySqlBuilderService extends QueryBuilderService {
         if(computed_column==='computed') {
           resultado = `${resultado} (${SQLexpression}) = '')`;
         } else {
-          resultado = `${resultado} \`${ validador ? valueListSource.target_table : filter_table}\`.\`${ validador ? valueListSource.target_description_column : filter_column}\` = '')`;
+          /* SDA CUSTOM */ resultado = `${resultado} \`${ validador ? valueListSource.target_table : filter_table}\`.\`${valueListFilterColumn}\` = '')`;
         }
       }
 


### PR DESCRIPTION
## Descripción
- solves #504
Este PR corrige un comportamiento en la generación de filtros lógicos (AND/OR) para campos de tipo desplegable.

Cuando existían combinaciones AND/OR a nivel de panel, los filtros pasaban a comparar contra la etiqueta visible (`value`) en lugar del identificador interno (`code`), provocando consultas incorrectas y, en algunos casos, sin resultados.

## Problema

- Sin configuración AND/OR: el filtro se aplicaba correctamente sobre la columna interna (`code` / `target_id_column`).
- Con configuración AND/OR: el filtro se construía sobre la columna de descripción (`value` / `target_description_column`).

Esto generaba inconsistencia funcional entre filtros simples y filtros anidados.

## Solución aplicada

Se ajustó la construcción de condiciones en filtros anidados para value lists:

- Si existen `filter_codes`, se usa `target_id_column` (código interno).
- Si no existen `filter_codes`, se mantiene el comportamiento previo.

Con esto, los filtros con AND/OR quedan alineados con el flujo estándar de filtrado por código interno.

## Impacto

- Se corrige el caso genérico de filtros desplegables en combinaciones lógicas AND/OR.
- No se modifica la semántica de filtros fuera de este flujo.
- Se mantiene compatibilidad con escenarios existentes sin `filter_codes`.

## Como probarlo
1. Verificar que los filtro sobre desplegable sin AND/OR (simples): sigue usando `code`.
2. Verificar que los filtro sobre desplegable con AND/OR (avanzados): ahora  usan `code`.
3. Verificar que el resto de filtros no se ven afectados.

