### PR TITLE
Mejora - Filtros - Automatización de rutas en filtros de informes

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -185,6 +185,7 @@ export class EdaBlankPanelComponent implements OnInit {
     public selectedFilters: any[] = [];
     public globalFilters: any[] = [];
     public filterValue: any = {};
+    /*SDA CUSTOM*/ public _pendingGlobalFilterReload: boolean = false;
 
     public loadingNodes: boolean = false;
     public rootTable: any;
@@ -488,6 +489,11 @@ export class EdaBlankPanelComponent implements OnInit {
         if (this.panel.content) {
             this.display_v.minispinner = true;
 
+            /*SDA CUSTOM*/ if (this.panel._isDuplicate) {
+            /*SDA CUSTOM*/     this.buildGlobalconfiguration(panelContent);
+            /*SDA CUSTOM*/     return;
+            /*SDA CUSTOM*/ }
+
             try {
                 const response = await QueryUtils.switchAndRun(this, panelContent.query);
                 this.chartLabels = this.chartUtils.uniqueLabels(response[0]);
@@ -584,6 +590,16 @@ export class EdaBlankPanelComponent implements OnInit {
 
         const currentQueryCheck = this.currentQuery;
         this.atLeastThereIsOneWithAggregation = this.checkAtLeastOneWithAggregation(currentQueryCheck);
+        /*SDA CUSTOM*/ let _ranQuery = false;
+        /*SDA CUSTOM*/ if (this._pendingGlobalFilterReload) {
+        /*SDA CUSTOM*/     this._pendingGlobalFilterReload = false;
+        /*SDA CUSTOM*/     QueryUtils.runQuery(this, true);
+        /*SDA CUSTOM*/     _ranQuery = true;
+        /*SDA CUSTOM*/ }
+        /*SDA CUSTOM*/ if (this.panel._isDuplicate) {
+        /*SDA CUSTOM*/     delete this.panel._isDuplicate;
+        /*SDA CUSTOM*/     if (!_ranQuery) QueryUtils.runQuery(this, true);
+        /*SDA CUSTOM*/ }
     }
 
 
@@ -1702,6 +1718,7 @@ export class EdaBlankPanelComponent implements OnInit {
         let duplicatedPanel = _.cloneDeep(this.panel, true);
         duplicatedPanel.id = this.fileUtiles.generateUUID();
         /*SDA CUSTOM*/duplicatedPanel.y = duplicatedPanel.y + 1;
+        /*SDA CUSTOM*/duplicatedPanel._isDuplicate = true;
         /*SDA CUSTOM*/this.duplicate.emit({ panel: duplicatedPanel, sourcePanelId });
     }
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -1689,10 +1689,11 @@ export class EdaBlankPanelComponent implements OnInit {
 
     /** duplicates a dashboard panel and positions it one point below the original one. */
     public duplicatePanel(): void {
-        let duplicatedPanel =   _.cloneDeep(this.panel, true);
+        /*SDA CUSTOM*/const sourcePanelId = this.panel.id;
+        let duplicatedPanel = _.cloneDeep(this.panel, true);
         duplicatedPanel.id = this.fileUtiles.generateUUID();
-        duplicatedPanel.y = duplicatedPanel.y+1;
-        this.duplicate.emit(duplicatedPanel);
+        /*SDA CUSTOM*/duplicatedPanel.y = duplicatedPanel.y + 1;
+        /*SDA CUSTOM*/this.duplicate.emit({ panel: duplicatedPanel, sourcePanelId });
     }
 
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -65,6 +65,7 @@ export class EdaBlankPanelComponent implements OnInit {
     @Output() duplicate: EventEmitter<any> = new EventEmitter();
     @Output() action: EventEmitter<IPanelAction> = new EventEmitter<IPanelAction>();
     @Output() d3Action: EventEmitter<IPanelAction> = new EventEmitter<IPanelAction>();
+    /*SDA CUSTOM*/ @Output() rootTableFirstSet = new EventEmitter<string>();
 
     /** properties that are injected into the dialogue with the specific properties of each chart. */
     public configController: EdaDialogController;
@@ -1659,6 +1660,7 @@ export class EdaBlankPanelComponent implements OnInit {
 
         if (this.selectedQueryMode == 'EDA2' && this.currentQuery.length === 1) {
             PanelInteractionUtils.loadTableNodes(this);
+            /*SDA CUSTOM*/ this.rootTableFirstSet.emit(this.rootTable?.table_name);
        }
     }
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -66,6 +66,7 @@ export class EdaBlankPanelComponent implements OnInit {
     @Output() action: EventEmitter<IPanelAction> = new EventEmitter<IPanelAction>();
     @Output() d3Action: EventEmitter<IPanelAction> = new EventEmitter<IPanelAction>();
     /*SDA CUSTOM*/ @Output() rootTableFirstSet = new EventEmitter<string>();
+    /*SDA CUSTOM*/ @Output() rootTableCleared = new EventEmitter<void>();
 
     /** properties that are injected into the dialogue with the specific properties of each chart. */
     public configController: EdaDialogController;
@@ -1685,6 +1686,11 @@ export class EdaBlankPanelComponent implements OnInit {
                                 }
                                 this.sortedFilters = []; // resets the values ​​because one or more filters were deleted
                             }
+/**SDA CUSTOM  */           // Last column of a new panel (query never executed): reset global filter config before utils runs
+/**SDA CUSTOM  */           if (currentQueryLength === 1 && _.isNil(this.panel.content)) {
+/**SDA CUSTOM  */               this.rootTableCleared.emit();
+/**SDA CUSTOM  */               this.globalFilters = [];
+/**SDA CUSTOM  */           }
                             PanelInteractionUtils.removeColumn(this, c, list);
                         }
 /**SDA CUSTOM  */       else {

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/panel-interaction-utils.ts
@@ -232,7 +232,10 @@ export const PanelInteractionUtils = {
      */
   handleFilters: (ebp: EdaBlankPanelComponent, content: any): void => {
     ebp.selectedFilters = _.cloneDeep(content.filters);
-    ebp.globalFilters = content.filters.filter(f => f.isGlobal === true);
+    /*SDA CUSTOM*/ const contentGlobalFilters = content.filters.filter((f: any) => f.isGlobal === true);
+    /*SDA CUSTOM*/ if (ebp.globalFilters.length === 0) {
+    /*SDA CUSTOM*/     ebp.globalFilters = contentGlobalFilters;
+    /*SDA CUSTOM*/ }
     ebp.selectedFilters.forEach(filter => { filter.removed = false; });
     ebp.selectedFilters = ebp.selectedFilters.filter(f => f.isGlobal === false);
   },

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
@@ -61,8 +61,7 @@
     <ng-template #panelTemplate let-panel>
         <ng-container [ngSwitch]="panel.type">
 
-            <!-- SDA CUSTOM --><eda-blank-panel *ngSwitchCase="0" #edaPanel [panel]="panel" [inject]="inject" (remove)="onRemovePanel($event)" (action)="onPanelAction($event)"  (duplicate)="onDuplicatePanel($event)" (rootTableFirstSet)="onNewPanelRootTableSet($event, panel)" >
-            </eda-blank-panel>
+            <!-- SDA CUSTOM --><eda-blank-panel *ngSwitchCase="0" #edaPanel [panel]="panel" [inject]="inject" (remove)="onRemovePanel($event)" (action)="onPanelAction($event)"  (duplicate)="onDuplicatePanel($event)" (rootTableFirstSet)="onNewPanelRootTableSet($event, panel)" (rootTableCleared)="onNewPanelRootTableCleared(panel)" ></eda-blank-panel>
 
             <eda-title-panel *ngSwitchCase="1" #edaPanel [id]="panel.id" [panel]="panel" [inject]="inject" (remove)="onRemovePanel($event)" (duplicate)="onDuplicatePanel($event)" class="eda-text-panel">
             </eda-title-panel>

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.html
@@ -61,7 +61,7 @@
     <ng-template #panelTemplate let-panel>
         <ng-container [ngSwitch]="panel.type">
 
-            <eda-blank-panel *ngSwitchCase="0" #edaPanel [panel]="panel" [inject]="inject" (remove)="onRemovePanel($event)" (action)="onPanelAction($event)"  (duplicate)="onDuplicatePanel($event)" >
+            <!-- SDA CUSTOM --><eda-blank-panel *ngSwitchCase="0" #edaPanel [panel]="panel" [inject]="inject" (remove)="onRemovePanel($event)" (action)="onPanelAction($event)"  (duplicate)="onDuplicatePanel($event)" (rootTableFirstSet)="onNewPanelRootTableSet($event, panel)" >
             </eda-blank-panel>
 
             <eda-title-panel *ngSwitchCase="1" #edaPanel [id]="panel.id" [panel]="panel" [inject]="inject" (remove)="onRemovePanel($event)" (duplicate)="onDuplicatePanel($event)" class="eda-text-panel">

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -1338,18 +1338,29 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
         const { panel, sourcePanelId } = event;
         /*SDA CUSTOM*/ if (this.gFilter?.globalFilters) {
         /*SDA CUSTOM*/     this.gFilter.globalFilters
-        /*SDA CUSTOM*/         .filter((f: any) => f.isGlobal && f.pathList)
+        /*SDA CUSTOM*/         .filter((f: any) => f.isGlobal)
         /*SDA CUSTOM*/         .forEach((filter: any) => {
-        /*SDA CUSTOM*/             if (filter.pathList[sourcePanelId]) {
+        /*SDA CUSTOM*/             if (filter.pathList && filter.pathList[sourcePanelId]) {
         /*SDA CUSTOM*/                 filter.pathList[panel.id] = _.cloneDeep(filter.pathList[sourcePanelId]);
-        /*SDA CUSTOM*/                 if (filter.panelList.includes(sourcePanelId) && !filter.panelList.includes(panel.id)) {
-        /*SDA CUSTOM*/                     filter.panelList.push(panel.id);
-        /*SDA CUSTOM*/                 }
+        /*SDA CUSTOM*/             }
+        /*SDA CUSTOM*/             if (filter.panelList.includes(sourcePanelId) && !filter.panelList.includes(panel.id)) {
+        /*SDA CUSTOM*/                 filter.panelList.push(panel.id);
         /*SDA CUSTOM*/             }
         /*SDA CUSTOM*/         });
         /*SDA CUSTOM*/ }
                         this.panels.push(panel);
                         this.dashboardService._notSaved.next(true);
+        /*SDA CUSTOM*/ const _dupSub = this.edaPanels.changes.subscribe(() => {
+        /*SDA CUSTOM*/     _dupSub.unsubscribe();
+        /*SDA CUSTOM*/     const newPanel = this.edaPanels.toArray().find(p => p.panel.id === panel.id);
+        /*SDA CUSTOM*/     if (newPanel && this.gFilter?.globalFilters) {
+        /*SDA CUSTOM*/         const applicable = this.gFilter.globalFilters.filter((f: any) => f.isGlobal && f.panelList.includes(panel.id));
+        /*SDA CUSTOM*/         applicable.forEach((filter: any) => {
+        /*SDA CUSTOM*/             newPanel.assertGlobalFilter(this.globalFiltersService.formatFilter(filter));
+        /*SDA CUSTOM*/         });
+        /*SDA CUSTOM*/         if (applicable.length > 0) newPanel._pendingGlobalFilterReload = true;
+        /*SDA CUSTOM*/     }
+        /*SDA CUSTOM*/ });
     /*SDA CUSTOM*/}
 
     public onResetWidgets(): void {

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -1342,6 +1342,9 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
         /*SDA CUSTOM*/         .forEach((filter: any) => {
         /*SDA CUSTOM*/             if (filter.pathList[sourcePanelId]) {
         /*SDA CUSTOM*/                 filter.pathList[panel.id] = _.cloneDeep(filter.pathList[sourcePanelId]);
+        /*SDA CUSTOM*/                 if (filter.panelList.includes(sourcePanelId) && !filter.panelList.includes(panel.id)) {
+        /*SDA CUSTOM*/                     filter.panelList.push(panel.id);
+        /*SDA CUSTOM*/                 }
         /*SDA CUSTOM*/             }
         /*SDA CUSTOM*/         });
         /*SDA CUSTOM*/ }

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -1334,10 +1334,20 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
         }
     }
 
-    public onDuplicatePanel(panel): void {
-        this.panels.push(panel);
-        this.dashboardService._notSaved.next(true);
-    }
+    /*SDA CUSTOM*/public onDuplicatePanel(event: { panel: any, sourcePanelId: string }): void {
+        const { panel, sourcePanelId } = event;
+        /*SDA CUSTOM*/ if (this.gFilter?.globalFilters) {
+        /*SDA CUSTOM*/     this.gFilter.globalFilters
+        /*SDA CUSTOM*/         .filter((f: any) => f.isGlobal && f.pathList)
+        /*SDA CUSTOM*/         .forEach((filter: any) => {
+        /*SDA CUSTOM*/             if (filter.pathList[sourcePanelId]) {
+        /*SDA CUSTOM*/                 filter.pathList[panel.id] = _.cloneDeep(filter.pathList[sourcePanelId]);
+        /*SDA CUSTOM*/             }
+        /*SDA CUSTOM*/         });
+        /*SDA CUSTOM*/ }
+                        this.panels.push(panel);
+                        this.dashboardService._notSaved.next(true);
+    /*SDA CUSTOM*/}
 
     public onResetWidgets(): void {
             // Get the queries in the dashboard for delete it from cache

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -228,6 +228,31 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
         });
     }
 
+    /*SDA CUSTOM*/ public onNewPanelRootTableSet(rootTableName: string, panel: EdaPanel): void {
+    /*SDA CUSTOM*/     if (!rootTableName) return;
+    /*SDA CUSTOM*/     const newPanelComp = this.edaPanels.find(p => p.panel.id === panel.id);
+    /*SDA CUSTOM*/     if (!newPanelComp) return;
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/     const globalFilters = this.gFilter?.globalFilters?.filter((f: any) => f.isGlobal && f.pathList) || [];
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/     globalFilters.forEach((filter: any) => {
+    /*SDA CUSTOM*/         if (!filter.panelList?.length) return;
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/         // Buscar el primer panel activo en este filtro que tenga la misma rootTable
+    /*SDA CUSTOM*/         const matchingPanelId = filter.panelList.find((pid: string) => {
+    /*SDA CUSTOM*/             const existing = this.edaPanels.find(p => p.panel.id === pid);
+    /*SDA CUSTOM*/             return existing?.rootTable?.table_name === rootTableName;
+    /*SDA CUSTOM*/         });
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/         if (matchingPanelId && filter.pathList[matchingPanelId]) {
+    /*SDA CUSTOM*/             filter.pathList[panel.id] = { ...filter.pathList[matchingPanelId] };
+    /*SDA CUSTOM*/             filter.panelList.push(panel.id);
+    /*SDA CUSTOM*/             const formatted = this.globalFiltersService.formatFilter(filter);
+    /*SDA CUSTOM*/             newPanelComp.assertGlobalFilter(formatted);
+    /*SDA CUSTOM*/         }
+    /*SDA CUSTOM*/     });
+    /*SDA CUSTOM*/ }
+
     public ngOnDestroy() {
         this.stopRefresh = true;
 /* SDA CUSTOM */         this.stopContinuousZoom();

--- a/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/dashboard.component.ts
@@ -253,6 +253,17 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
     /*SDA CUSTOM*/     });
     /*SDA CUSTOM*/ }
 
+    /*SDA CUSTOM*/ public onNewPanelRootTableCleared(panel: EdaPanel): void {
+    /*SDA CUSTOM*/     const globalFilters = this.gFilter?.globalFilters?.filter((f: any) => f.isGlobal) || [];
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/     globalFilters.forEach((filter: any) => {
+    /*SDA CUSTOM*/         filter.panelList = filter.panelList?.filter((pid: string) => pid !== panel.id) || [];
+    /*SDA CUSTOM*/         if (filter.pathList?.[panel.id]) {
+    /*SDA CUSTOM*/             delete filter.pathList[panel.id];
+    /*SDA CUSTOM*/         }
+    /*SDA CUSTOM*/     });
+    /*SDA CUSTOM*/ }
+
     public ngOnDestroy() {
         this.stopRefresh = true;
 /* SDA CUSTOM */         this.stopContinuousZoom();

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
@@ -19,6 +19,7 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
 
     public allPanels: any[] = [];
     public filteredPanels: any[] = [];
+    /*SDA CUSTOM*/ private _pathBackup: { [panelId: string]: any } = {};
 
     @Output() close: EventEmitter<any> = new EventEmitter<any>();
     @Output() globalFilterChange: EventEmitter<any> = new EventEmitter<any>();
@@ -205,9 +206,18 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
             this.filteredPanels = this.allPanels.filter((p: any) => p.avaliable && p.active);
 
             if (panel.active) {
+                /*SDA CUSTOM*/ if (this._pathBackup[panel.id]) {
+                /*SDA CUSTOM*/     this.globalFilter.pathList[panel.id] = _.cloneDeep(this._pathBackup[panel.id]);
+                /*SDA CUSTOM*/     delete this._pathBackup[panel.id];
+                /*SDA CUSTOM*/ }
+                /*SDA CUSTOM*/ if (this.globalFilter.pathList[panel.id] && !this.isEmpty(this.globalFilter.pathList[panel.id].selectedTableNodes)) {
+                /*SDA CUSTOM*/     if (!this.globalFilter.panelList.includes(panel.id)) {
+                /*SDA CUSTOM*/         this.globalFilter.panelList.push(panel.id);
+                /*SDA CUSTOM*/     }
+                /*SDA CUSTOM*/ }
                 this.initTablesForFilter();
                 this.findPanelPathTables();
-            } 
+            }
             else this.clearFilterPaths(panel);
         }
 
