### PR TITLE
Hotfix - Administración - Error al exportar e importar informe 

### DIFF
--- a/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.html
+++ b/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.html
@@ -70,9 +70,15 @@
                   [style]="{width:'50%', padding:'.35rem .75rem'}" (onChange)="exportDashboard()"> </p-dropdown>
               </div>
               <div *ngIf="dashBoardForm.value.dashboard!=null" class="download-container">
-                <a style="margin: auto" title="Download JSON" [href]="downloadJsonDashboardHref"
-                  download="dashboard.json">
-                  <i class="fa fa-download"></i> {{downloadDashboard}}</a>
+                <a style="margin: auto" title="Download JSON"
+                  [href]="downloadJsonDashboardHref"
+                  download="dashboard.json"
+                  [class.disabled]="loadingDashboardExport"
+                  (click)="onDownloadDashboardClick($event)">
+                  <i *ngIf="!loadingDashboardExport" class="fa fa-fw fa-download"></i>
+                  <i *ngIf="loadingDashboardExport" class="fa fa-fw fa-spinner fa-spin"></i>
+                  {{downloadDashboard}}
+                </a>
               </div>
             </form>
           </div>

--- a/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.html
+++ b/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.html
@@ -70,15 +70,11 @@
                   [style]="{width:'50%', padding:'.35rem .75rem'}" (onChange)="exportDashboard()"> </p-dropdown>
               </div>
               <div *ngIf="dashBoardForm.value.dashboard!=null" class="download-container">
-                <a style="margin: auto" title="Download JSON"
-                  [href]="downloadJsonDashboardHref"
-                  download="dashboard.json"
-                  [class.disabled]="loadingDashboardExport"
-                  (click)="onDownloadDashboardClick($event)">
-                  <i *ngIf="!loadingDashboardExport" class="fa fa-fw fa-download"></i>
-                  <i *ngIf="loadingDashboardExport" class="fa fa-fw fa-spinner fa-spin"></i>
-                  {{downloadDashboard}}
-                </a>
+                <!-- SDA CUSTOM --> <a style="margin: auto" title="Download JSON" [href]="downloadJsonDashboardHref" download="dashboard.json" [class.disabled]="loadingDashboardExport" (click)="onDownloadDashboardClick($event)">
+                <!-- SDA CUSTOM -->  <i *ngIf="!loadingDashboardExport" class="fa fa-fw fa-download"></i>
+                <!-- SDA CUSTOM -->  <i *ngIf="loadingDashboardExport" class="fa fa-fw fa-spinner fa-spin"></i>
+                <!-- SDA CUSTOM -->   {{downloadDashboard}}
+                <!-- SDA CUSTOM --> </a>
               </div>
             </form>
           </div>

--- a/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.html
+++ b/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.html
@@ -15,10 +15,11 @@
                 <p-dropdown [options]="dataSources" formControlName="model" [placeholder]="header1"  [filter]="true" [filterBy]="'label'" 
                   [style]="{width:'50%', padding:'.35rem .75rem'}" (onChange)="exportModel()"> </p-dropdown>
               </div>
-              <div *ngIf="exportModelForm.value.model!=null" class="download-container">
-                <a style="margin: auto" title="Download JSON" [href]="downloadJsonModelHref" download="model.json">
+              <!-- SDA CUSTOM --> <div *ngIf="exportModelForm.value.model!=null" class="download-container">
+                <!-- SDA CUSTOM --> <a style="margin: auto" [title]="downloadJsonTitle" [href]="downloadJsonModelHref" download="model.json">
                   <i class="fa fa-download"></i> {{downloadModel}}</a>
-              </div>
+              <!-- SDA CUSTOM --> </div>
+              <!-- END SDA CUSTOM -->
             </form>
           </div>
 
@@ -70,7 +71,7 @@
                   [style]="{width:'50%', padding:'.35rem .75rem'}" (onChange)="exportDashboard()"> </p-dropdown>
               </div>
               <div *ngIf="dashBoardForm.value.dashboard!=null" class="download-container">
-                <!-- SDA CUSTOM --> <a style="margin: auto" title="Download JSON" [href]="downloadJsonDashboardHref" download="dashboard.json" [class.disabled]="loadingDashboardExport" (click)="onDownloadDashboardClick($event)">
+                <!-- SDA CUSTOM --> <a style="margin: auto" [title]="downloadJsonTitle" [href]="downloadJsonDashboardHref" download="dashboard.json" [class.disabled]="loadingDashboardExport" (click)="onDownloadDashboardClick($event)">
                 <!-- SDA CUSTOM -->  <i *ngIf="!loadingDashboardExport" class="fa fa-fw fa-download"></i>
                 <!-- SDA CUSTOM -->  <i *ngIf="loadingDashboardExport" class="fa fa-fw fa-spinner fa-spin"></i>
                 <!-- SDA CUSTOM -->   {{downloadDashboard}}

