### PR TITLE
Hotfix - Informes - Fix para filtro de texto libre en campos desplegables sin opciones

### DIFF
--- a/eda/eda_app/src/app/services/utils/column-utils.service.ts
+++ b/eda/eda_app/src/app/services/utils/column-utils.service.ts
@@ -33,13 +33,18 @@ export class ColumnUtilsService {
             }
         }).filter(Boolean);
 
-        let valuesIds
-        // Adding the values Codes
-        if(data.length !== 0) {
-            valuesIds = [{value1: _.cloneDeep(values)[0].value1.map((e: any) => data.find((d: any) => d.value === e).id)}];
-        } else {
-            valuesIds = _.cloneDeep(values);
-        }
+        /* SDA CUSTOM */ let valuesIds
+        /* SDA CUSTOM */ // Adding the values Codes
+        /* SDA CUSTOM */ if (Array.isArray(data) && data.length !== 0 && _.cloneDeep(values)[0]?.value1) {
+        /* SDA CUSTOM */     valuesIds = [{
+        /* SDA CUSTOM */         value1: _.cloneDeep(values)[0].value1.map((e: any) => {
+        /* SDA CUSTOM */             const match = data.find((d: any) => d.value === e);
+        /* SDA CUSTOM */             return !_.isNil(match?.id) ? match.id : e;
+        /* SDA CUSTOM */         })
+        /* SDA CUSTOM */     }];
+        /* SDA CUSTOM */ } else {
+        /* SDA CUSTOM */     valuesIds = _.cloneDeep(values);
+        /* SDA CUSTOM */ }
     
         const filterObject = {
             isGlobal: false,

--- a/eda/eda_app/src/app/services/utils/column-utils.service.ts
+++ b/eda/eda_app/src/app/services/utils/column-utils.service.ts
@@ -23,10 +23,10 @@ interface FilterOptions {
 export class ColumnUtilsService {
     constructor(private fileUtiles: FileUtiles) { }
 
-    
+
     public setFilter(options: FilterOptions): object {
         const { obj, table, column, column_type, type, selectedRange, valueListSource, autorelation, joins, filterBeforeGrouping, aggregation_type,  data,  computed_column, SQLexpression } = options;
-    
+
         const values = Object.keys(obj).map((key) => {
             if (!_.isNil(obj[key])) {
                 return { [key]: Array.isArray(obj[key]) ? obj[key] : [obj[key]] };
@@ -45,7 +45,7 @@ export class ColumnUtilsService {
         /* SDA CUSTOM */ } else {
         /* SDA CUSTOM */     valuesIds = _.cloneDeep(values);
         /* SDA CUSTOM */ }
-    
+
         const filterObject = {
             isGlobal: false,
             filter_id: this.fileUtiles.generateUUID(),
@@ -56,22 +56,22 @@ export class ColumnUtilsService {
             filter_elements: values,
             filter_codes: valuesIds,
             selectedRange: selectedRange,
-            autorelation, 
+            autorelation,
             joins,
             filterBeforeGrouping,
             aggregation_type,
             computed_column,
             SQLexpression
         };
-    
+
         if (valueListSource) {
             filterObject['valueListSource'] = valueListSource;
         }
-    
+
         return filterObject;
     }
 
-    
+
     public handleInputTypes(type: string) {
         let inputType;
         switch (type) {


### PR DESCRIPTION
- solves #507

### Resumen
Este PR corrige un fallo al añadir filtros de panel en campos desplegables cuando:
- operación = IGUAL A / NO IGUAL A
- switch Opciones desactivado
- valor introducido manualmente no presente en el catálogo

### Cambios realizados
- Se endurece la construcción de `filter_codes` para que:
  - mapee a `id` cuando exista coincidencia en opciones
  - use fallback al valor original cuando no exista coincidencia
  - no intente mapear si no hay datos válidos para mapear

### Validación sugerida
1. IGUAL A + Opciones OFF + texto libre → guarda sin error.
2. IGUAL A + Opciones ON + valor de lista → mantiene uso de id.
3. IN / NOT IN con multiselección → sin cambios funcionales.