@@ -536,6 +546,10 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
     private clearFilterPaths(clearPanel?: any) {
         if (clearPanel) {
             this.globalFilter.panelList = this.globalFilter.panelList.filter((p) => p !== clearPanel.id);
+            /*SDA CUSTOM*/ const current = this.globalFilter.pathList[clearPanel.id];
+            /*SDA CUSTOM*/ if (current && !this.isEmpty(current.selectedTableNodes)) {
+            /*SDA CUSTOM*/     this._pathBackup[clearPanel.id] = _.cloneDeep(current);
+            /*SDA CUSTOM*/ }
             this.globalFilter.pathList[clearPanel.id] = {
                 selectedTableNodes: {},
                 path: []
@@ -544,6 +558,7 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
         } else {
             this.globalFilter.panelList = [];
             this.globalFilter.pathList = {};
+            /*SDA CUSTOM*/ this._pathBackup = {};
 
             for (const panel of this.allPanels) {
                 panel.content.globalFilterPaths = [];

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
@@ -359,10 +359,87 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
                     this.globalFilter.pathList[panel.id].selectedTableNodes = node;
 
                     if (!this.globalFilter.panelList.includes(panel.id)) this.globalFilter.panelList.push(panel.id);
-                }
+                /*SDA CUSTOM*/} else {
+                /*SDA CUSTOM*/    this.tryAutoFillSingleHop(panel);
+                /*SDA CUSTOM*/}
             }
         }
     }