--- a/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.ts
+++ b/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.ts
@@ -23,7 +23,7 @@ export class ModelSettingsComponent implements OnInit {
   private globalDSRoute = '/datasource';
   public downloadJsonModelHref: any;
   public downloadJsonDashboardHref: any;
-  public loadingDashboardExport: boolean = false;
+  /*SDA CUSTOM*/ public loadingDashboardExport: boolean = false;
   public files: any;
 
   //STRINGS
@@ -123,27 +123,27 @@ export class ModelSettingsComponent implements OnInit {
 
   }
 
-  onDownloadDashboardClick(event: MouseEvent): void {
-    if (this.loadingDashboardExport) {
-      event.preventDefault();
-    }
-  }
+/*SDA CUSTOM*/  onDownloadDashboardClick(event: MouseEvent): void {
+/*SDA CUSTOM*/    if (this.loadingDashboardExport) {
+/*SDA CUSTOM*/      event.preventDefault();
+/*SDA CUSTOM*/    }
+/*SDA CUSTOM*/  }
 
   exportDashboard() {
     const id = this.dashBoardForm.value.dashboard._id;
-    this.downloadJsonDashboardHref = null;
-    this.loadingDashboardExport = true;
+    /*SDA CUSTOM*/ this.downloadJsonDashboardHref = null;
+    /*SDA CUSTOM*/ this.loadingDashboardExport = true;
 
     this.dashboardService.getDashboard(id).subscribe(
       data => {
         let theJSON = JSON.stringify(data.dashboard);
         let uri = this.sanitizer.bypassSecurityTrustUrl("data:text/json;charset=UTF-8," + encodeURIComponent(theJSON));
         this.downloadJsonDashboardHref = uri;
-        this.loadingDashboardExport = false;
+        /*SDA CUSTOM*/ this.loadingDashboardExport = false;
       },
       err => {
         this.loadingDashboardExport = false;
-        this.alertService.addError(err);
+        /*SDA CUSTOM*/ this.alertService.addError(err);
       });
 
   }
@@ -170,6 +170,10 @@ export class ModelSettingsComponent implements OnInit {
 
           panels.forEach(panel => {
             const fields = panel.content.query.query.fields;
+            
+/*SDA CUSTOM*/ // No se verifican los paneles en modo SQL
+/*SDA CUSTOM*/ if(panel.content.query.query?.modeSQL) return
+/*SDA CUSTOM*/
             fields.forEach(field => {
 
               const table = tables.filter(t => t.table_name === field.table_id);

--- a/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.ts
+++ b/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.ts
@@ -23,6 +23,7 @@ export class ModelSettingsComponent implements OnInit {
   private globalDSRoute = '/datasource';
   public downloadJsonModelHref: any;
   public downloadJsonDashboardHref: any;
+  public loadingDashboardExport: boolean = false;
   public files: any;
 
   //STRINGS
@@ -122,16 +123,26 @@ export class ModelSettingsComponent implements OnInit {
 
   }
 
+  onDownloadDashboardClick(event: MouseEvent): void {
+    if (this.loadingDashboardExport) {
+      event.preventDefault();
+    }
+  }
+
   exportDashboard() {
     const id = this.dashBoardForm.value.dashboard._id;
+    this.downloadJsonDashboardHref = null;
+    this.loadingDashboardExport = true;
 
     this.dashboardService.getDashboard(id).subscribe(
       data => {
         let theJSON = JSON.stringify(data.dashboard);
         let uri = this.sanitizer.bypassSecurityTrustUrl("data:text/json;charset=UTF-8," + encodeURIComponent(theJSON));
         this.downloadJsonDashboardHref = uri;
+        this.loadingDashboardExport = false;
       },
       err => {
+        this.loadingDashboardExport = false;
         this.alertService.addError(err);
       });
 

--- a/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.ts
+++ b/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.ts
@@ -203,9 +203,6 @@ export class ModelSettingsComponent implements OnInit {
   }
 
   async importDashboard() {
-
-    console.log('holaaaaaaaaaaaaaaaaaa ..... ');
-
     this.dashboardService.updateDashboard(this.loadedDashboard._id, this.loadedDashboard).subscribe(
       () => {
 

--- a/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.ts
+++ b/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.ts
@@ -23,7 +23,7 @@ export class ModelSettingsComponent implements OnInit {
   private globalDSRoute = '/datasource';
   public downloadJsonModelHref: any;
   public downloadJsonDashboardHref: any;
-  /*SDA CUSTOM*/ public loadingDashboardExport: boolean = false;
+  /* SDA CUSTOM */ public loadingDashboardExport: boolean = false;
   public files: any;
 
   //STRINGS
@@ -39,6 +39,7 @@ export class ModelSettingsComponent implements OnInit {
   public modelSaved : string = $localize`:@@ModelSaved:Modelo guardado correctamente`;
   public downloadModel : string  = $localize`:@@downloadModel:Descargar modelo`;
   public downloadDashboard : string  = $localize`:@@downloadDashboard:Descargar informe`;
+  /* SDA CUSTOM */ public downloadJsonTitle : string  = $localize`:@@downloadJsonTitle:Download JSON`;
 
   //FORMS
   public exportModelForm: UntypedFormGroup;
@@ -123,27 +124,27 @@ export class ModelSettingsComponent implements OnInit {
 
   }
 
-/*SDA CUSTOM*/  onDownloadDashboardClick(event: MouseEvent): void {
-/*SDA CUSTOM*/    if (this.loadingDashboardExport) {
-/*SDA CUSTOM*/      event.preventDefault();
-/*SDA CUSTOM*/    }
-/*SDA CUSTOM*/  }
+/* SDA CUSTOM */  onDownloadDashboardClick(event: MouseEvent): void {
+/* SDA CUSTOM */    if (this.loadingDashboardExport) {
+/* SDA CUSTOM */      event.preventDefault();
+/* SDA CUSTOM */    }
+/* SDA CUSTOM */  }
 
   exportDashboard() {
     const id = this.dashBoardForm.value.dashboard._id;
-    /*SDA CUSTOM*/ this.downloadJsonDashboardHref = null;
-    /*SDA CUSTOM*/ this.loadingDashboardExport = true;
+    /* SDA CUSTOM */ this.downloadJsonDashboardHref = null;
+    /* SDA CUSTOM */ this.loadingDashboardExport = true;
 
     this.dashboardService.getDashboard(id).subscribe(
       data => {
         let theJSON = JSON.stringify(data.dashboard);
         let uri = this.sanitizer.bypassSecurityTrustUrl("data:text/json;charset=UTF-8," + encodeURIComponent(theJSON));
         this.downloadJsonDashboardHref = uri;
-        /*SDA CUSTOM*/ this.loadingDashboardExport = false;
+        /* SDA CUSTOM */ this.loadingDashboardExport = false;
       },
       err => {
         this.loadingDashboardExport = false;
-        /*SDA CUSTOM*/ this.alertService.addError(err);
+        /* SDA CUSTOM */ this.alertService.addError(err);
       });
 
   }
@@ -171,14 +172,14 @@ export class ModelSettingsComponent implements OnInit {
           panels.forEach(panel => {
             const fields = panel.content.query.query.fields;
             
-/*SDA CUSTOM*/ // No se verifican los paneles en modo SQL
-/*SDA CUSTOM*/ if(panel.content.query.query?.modeSQL) return
-/*SDA CUSTOM*/
+/* SDA CUSTOM */ // No se verifican los paneles en modo SQL
+/* SDA CUSTOM */ if(panel.content.query.query?.modeSQL) return
+/* SDA CUSTOM */
             fields.forEach(field => {
 
               // Joined fields encode the join path in table_id (e.g. "sda_project.id.joincolumn"); extract just the table name
-/*SDA CUSTOM*/const realTableId = field.table_id.split('.')[0];
-/*SDA CUSTOM*/const table = tables.filter(t => t.table_name === realTableId);
+/* SDA CUSTOM */const realTableId = field.table_id.split('.')[0];
+/* SDA CUSTOM */const table = tables.filter(t => t.table_name === realTableId);
               if (table.length > 0) {
                 const column = table[0].columns.filter(column => column.column_name === field.column_name)[0];
                 if (!column) {
@@ -197,7 +198,7 @@ export class ModelSettingsComponent implements OnInit {
       }
       fileReader.readAsText(file);
     } catch (err) {
-      console.log(err);
+      this.alertService.addError(err);
     }
 
   }
@@ -298,7 +299,7 @@ export class ModelSettingsComponent implements OnInit {
       fileReader.readAsText(file);
 
     } catch (err) {
-      console.log(err);
+      this.alertService.addError(err);
     }
 
   }

--- a/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.ts
+++ b/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.ts
@@ -176,7 +176,9 @@ export class ModelSettingsComponent implements OnInit {
 /*SDA CUSTOM*/
             fields.forEach(field => {
 
-              const table = tables.filter(t => t.table_name === field.table_id);
+              // Joined fields encode the join path in table_id (e.g. "sda_project.id.joincolumn"); extract just the table name
+/*SDA CUSTOM*/const realTableId = field.table_id.split('.')[0];
+/*SDA CUSTOM*/const table = tables.filter(t => t.table_name === realTableId);
               if (table.length > 0) {
                 const column = table[0].columns.filter(column => column.column_name === field.column_name)[0];
                 if (!column) {
@@ -201,6 +203,8 @@ export class ModelSettingsComponent implements OnInit {
   }
 
   async importDashboard() {
+
+    console.log('holaaaaaaaaaaaaaaaaaa ..... ');
 
     this.dashboardService.updateDashboard(this.loadedDashboard._id, this.loadedDashboard).subscribe(
       () => {

--- a/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.ts
+++ b/eda/eda_app/src/app/module/pages/model-settings/model-settings.component.ts
@@ -172,7 +172,7 @@ export class ModelSettingsComponent implements OnInit {
           panels.forEach(panel => {
             const fields = panel.content.query.query.fields;
             
-/* SDA CUSTOM */ // No se verifican los paneles en modo SQL
+/* SDA CUSTOM */ // Panels are not verified in SQL mode
 /* SDA CUSTOM */ if(panel.content.query.query?.modeSQL) return
 /* SDA CUSTOM */
             fields.forEach(field => {
@@ -198,7 +198,7 @@ export class ModelSettingsComponent implements OnInit {
       }
       fileReader.readAsText(file);
     } catch (err) {
-      this.alertService.addError(err);
+      /* SDA CUSTOM */ this.alertService.addError(err);
     }
 
   }
@@ -299,7 +299,7 @@ export class ModelSettingsComponent implements OnInit {
       fileReader.readAsText(file);
 
     } catch (err) {
-      this.alertService.addError(err);
+      /* SDA CUSTOM */ this.alertService.addError(err);
     }
 
   }

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -906,8 +906,11 @@
     <source>Update Model Failed</source>
     <target>Error en actualització del model</target>
   </trans-unit>
-  <!-- END SDA CUSTOM -->
-  <!-- END SDA CUSTOM -->
+<!-- END SDA CUSTOM -->
+  <!-- SDA CUSTOM - Download JSON title -->
+  <trans-unit id="downloadJsonTitle">
+    <source>Download JSON</source>
+    <target>Descarregar JSON</target>
+  </trans-unit>
 </body>
-</file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -904,8 +904,11 @@
     <source>Update Model Failed</source>
     <target>Model update failed</target>
   </trans-unit>
-  <!-- END SDA CUSTOM -->
-  <!-- END SDA CUSTOM -->
+<!-- END SDA CUSTOM -->
+  <!-- SDA CUSTOM - Download JSON title -->
+  <trans-unit id="downloadJsonTitle">
+    <source>Download JSON</source>
+    <target>Download JSON</target>
+  </trans-unit>
 </body>
-</file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -907,7 +907,11 @@
     <target>Fallo en actualización del modelo</target>
   </trans-unit>
   <!-- END SDA CUSTOM -->
-  <!-- END SDA CUSTOM -->
+<!-- END SDA CUSTOM -->
+  <!-- SDA CUSTOM - Download JSON title -->
+  <trans-unit id="downloadJsonTitle">
+    <source>Download JSON</source>
+    <target>Descargar JSON</target>
+  </trans-unit>
 </body>
-</file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -906,8 +906,11 @@
     <source>Update Model Failed</source>
     <target>Fallo en actualización do modelo</target>
   </trans-unit>
-  <!-- END SDA CUSTOM -->
-  <!-- END SDA CUSTOM -->
+<!-- END SDA CUSTOM -->
+  <!-- SDA CUSTOM - Download JSON title -->
+  <trans-unit id="downloadJsonTitle">
+    <source>Download JSON</source>
+    <target>Descargar JSON</target>
+  </trans-unit>
 </body>
-</file>
 </xliff>


### PR DESCRIPTION
## Descripción del Cambio
Cuando se exporta e importa un informe que contiene consultas en modo arbol. La comprobación falla porque se desarrolló antes de que existiera el modo arbol y compara  ids de tablas. Los ids de tabla en modo arbol son distintos. Por lo que ha habido que revisarlo.

Adicionalmente se ha resuelto el issue que sucedía cuando se intentaba exportar un informe y "a veces" fallaba.  Se ha comprobado que el motivo por el que fallaba era porque se intentaba exportar antes de que acabara de llegar la información. Se ha añadido un control para que no se habilite el botón de exportar hasta que no se tenga toda la información.

## Issue(s) resuelto(s)

- solves #123 

## Pruebas a realizar para validar el cambio
En la rama de desarrollo. Hacer un informe con un panel con más de una tabla en modo arbol. exportar el informe y volver a importarlo. Se verá que muestra la alerta. 
Cambiar de rama e intentar importar el informe. La alerta ya no aparece porque la comprobación se hace correctamente. 

