### PR TITLE
Incidencia - Filtros - La configuración avanzada solo permite 9 escalones de filtrado

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-filter-and-or/eda-filter-and-or.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-filter-and-or/eda-filter-and-or.component.ts
@@ -86,8 +86,8 @@ export class EdaFilterAndOrComponent implements OnInit {
       resizable: {
         enabled: false // Element that is not resized
       },
-      minCols: 10,
-      maxCols: 10,
+      minCols: 11,
+      maxCols: 11,
       minRows: 9, // Make this value dynamic - pending
       maxRows: 9, // Make this value dynamic - pending
       margin: 0.2, // Reduce the margin between cells
@@ -118,11 +118,13 @@ export class EdaFilterAndOrComponent implements OnInit {
       if(previousDashboard) {
         this.dashboard = _.cloneDeep(this.sortedFilters);
         this.dashboardClone = _.cloneDeep(this.sortedFilters);
+        this.updateGridDimensions();
         this.creacionQueryFiltros(this.dashboard);
       } else {
         if(this.sortedFilters.length !== 0) {
           this.dashboard = _.cloneDeep(this.sortedFilters);
           this.dashboardClone = _.cloneDeep(this.sortedFilters);
+          this.updateGridDimensions();
           this.creacionQueryFiltros(this.sortedFilters);
 
         } else {
@@ -192,6 +194,9 @@ export class EdaFilterAndOrComponent implements OnInit {
 
     // A clone of the dashboard is created
     this.dashboardClone = _.cloneDeep(this.dashboard);
+
+    // Update grid dimensions based on dashboard length
+    this.updateGridDimensions();
 
     // At the beginning of the execution
     this.creacionQueryFiltros(this.dashboard);
@@ -569,6 +574,18 @@ export class EdaFilterAndOrComponent implements OnInit {
 
   public getNiceTableName(table: any) {
     return this.tables.find( t => t.table_name === table)?.display_name?.default;
+  }
+
+  private updateGridDimensions(): void {
+    const base = 9;
+    const extra = Math.max(0, this.dashboard.length - base);
+    this.options = {
+      ...this.options,
+      minCols: 11 + extra,
+      maxCols: 11 + extra,
+      minRows: base + extra,
+      maxRows: base + extra,
+    };
   }
 
 }

--- a/eda/eda_app/src/app/module/components/eda-filter-and-or/eda-filter-and-or.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-filter-and-or/eda-filter-and-or.component.ts
@@ -86,8 +86,8 @@ export class EdaFilterAndOrComponent implements OnInit {
       resizable: {
         enabled: false // Element that is not resized
       },
-      minCols: 11,
-      maxCols: 11,
+/* SDA CUSTOM */      minCols: 11,
+/* SDA CUSTOM */      maxCols: 11,
       minRows: 9, // Make this value dynamic - pending
       maxRows: 9, // Make this value dynamic - pending
       margin: 0.2, // Reduce the margin between cells
@@ -118,13 +118,13 @@ export class EdaFilterAndOrComponent implements OnInit {
       if(previousDashboard) {
         this.dashboard = _.cloneDeep(this.sortedFilters);
         this.dashboardClone = _.cloneDeep(this.sortedFilters);
-        this.updateGridDimensions();
+/* SDA CUSTOM */        this.updateGridDimensions();
         this.creacionQueryFiltros(this.dashboard);
       } else {
         if(this.sortedFilters.length !== 0) {
           this.dashboard = _.cloneDeep(this.sortedFilters);
           this.dashboardClone = _.cloneDeep(this.sortedFilters);
-          this.updateGridDimensions();
+/* SDA CUSTOM */          this.updateGridDimensions();
           this.creacionQueryFiltros(this.sortedFilters);
 
         } else {
@@ -196,7 +196,7 @@ export class EdaFilterAndOrComponent implements OnInit {
     this.dashboardClone = _.cloneDeep(this.dashboard);
 
     // Update grid dimensions based on dashboard length
-    this.updateGridDimensions();
+/* SDA CUSTOM */    this.updateGridDimensions();
 
     // At the beginning of the execution
     this.creacionQueryFiltros(this.dashboard);
@@ -576,16 +576,16 @@ export class EdaFilterAndOrComponent implements OnInit {
     return this.tables.find( t => t.table_name === table)?.display_name?.default;
   }
 
-  private updateGridDimensions(): void {
-    const base = 9;
-    const extra = Math.max(0, this.dashboard.length - base);
-    this.options = {
-      ...this.options,
-      minCols: 11 + extra,
-      maxCols: 11 + extra,
-      minRows: base + extra,
-      maxRows: base + extra,
-    };
+/* SDA CUSTOM */  private updateGridDimensions(): void {
+/* SDA CUSTOM */  const base = 9;
+/* SDA CUSTOM */    const extra = Math.max(0, this.dashboard.length - base);
+/* SDA CUSTOM */    this.options = {
+/* SDA CUSTOM */      ...this.options,
+/* SDA CUSTOM */      minCols: 11 + extra,
+/* SDA CUSTOM */      maxCols: 11 + extra,
+/* SDA CUSTOM */      minRows: base + extra,
+/* SDA CUSTOM */      maxRows: base + extra,
+/* SDA CUSTOM */    };
   }
 
 }


### PR DESCRIPTION
## Descripción del Cambio
Se añade una función que calcula el número de filas y columnas que debe haber para contener los filtros. 


## Issue(s) resuelto(s) 

- solves #382 

## Pruebas a realizar para validar el cambio
Hacer un informe con menos de 9 filtros e ir añadiendo filtros progresivamente y comprobar que el componente que permite anidar los filtros en la consulta los maneja correctamente.  