+
+    /*SDA CUSTOM*/private tryAutoFillSingleHop(panel: any): void {
+    /*SDA CUSTOM*/    const filterTableName = this.globalFilter.selectedTable?.table_name;
+    /*SDA CUSTOM*/    const rootTableName = panel.content.query.query.rootTable;
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    if (!filterTableName || !rootTableName || filterTableName === rootTableName) return;
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    const rootTable = this.modelTables.find((t: any) => t.table_name === rootTableName);
+    /*SDA CUSTOM*/    if (!rootTable) return;
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    // Mirror onNodeExpand: exclude only bridge and autorelation (visible is not a filter in the tree).
+    /*SDA CUSTOM*/    const directRelations = (rootTable.relations || []).filter((rel: any) =>
+    /*SDA CUSTOM*/        !rel.bridge && !rel.autorelation && rel.target_table === filterTableName
+    /*SDA CUSTOM*/    );
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    // If multiple relations exist to the same table, use the first primary; user can override manually.
+    /*SDA CUSTOM*/    if (directRelations.length === 0) return;
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    const rel = directRelations[0];
+    /*SDA CUSTOM*/    const sourceJoin = `${rel.source_table || rootTableName}.${rel.source_column[0]}`;
+    /*SDA CUSTOM*/    const joinChildId = `${rel.target_table}.${rel.target_column[0]}`;
+    /*SDA CUSTOM*/    const child_id = `${joinChildId}.${rel.source_column[0]}`;
+    /*SDA CUSTOM*/    const joins: any[] = [[sourceJoin, joinChildId]];
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    const childLabel = rel.display_name?.default || `${rel.source_column[0]} - ${rel.target_table}`;
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    const syntheticNode = {
+    /*SDA CUSTOM*/        child_id,
+    /*SDA CUSTOM*/        type: 'child',
+    /*SDA CUSTOM*/        label: childLabel,
+    /*SDA CUSTOM*/        autorelation: false,
+    /*SDA CUSTOM*/        joins
+    /*SDA CUSTOM*/    };
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    this.globalFilter.pathList[panel.id].table_id = child_id;
+    /*SDA CUSTOM*/    this.globalFilter.pathList[panel.id].path = joins;
+    /*SDA CUSTOM*/    this.globalFilter.pathList[panel.id].selectedTableNodes = syntheticNode;
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    if (!this.globalFilter.panelList.includes(panel.id)) {
+    /*SDA CUSTOM*/        this.globalFilter.panelList.push(panel.id);
+    /*SDA CUSTOM*/    }
+    /*SDA CUSTOM*/}
+
+    /*SDA CUSTOM*/private propagatePathToSimilarPanels(sourcePanelId: string, table_id: string, node: any): void {
+    /*SDA CUSTOM*/    const sourcePanel = this.filteredPanels.find((p: any) => p.id === sourcePanelId);
+    /*SDA CUSTOM*/    if (!sourcePanel) return;
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    const sourceRootTable = sourcePanel.content.query.query.rootTable;
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    const nodeSnapshot = {
+    /*SDA CUSTOM*/        child_id: node.child_id,
+    /*SDA CUSTOM*/        table_id: node.table_id,
+    /*SDA CUSTOM*/        type: node.type,
+    /*SDA CUSTOM*/        label: node.label,
+    /*SDA CUSTOM*/        autorelation: node.autorelation,
+    /*SDA CUSTOM*/        joins: (node.joins || []).map((j: any[]) => [...j])
+    /*SDA CUSTOM*/    };
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    for (const panel of this.filteredPanels) {
+    /*SDA CUSTOM*/        if (panel.id === sourcePanelId) continue;
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/        const panelRootTable = panel.content.query.query.rootTable;
+    /*SDA CUSTOM*/        const panelPath = this.globalFilter.pathList[panel.id];
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/        if (panelRootTable === sourceRootTable && panelPath && this.isEmpty(panelPath.selectedTableNodes)) {
+    /*SDA CUSTOM*/            panelPath.table_id = table_id;
+    /*SDA CUSTOM*/            panelPath.path = (node.joins || []).map((j: any[]) => [...j]);
+    /*SDA CUSTOM*/            panelPath.selectedTableNodes = { ...nodeSnapshot };
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/            if (!this.globalFilter.panelList.includes(panel.id)) {
+    /*SDA CUSTOM*/                this.globalFilter.panelList.push(panel.id);
+    /*SDA CUSTOM*/            }
+    /*SDA CUSTOM*/        }
+    /*SDA CUSTOM*/    }
+    /*SDA CUSTOM*/}
 
     public onNodeExpand(panel: any, event: any): void {
         const node = event?.node;
@@ -394,9 +471,7 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
                 this.globalFilter.panelList.push(panel.id);
             }
 
