### PR TITLE
Hotfix - Idiomas - Corregir tag </file> faltante en stic_messages

### DIFF
--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -913,4 +913,5 @@
     <target>Descarregar JSON</target>
   </trans-unit>
 </body>
+  </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -911,4 +911,5 @@
     <target>Download JSON</target>
   </trans-unit>
 </body>
+  </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -914,4 +914,5 @@
     <target>Descargar JSON</target>
   </trans-unit>
 </body>
+  </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -913,4 +913,5 @@
     <target>Descargar JSON</target>
   </trans-unit>
 </body>
+  </file>
 </xliff>


### PR DESCRIPTION
## Resumen
Corregido el tag `</file>` faltante en los 4 archivos `stic_messages.*.xlf` que causaba error "Unexpected close tag" al compilar.

## Archivos modificados
- `eda/eda_app/src/locale/stic_messages.es.xlf`
- `eda/eda_app/src/locale/stic_messages.ca.xlf`
- `eda/eda_app/src/locale/stic_messages.en.xlf`
- `eda/eda_app/src/locale/stic_messages.gl.xlf`

## Error de compilación resuelto
```
Error: Unexpected close tag
Line: 913
Column: 8
Char: >
```

El tag `<file>` abierto en la línea 4 nunca tenía su cierre `</file>`, causando que xliff-simple-merge fallara al intentar fusionar los archivos durante el build de producción.