### PR TITLE
Hotfix - Filtros - Permitir filtros avanzados y de URL simultáneamente.

### DIFF
--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
@@ -630,11 +630,54 @@ export class GlobalFilterComponent implements OnInit {
                                 // Adding the joins of the filter that comes from the url
                                 formatedFilter.joins = pathList;
 
+                                // SDA CUSTOM - Fix: Also set filter_table from pathList for tree filters
+                                /* SDA CUSTOM */ if (formatedFilter.pathList && formatedFilter.pathList[panel.id] && formatedFilter.pathList[panel.id].table_id) {
+                                    /* SDA CUSTOM */ formatedFilter.filter_table = formatedFilter.pathList[panel.id].table_id;
+                                /* SDA CUSTOM */ }
+
                                 // Controlling the filters
                                 if( _.findIndex(panelFilter, (inx) => inx.filter_column === formatedFilter.filter_column) >=0 ){
                                     panelFilter.splice(_.findIndex(panelFilter, (inx) => inx.filter_column === formatedFilter.filter_column), 1);
                                 }
                                 panelFilter.push(formatedFilter);
+
+                                // SDA CUSTOM - Fix: Inject URL filter into sortedFilters when advanced filters exist
+                                /* SDA CUSTOM */ const sortedFilters = panel.content?.query?.query?.sortedFilters;
+                                /* SDA CUSTOM */ if (sortedFilters && sortedFilters.length > 0) {
+                                    /* SDA CUSTOM */     const existingIndex = sortedFilters.findIndex((sf: any) => sf.filter_id === formatedFilter.filter_id);
+                                    /* SDA CUSTOM */     if (existingIndex >= 0) {
+                                    /* SDA CUSTOM */         sortedFilters[existingIndex].filter_elements = formatedFilter.filter_elements;
+                                    /* SDA CUSTOM */         sortedFilters[existingIndex].filter_codes = formatedFilter.filter_codes;
+                                    /* SDA CUSTOM */         sortedFilters[existingIndex].joins = formatedFilter.joins;
+                                    /* SDA CUSTOM */         sortedFilters[existingIndex].filter_table = formatedFilter.filter_table;
+                                    /* SDA CUSTOM */     } else {
+                                    /* SDA CUSTOM */         const lastElement = sortedFilters[sortedFilters.length - 1];
+                                    /* SDA CUSTOM */         const newSortedFilter = {
+                                    /* SDA CUSTOM */             cols: 3,
+                                    /* SDA CUSTOM */             rows: 1,
+                                    /* SDA CUSTOM */             y: lastElement.y + 1,
+                                    /* SDA CUSTOM */             x: 0,
+                                    /* SDA CUSTOM */             filter_table: formatedFilter.filter_table,
+                                    /* SDA CUSTOM */             filter_column: formatedFilter.filter_column,
+                                    /* SDA CUSTOM */             filter_type: formatedFilter.filter_type,
+                                    /* SDA CUSTOM */             filter_column_type: formatedFilter.filter_column_type,
+                                    /* SDA CUSTOM */             filter_elements: formatedFilter.filter_elements,
+                                    /* SDA CUSTOM */             filter_codes: formatedFilter.filter_codes,
+                                    /* SDA CUSTOM */             filter_id: formatedFilter.filter_id,
+                                    /* SDA CUSTOM */             isGlobal: formatedFilter.isGlobal,
+                                    /* SDA CUSTOM */             value: "and",
+                                    /* SDA CUSTOM */             joins: formatedFilter.joins,
+                                    /* SDA CUSTOM */             pathList: formatedFilter.pathList,
+                                    /* SDA CUSTOM */             valueListSource: formatedFilter.valueListSource,
+                                    /* SDA CUSTOM */             filterBeforeGrouping: formatedFilter.filterBeforeGrouping ?? true,
+                                    /* SDA CUSTOM */             autorelation: formatedFilter.autorelation,
+                                    /* SDA CUSTOM */             computed_column: formatedFilter.computed_column,
+                                    /* SDA CUSTOM */             SQLexpression: formatedFilter.SQLexpression,
+                                    /* SDA CUSTOM */             applyToAll: formatedFilter.applyToAll,
+                                    /* SDA CUSTOM */         };
+                                    /* SDA CUSTOM */         sortedFilters.push(newSortedFilter);
+                                    /* SDA CUSTOM */     }
+                                /* SDA CUSTOM */ }
                             });
 
                     }


### PR DESCRIPTION
Closes #524 

### Descripción
Corrige la inyección de filtros provenientes de la URL para que se apliquen correctamente en paneles que tienen configuración avanzada de filtros (AND/OR). Anteriormente, `findGlobalFilterByUrlParams` solo actualizaba el array filters de cada panel, pero ignoraba `sortedFilters`, que es el array que el backend utiliza para construir la cláusula `WHERE` cuando existen filtros avanzados configurados.

Cambios realizados
`- eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts:
`  - Dentro de `findGlobalFilterByUrlParams`, tras inyectar el filtro en panel.content.query.query.filters, se añade lógica para sincronizar el mismo filtro en `panel.content.query.query.sortedFilters`.
  - Si el filtro ya existe en sortedFilters, se actualizan sus valores (filter_elements, filter_codes, joins, filter_table).
  - Si no existe, se crea un nuevo nodo con todas las propiedades necesarias para que el backend (getSortedFilters) lo procese correctamente: filterBeforeGrouping, valueListSource, autorelation, computed_column, SQLexpression, joins, pathList, etc.
  - Se corrige filter_table desde pathList para filtros en modo árbol.

### Cómo probar
1. Abrir un dashboard que tenga un filtro global y paneles con configuración avanzada de filtros (AND/OR).
2. Acceder al dashboard mediante una URL con parámetros de filtro.
3. Verificar que:
   - El filtro aparece seleccionado en la barra de filtros globales.
   - La consulta de los paneles respeta el filtro (los datos están filtrados).
   - Al abrir el diálogo de "Configuración avanzada de filtros", el filtro de URL aparece integrado en el grid de AND/OR.