-            // const existsPath = pathList.find((path: any) => path.panel_id == panel.id);
-            // pathList.push({ panel_id: panel.id, path: node.joins || [] });
-            // this.globalFilter.table_id = table_id;
+            /*SDA CUSTOM*/ this.propagatePathToSimilarPanels(panel.id, table_id, node);
         }
     }
 
@@ -499,28 +574,22 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
         return this.modelTables.find((table: any) => table.table_name === tableName);
     }
 
-    public getDisplayPathStr(node: any) {
-        let str = '&nbsp';
+    /*SDA CUSTOM*/public getDisplayPathStr(node: any): string {
+    /*SDA CUSTOM*/    if (!node) return '&nbsp';
 
-        if (node) {
-            if ((node.joins||[]).length > 0) {
-                for (const join of node.joins) {
-                    const table = this.findTable(join[0]?.split('.')[0]);
-
-                    if (table) {
-                        str += `<strong>${table.display_name.default}</strong>&nbsp <i class="pi pi-angle-right"></i>`
-                    }
-                }
-
-                str += `<strong>${node.label}</strong>`;
-            } else {
-                str = `<strong>${node.label}</strong>`;
+    /*SDA CUSTOM*/    if ((node.joins || []).length > 0) {
+    /*SDA CUSTOM*/        let str = '';
+    /*SDA CUSTOM*/        for (const join of node.joins) {
+    /*SDA CUSTOM*/            const table = this.findTable(join[0]?.split('.')[0]);
+    /*SDA CUSTOM*/            if (table) {
+    /*SDA CUSTOM*/                str += `<strong>${table.display_name.default}</strong>&nbsp;<i class="pi pi-angle-right"></i>&nbsp;`;
+    /*SDA CUSTOM*/            }
             }
-        }
+    /*SDA CUSTOM*/        return str + `<strong>${node.label}</strong>`;
+    /*SDA CUSTOM*/    }
 
-
-        return str;
-    }
+    /*SDA CUSTOM*/    return `<strong>${node.label}</strong>`;
+    /*SDA CUSTOM*/}
 
     public onApply(): void {
         if (this.validateGlobalFilter()) {

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
@@ -357,6 +357,11 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
         for (const panel of this.filteredPanels) {
             panel.content.globalFilterPaths = this.globalFilterService.loadTablePaths(this.modelTables, panel);
 
+            /*SDA CUSTOM*/ if (this.isPathStaleForPanel(panel)) {
+            /*SDA CUSTOM*/     this.globalFilter.pathList[panel.id] = { selectedTableNodes: {}, path: [] };
+            /*SDA CUSTOM*/     this.globalFilter.panelList = this.globalFilter.panelList.filter((id: string) => id !== panel.id);
+            /*SDA CUSTOM*/ }
+
             if (this.globalFilter.pathList[panel.id] && this.isEmpty(this.globalFilter.pathList[panel.id].selectedTableNodes)) {
                 const panelQuery = panel.content.query.query;
                 const rootTable = panelQuery.rootTable;
@@ -378,6 +383,24 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
             }
         }
     }
+
+    /*SDA CUSTOM*/private isPathStaleForPanel(panel: any): boolean {
+    /*SDA CUSTOM*/    const pathEntry = this.globalFilter.pathList[panel.id];
+    /*SDA CUSTOM*/    if (!pathEntry || this.isEmpty(pathEntry.selectedTableNodes)) return false;
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    const currentRootTable = panel.content.query.query.rootTable;
+    /*SDA CUSTOM*/    if (!currentRootTable) return false; // paneles sin rootTable (ej. SQL): no validar
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    const path: any[] = pathEntry.path || [];
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    if (path.length === 0) {
+    /*SDA CUSTOM*/        // 0 saltos: el inicio está en selectedTableNodes.table_id
+    /*SDA CUSTOM*/        return pathEntry.selectedTableNodes?.table_id !== currentRootTable;
+    /*SDA CUSTOM*/    } else {
+    /*SDA CUSTOM*/        // 1+ saltos: el inicio está en la primera parte del primer join
+    /*SDA CUSTOM*/        return path[0][0]?.split('.')[0] !== currentRootTable;
+    /*SDA CUSTOM*/    }
+    /*SDA CUSTOM*/}
 
     /*SDA CUSTOM*/private tryAutoFillSingleHop(panel: any): void {
     /*SDA CUSTOM*/    const filterTableName = this.globalFilter.selectedTable?.table_name;

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
@@ -371,6 +371,9 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
                     if (!this.globalFilter.panelList.includes(panel.id)) this.globalFilter.panelList.push(panel.id);
                 /*SDA CUSTOM*/} else {
                 /*SDA CUSTOM*/    this.tryAutoFillSingleHop(panel);
+                /*SDA CUSTOM*/    if (this.isEmpty(this.globalFilter.pathList[panel.id].selectedTableNodes)) {
+                /*SDA CUSTOM*/        this.tryCopyPathFromSiblingPanel(panel);
+                /*SDA CUSTOM*/    }
                 /*SDA CUSTOM*/}
             }
         }
@@ -412,6 +415,28 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
     /*SDA CUSTOM*/    this.globalFilter.pathList[panel.id].table_id = child_id;
     /*SDA CUSTOM*/    this.globalFilter.pathList[panel.id].path = joins;
     /*SDA CUSTOM*/    this.globalFilter.pathList[panel.id].selectedTableNodes = syntheticNode;
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    if (!this.globalFilter.panelList.includes(panel.id)) {
+    /*SDA CUSTOM*/        this.globalFilter.panelList.push(panel.id);
+    /*SDA CUSTOM*/    }
+    /*SDA CUSTOM*/}
+
+    /*SDA CUSTOM*/private tryCopyPathFromSiblingPanel(panel: any): void {
+    /*SDA CUSTOM*/    const rootTableName = panel.content.query.query.rootTable;
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    const sibling = this.filteredPanels.find((p: any) => {
+    /*SDA CUSTOM*/        if (p.id === panel.id) return false;
+    /*SDA CUSTOM*/        if (p.content.query.query.rootTable !== rootTableName) return false;
+    /*SDA CUSTOM*/        const siblingPath = this.globalFilter.pathList[p.id];
+    /*SDA CUSTOM*/        return siblingPath && !this.isEmpty(siblingPath.selectedTableNodes);
+    /*SDA CUSTOM*/    });
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    if (!sibling) return;
+    /*SDA CUSTOM*/
+    /*SDA CUSTOM*/    const siblingPath = this.globalFilter.pathList[sibling.id];
+    /*SDA CUSTOM*/    this.globalFilter.pathList[panel.id].table_id = siblingPath.table_id;
+    /*SDA CUSTOM*/    this.globalFilter.pathList[panel.id].path = (siblingPath.path || []).map((j: any[]) => [...j]);
+    /*SDA CUSTOM*/    this.globalFilter.pathList[panel.id].selectedTableNodes = _.cloneDeep(siblingPath.selectedTableNodes);
     /*SDA CUSTOM*/
     /*SDA CUSTOM*/    if (!this.globalFilter.panelList.includes(panel.id)) {
     /*SDA CUSTOM*/        this.globalFilter.panelList.push(panel.id);

--- a/eda/eda_app/src/app/shared/models/dashboard-models/eda-panel.model.ts
+++ b/eda/eda_app/src/app/shared/models/dashboard-models/eda-panel.model.ts
@@ -23,6 +23,7 @@ export class EdaPanel {
     public size : number ;
     public linkedDashboard : boolean = false;
     public linkedDashboardProps : LinkedDashboardProps;
+    /*SDA CUSTOM*/ public _isDuplicate?: boolean;
 
     constructor(init?: Partial<EdaPanel>) {
         Object.assign(this, init);


### PR DESCRIPTION
## Descripción del Cambio
Se crea una lógica para inferir el camino que debe seguir un filtro para  aplicar a un panel. 
La lógica a seguir es la descrita en el issue:

1. Inferencia de ruta simple: Autocompletar el camino si el módulo destino está a un solo salto de distancia.
2. Propagación de contexto: Replicar el camino seleccionado en paneles no definidos que compartan el mismo origen y destino.

1. Auto-relleno de relación a un salto
Cuando un usuario intenta filtrar por un campo perteneciente a un módulo que no es el principal del panel, el sistema debe:

Analizar la distancia entre los módulos.
Si la distancia es igual a 1 (ej. Pagos -> Persona ignorando la relación con Usuarios), el sistema debe pre-configurar automáticamente la ruta Pagos > Persona sin intervención del usuario.
2. Replicación de caminos entre paneles
Para informes con múltiples paneles:

Si el usuario define manualmente un camino específico para conectar dos módulos en un panel.
Y existen otros paneles con el mismo Módulo Inicial y Módulo Final que aún no tienen un camino definido.
El sistema debe replicar automáticamente el camino seleccionado en el primer panel a los demás para mantener la consistencia del informe.


## Issue(s) resuelto(s)
- solves  #441

## Pruebas a realizar para validar el cambio
Las descritas en el issue:
1. Crear un panel con campos de diferente tablas. Por ejemplo. Compromisos de pago persona , inscripciones y eventos.
2. Crear un filtro para ese panel con campos de la tabla principal o una de las relacionadas. 
3. Duplicar el panel y comprobar que las rutas se propagan.
4. Crear un filtro que esté muy alejado y comprobar que la ruta no se infiere.

