### PR TITLE
Incidencia - Filtros - Definir filtros obligatorios para asegurar seguridad en informes públicos.

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.html
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.html
@@ -21,3 +21,13 @@
       </p>
     </div>
 </ng-container>
+
+<!-- SDA CUSTOM - Toggle mandatory filter -->
+<ng-container *ngIf="MANDATORY_FILTER_REQUIRED">
+  <div class="d-flex justify-content-center">
+      <p class="alert alert-warning text-center" style="position: absolute; top: 50%; transform: translateY(-50%); font-size: 12px;">
+        <span i18n="@@mandatoryFilterRequired" class="ml-2">Seleccione un valor para el filtro obligatorio para ver los datos</span>
+      </p>
+    </div>
+</ng-container>
+<!-- END SDA CUSTOM -->

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-charts/panel-chart.component.ts
@@ -64,6 +64,9 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
     public NO_DATA: boolean;
     public NO_DATA_ALLOWED: boolean;
     public NO_FILTER_ALLOWED: boolean;
+    /* SDA CUSTOM - Toggle mandatory filter */
+    public MANDATORY_FILTER_REQUIRED: boolean;
+    /* END SDA CUSTOM */
 
     /**Styles */
     public fontColor: string;
@@ -105,6 +108,9 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
         this.NO_DATA = false;
         this.NO_DATA_ALLOWED = false;
         this.NO_FILTER_ALLOWED = false;
+        /* SDA CUSTOM - Toggle mandatory filter */
+        this.MANDATORY_FILTER_REQUIRED = false;
+        /* END SDA CUSTOM */
     }
 
     ngOnChanges(changes: SimpleChanges): void {
@@ -117,6 +123,9 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
 
             setTimeout(_ => {
                 this.NO_DATA = false;
+                /* SDA CUSTOM - Toggle mandatory filter */
+                this.MANDATORY_FILTER_REQUIRED = false;
+                /* END SDA CUSTOM */
             });
 
             this.changeChartType();
@@ -129,15 +138,31 @@ export class PanelChartComponent implements OnInit, OnChanges, OnDestroy {
             this.destroyComponent();
             setTimeout(_ => {
                 this.NO_DATA = true;
+                /* SDA CUSTOM - Toggle mandatory filter */
+                this.MANDATORY_FILTER_REQUIRED = false;
+                /* END SDA CUSTOM */
                 if( this.props.data?.labels[0]== "noDataAllowed") {
                     this.NO_DATA = false;
                     this.NO_DATA_ALLOWED = true;
                     this.NO_FILTER_ALLOWED = false;
+                    /* SDA CUSTOM - Toggle mandatory filter */
+                    this.MANDATORY_FILTER_REQUIRED = false;
+                    /* END SDA CUSTOM */
                 }else if( this.props.data?.labels[0]== "noFilterAllowed") {
                     this.NO_DATA = false;
                     this.NO_DATA_ALLOWED = false;
                     this.NO_FILTER_ALLOWED = true;
+                    /* SDA CUSTOM - Toggle mandatory filter */
+                    this.MANDATORY_FILTER_REQUIRED = false;
+                    /* END SDA CUSTOM */
+                /* SDA CUSTOM - Toggle mandatory filter */
+                }else if( this.props.data?.labels[0]== "mandatoryFilterRequired") {
+                    this.NO_DATA = false;
+                    this.NO_DATA_ALLOWED = false;
+                    this.NO_FILTER_ALLOWED = false;
+                    this.MANDATORY_FILTER_REQUIRED = true;
                 }
+                /* END SDA CUSTOM */
             })
 
         }

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
@@ -44,6 +44,20 @@ export const QueryUtils = {
    */
   switchAndRun: async (ebp: EdaBlankPanelComponent, query: Query) => {
     try {
+      /* SDA CUSTOM - Toggle mandatory filter */
+      // Check if there are mandatory global filters without values
+      const mandatoryFiltersEmpty = ebp.globalFilters?.some((filter: any) =>
+        filter.isMandatory === true &&
+        (!filter.filter_elements?.[0]?.value1 || filter.filter_elements[0].value1.length === 0)
+      );
+
+      if (mandatoryFiltersEmpty) {
+        // Return empty data when mandatory filters have no values
+        // Use ID instead of translated text - translation happens in HTML
+        return [["mandatoryFilterRequired"], []];
+      }
+      /* END SDA CUSTOM */
+
       if (ebp.selectedQueryMode != 'SQL') {
         const queryData = JSON.parse(JSON.stringify(query));
         queryData.query.filters = query.query.filters.filter((f) =>

--- a/eda/eda_app/src/app/module/pages/dashboard/filter-dialog/dashboard-filter-dialog.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/filter-dialog/dashboard-filter-dialog.component.html
@@ -12,7 +12,7 @@
     <div footer>
         <div class="ui-dialog-buttonpane ui-widget-content ui-helper-clearfix text-right">
             <!--SDA CUSTOM--><button id="saveFilterButton" type="submit" pButton (click)="saveGlobalFilter()" i18n-label="@@guardarButton"
-                label="Confirmar" icon="fa fa-check" class="p-button-raised p-button-success" [disabled]="confirmDisabled()"></button>
+                label="Confirmar" icon="fa fa-check" class="p-button-raised p-button-success"></button>
             <!--SDA CUSTOM--><button type="button" pButton (click)="closeDialog()" class="p-button-raised p-button-danger"
                 i18n-label="@@cancelarButton" label="Cancelar"></button>
         </div>
@@ -37,6 +37,15 @@
                         i18n-title="@@filterVisibleScope" title="Definir la visibilidad del filtro. Público: todos pueden usarlo.  Deshabilitado: El resto de usuarios pueden ver el filtro pero no pueden modificarlo.  Oculto: El resto de usuarios no pueden ver el filtro, pero se les aplica"
                         [options]="publicRoHidden" [(ngModel)]="publicRoHiddenOption" selected="publicRoHiddenOption" autoWidth="false"></p-dropdown>
                     </div>
+                    <!-- SDA CUSTOM - Toggle mandatory filter -->
+                    <div class="col-4">
+                        <div class="filterDialogTitles" i18n="@@mandatoryFilter">¿Filtro obligatorio?</div>
+                        <p-inputSwitch [(ngModel)]="isMandatory" (onChange)="isMandatoryError = false"></p-inputSwitch>
+                        <div *ngIf="isMandatoryError" class="p-error mt-2">
+                            <small i18n="@@mandatoryFilterError">El filtro obligatorio debe tener al menos un valor seleccionado</small>
+                        </div>
+                    </div>
+                    <!-- END SDA CUSTOM -->
                 </div>
             </div>
         </div>

--- a/eda/eda_app/src/app/module/pages/dashboard/filter-dialog/dashboard-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/filter-dialog/dashboard-filter-dialog.component.ts
@@ -43,6 +43,11 @@ export class DashboardFilterDialogComponent extends EdaDialogAbstract {
         {label: $localize`:@@hidden:oculto`, value: `hidden` }
         ]; 
     public publicRoHiddenOption: any //valor per defecte del dropdown
+
+    /* SDA CUSTOM - Toggle mandatory filter */
+    public isMandatory: boolean = false;
+    public isMandatoryError: boolean = false;
+    /* END SDA CUSTOM */
     
     public rangeDates: Date[];
     public selectedRange : string = null;
@@ -51,7 +56,9 @@ export class DashboardFilterDialogComponent extends EdaDialogAbstract {
     public aliasValue : string = "";
     
     // Global filters vars
-    public filtersList: Array<{ table, column, panelList, data, selectedItems, selectedRange, id, isGlobal, applyToAll, visible }> = [];
+    /* SDA CUSTOM - Toggle mandatory filter */
+    public filtersList: Array<{ table, column, panelList, data, selectedItems, selectedRange, id, isGlobal, applyToAll, visible, isMandatory? }> = [];
+    /* END SDA CUSTOM */
 
     //strings
     public header1 : string = $localize`:@@aplyToAllPanelsH5:¿Aplica a todos los paneles?`;
@@ -184,6 +191,13 @@ export class DashboardFilterDialogComponent extends EdaDialogAbstract {
 
     public saveGlobalFilter() {
         let response: any;
+        /* SDA CUSTOM - Toggle mandatory filter */
+        if (this.isMandatory && (!this.selectedValues || this.selectedValues.length === 0)) {
+            this.isMandatoryError = true;
+            return this.alertService.addWarning($localize`:@@mandatoryFilterError:El filtro obligatorio debe tener al menos un valor seleccionado`);
+        }
+        this.isMandatoryError = false;
+        /* END SDA CUSTOM */
         if (this.params?.isnew) {
             if (this.panelstoFilter.length === 0 || !this.targetTable || !this.targetCol) {
                 return this.alertService.addWarning($localize`:@@mandatoryFields:Recuerde rellenar los campos obligatorios`);
@@ -193,6 +207,7 @@ export class DashboardFilterDialogComponent extends EdaDialogAbstract {
                 this.targetCol.label = this.aliasValue;
             }
             
+            /* SDA CUSTOM - Toggle mandatory filter */
             this.filtersList.push({
                 id: this.fileUtils.generateUUID(),
                 table: this.targetTable,
@@ -203,8 +218,10 @@ export class DashboardFilterDialogComponent extends EdaDialogAbstract {
                 selectedRange:this.selectedRange,
                 isGlobal: true,
                 applyToAll: !this.applyToAll,
-                visible: this.publicRoHiddenOption
+                visible: this.publicRoHiddenOption,
+                isMandatory: this.isMandatory
             });
+            /* END SDA CUSTOM */
     
             // this.loadGLobalFiltersData(this.filtersList[this.filtersList.length - 1]);
             response = {
@@ -225,6 +242,9 @@ export class DashboardFilterDialogComponent extends EdaDialogAbstract {
                 this.selectedFilter.selectedRange =this.selectedRange;
                 this.selectedFilter.applyToAll = !this.applyToAll;
                 this.selectedFilter.visible = this.publicRoHiddenOption;
+                /* SDA CUSTOM - Toggle mandatory filter */
+                this.selectedFilter.isMandatory = this.isMandatory;
+                /* END SDA CUSTOM */
                 //this.selectedFilter.filterMaker = this;
 
                 for (let filter of this.filtersList) {
@@ -299,6 +319,11 @@ export class DashboardFilterDialogComponent extends EdaDialogAbstract {
         if(this.datePicker){
             return this.targetCol && this.targetCol.value.column_type === 'date' && this.datePicker.active;
         }
+        /* SDA CUSTOM - Toggle mandatory filter */
+        if (this.isMandatory && (!this.selectedValues || this.selectedValues.length === 0)) {
+            return true;
+        }
+        /* END SDA CUSTOM */
        else return false;
     }
 
@@ -334,6 +359,10 @@ export class DashboardFilterDialogComponent extends EdaDialogAbstract {
         this.selectedRange = filter.selectedRange;
         this.selectedFilter = filter;
         this.publicRoHiddenOption = filter.visible;
+        /* SDA CUSTOM - Toggle mandatory filter */
+        this.isMandatory = filter.isMandatory || false;
+        this.isMandatoryError = false;
+        /* END SDA CUSTOM */
         if (filter.column.value.column_type === 'date') {
             this.loadDatesFromFilter(filter)
         }

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.html
@@ -1,5 +1,7 @@
+<!-- SDA CUSTOM - Toggle mandatory filter -->
 <eda-dialog2 [display]="display" [header]="dialogHeader" width="80vw" height="90vh" (apply)="onApply()"
     (close)="onClose()">
+<!-- END SDA CUSTOM -->
 
     <div content>
         <div class="row">
@@ -60,6 +62,22 @@
                             </p-dropdown>
                         </div>
                     </div>
+                    <!-- SDA CUSTOM - Mandatory filter toggle switch -->
+                    <div class="row mt-3">
+                        <div class="col-12 d-flex align-items-center">
+                            <span i18n="@@mandatoryFilter">¿Filtro obligatorio?</span>
+                            &nbsp;
+                            <p-inputSwitch [(ngModel)]="isMandatory" (onChange)="mandatoryFilterCheck()"
+                                [style]="{'vertical-align': 'middle'}">
+                            </p-inputSwitch>
+                        </div>
+                    </div>
+                    <div class="row mt-2" *ngIf="isMandatoryError">
+                        <div class="col-12">
+                            <small class="p-error" i18n="@@mandatoryFilterError">El filtro obligatorio debe tener al menos un valor seleccionado</small>
+                        </div>
+                    </div>
+                    <!-- END SDA CUSTOM -->
                 </p-card>
             </div>
         </div>

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
@@ -58,6 +58,11 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
     public datePickerConfigs: any = {};
     public aliasValue: string = "";
 
+    /* SDA CUSTOM - Toggle mandatory filter */
+    public isMandatory: boolean = false;
+    public isMandatoryError: boolean = false;
+    /* END SDA CUSTOM */
+
     constructor(
         private globalFilterService: GlobalFiltersService,
         private dashboardService: DashboardService,
@@ -91,6 +96,9 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
                 // selectedRange:this.selectedRange,
                 isGlobal: true,
                 visible: null,
+                /* SDA CUSTOM - Toggle mandatory filter */
+                isMandatory: false,
+                /* END SDA CUSTOM */
             };
 
             this.initPanels();
@@ -114,6 +122,9 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
             this.loadColumnValues();
             this.findPanelPathTables();
             this.aliasValue = display_name_alias;
+            /* SDA CUSTOM - Toggle mandatory filter */
+            this.isMandatory = this.globalFilter.isMandatory || false;
+            /* END SDA CUSTOM */
         }
 
         this.formReady = true;
@@ -444,6 +455,13 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
             }
         }
 
+        /* SDA CUSTOM - Toggle mandatory filter */
+        if (this.isMandatory) {
+            valid = this.globalFilter.selectedItems && this.globalFilter.selectedItems.length > 0;
+            this.isMandatoryError = !valid;
+        }
+        /* END SDA CUSTOM */
+
         return valid;
     }
 
@@ -536,5 +554,19 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
         this.display = false;
         this.close.emit(false);
     }
+
+    /* SDA CUSTOM - Toggle mandatory filter */
+    public mandatoryFilterCheck(): void {
+        // ngModel already updated isMandatory, just copy to globalFilter
+        this.globalFilter.isMandatory = this.isMandatory;
+        this.isMandatoryError = false;
+    }
+    /* END SDA CUSTOM */
+
+    /* SDA CUSTOM - Toggle mandatory filter */
+    public disableApply(): boolean {
+        return this.isMandatory && (!this.globalFilter.selectedItems || this.globalFilter.selectedItems.length === 0);
+    }
+    /* END SDA CUSTOM */
 
 }

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
@@ -258,6 +258,9 @@ export class GlobalFilterComponent implements OnInit {
                     filter.type = this.globalFilter.type;
                     filter.isGlobal = this.globalFilter.isGlobal;
                     filter.visible = this.globalFilter.visible;
+                    /* SDA CUSTOM - Toggle mandatory filter */
+                    filter.isMandatory = this.globalFilter.isMandatory;
+                    /* END SDA CUSTOM */
 
                     for (const key in filter.pathList) {
                         if (filter.pathList[key]?.selectedTableNodes) {
@@ -336,6 +339,9 @@ export class GlobalFilterComponent implements OnInit {
 
                     if (existFilter) {
                         existFilter.selectedItems = filter.selectedItems;
+                        /* SDA CUSTOM - Toggle mandatory filter */
+                        existFilter.isMandatory = filter.isMandatory;
+                        /* END SDA CUSTOM */
                     } else {
                         this.globalFilters.push(filter);
                     }

--- a/eda/eda_app/src/app/services/api/global-filters.service.ts
+++ b/eda/eda_app/src/app/services/api/global-filters.service.ts
@@ -383,7 +383,8 @@ export class GlobalFiltersService {
             filter_elements: this.assertGlobalFilterItems(globalFilter),
             isGlobal: true,
             applyToAll: globalFilter.applyToAll,
-            valueListSource: globalFilter.column.value.valueListSource
+            valueListSource: globalFilter.column.value.valueListSource,
+            /* SDA CUSTOM */ isMandatory: globalFilter.isMandatory || false
         }
 
         return formatedFilter;
@@ -420,6 +421,7 @@ export class GlobalFiltersService {
             joins: globalFilter.joins,
             computed_column: globalFilter.selectedColumn.computed_column,
             SQLexpression: globalFilter.selectedColumn.SQLexpression,
+            /* SDA CUSTOM */ isMandatory: globalFilter.isMandatory || false
         }
 
         return formatedFilter;

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -921,6 +921,10 @@
     <source>El filtro obligatorio debe tener al menos un valor seleccionado</source>
     <target>El filtre obligatori ha de tenir almenys un valor seleccionat</target>
   </trans-unit>
+  <trans-unit id="mandatoryFilterRequired">
+    <source>Filtro obligatorio requerido</source>
+    <target>Seleccioneu un valor per al filtre obligatori per veure les dades</target>
+  </trans-unit>
   <!-- END SDA CUSTOM -->
 </body>
   </file>

--- a/eda/eda_app/src/locale/stic_messages.ca.xlf
+++ b/eda/eda_app/src/locale/stic_messages.ca.xlf
@@ -912,6 +912,16 @@
     <source>Download JSON</source>
     <target>Descarregar JSON</target>
   </trans-unit>
+  <!-- SDA CUSTOM - Toggle mandatory filter -->
+  <trans-unit id="mandatoryFilter">
+    <source>¿Filtro obligatorio?</source>
+    <target>Filtre obligatori?</target>
+  </trans-unit>
+  <trans-unit id="mandatoryFilterError">
+    <source>El filtro obligatorio debe tener al menos un valor seleccionado</source>
+    <target>El filtre obligatori ha de tenir almenys un valor seleccionat</target>
+  </trans-unit>
+  <!-- END SDA CUSTOM -->
 </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -910,6 +910,16 @@
     <source>Download JSON</source>
     <target>Download JSON</target>
   </trans-unit>
+  <!-- SDA CUSTOM - Toggle mandatory filter -->
+  <trans-unit id="mandatoryFilter">
+    <source>¿Filtro obligatorio?</source>
+    <target>Mandatory filter?</target>
+  </trans-unit>
+  <trans-unit id="mandatoryFilterError">
+    <source>El filtro obligatorio debe tener al menos un valor seleccionado</source>
+    <target>The mandatory filter must have at least one value selected</target>
+  </trans-unit>
+  <!-- END SDA CUSTOM -->
 </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.en.xlf
+++ b/eda/eda_app/src/locale/stic_messages.en.xlf
@@ -919,6 +919,10 @@
     <source>El filtro obligatorio debe tener al menos un valor seleccionado</source>
     <target>The mandatory filter must have at least one value selected</target>
   </trans-unit>
+  <trans-unit id="mandatoryFilterRequired">
+    <source>Filtro obligatorio requerido</source>
+    <target>Please select a value for the mandatory filter to view data</target>
+  </trans-unit>
   <!-- END SDA CUSTOM -->
 </body>
   </file>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -913,6 +913,16 @@
     <source>Download JSON</source>
     <target>Descargar JSON</target>
   </trans-unit>
+  <!-- SDA CUSTOM - Toggle mandatory filter -->
+  <trans-unit id="mandatoryFilter">
+    <source>¿Filtro obligatorio?</source>
+    <target>¿Filtro obligatorio?</target>
+  </trans-unit>
+  <trans-unit id="mandatoryFilterError">
+    <source>El filtro obligatorio debe tener al menos un valor seleccionado</source>
+    <target>El filtro obligatorio debe tener al menos un valor seleccionado</target>
+  </trans-unit>
+  <!-- END SDA CUSTOM -->
 </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.es.xlf
+++ b/eda/eda_app/src/locale/stic_messages.es.xlf
@@ -922,6 +922,10 @@
     <source>El filtro obligatorio debe tener al menos un valor seleccionado</source>
     <target>El filtro obligatorio debe tener al menos un valor seleccionado</target>
   </trans-unit>
+  <trans-unit id="mandatoryFilterRequired">
+    <source>Filtro obligatorio requerido</source>
+    <target>Seleccione un valor para el filtro obligatorio para ver los datos</target>
+  </trans-unit>
   <!-- END SDA CUSTOM -->
 </body>
   </file>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -912,6 +912,16 @@
     <source>Download JSON</source>
     <target>Descargar JSON</target>
   </trans-unit>
+  <!-- SDA CUSTOM - Toggle mandatory filter -->
+  <trans-unit id="mandatoryFilter">
+    <source>¿Filtro obligatorio?</source>
+    <target>Filtro obrigatorio?</target>
+  </trans-unit>
+  <trans-unit id="mandatoryFilterError">
+    <source>El filtro obligatorio debe tener al menos un valor seleccionado</source>
+    <target>O filtro obrigatorio debe ter polo menos un valor seleccionado</target>
+  </trans-unit>
+  <!-- END SDA CUSTOM -->
 </body>
   </file>
 </xliff>

--- a/eda/eda_app/src/locale/stic_messages.gl.xlf
+++ b/eda/eda_app/src/locale/stic_messages.gl.xlf
@@ -921,6 +921,10 @@
     <source>El filtro obligatorio debe tener al menos un valor seleccionado</source>
     <target>O filtro obrigatorio debe ter polo menos un valor seleccionado</target>
   </trans-unit>
+  <trans-unit id="mandatoryFilterRequired">
+    <source>Filtro obligatorio requerido</source>
+    <target>Seleccione un valor para o filtro obrigatorio para ver os datos</target>
+  </trans-unit>
   <!-- END SDA CUSTOM -->
 </body>
   </file>


### PR DESCRIPTION
- closes #525 
### Descripción

Implementación de la funcionalidad de filtros obligatorios que permite marcar un filtro global como requerido, obligando a los usuarios a seleccionar al menos un valor antes de poder aplicar el filtro. Esto permite evitar errores en filtros públicos con filtros de URL: al hacer obligatorio el filtro, aunque los usuarios modifiquen la URL no podrán ver datos ya que el informe necesita de un valor obligatorio para mostrar los paneles. Cuando un filtro se marca como obligatorio, los usuarios deben seleccionar al menos un valor antes de poder guardar la configuración del filtro.


### Cómo probar los cambios

1. Acceder a un dashboard existente o crear uno nuevo
2. Añadir un panel con al menos un campo de una tabla
3. Seleccionar "Añadir filtro"
4. Seleccionar una tabla y columna para el filtro
5. Verificar: Aparece el toggle "¿Filtro obligatorio?"
6. Activar el toggle "¿Filtro obligatorio?" (debe cambiar a ON/verde)
7. Verificar: Al intentar guardar sin seleccionar valores, aparece error: "El filtro obligatorio debe tener al menos un valor seleccionado"
8. Seleccionar al menos un valor del filtro
9. Guardar el filtro y el dashboard
10. Recargar la página y verificar que el filtro mantiene la marca de obligatorio

**Filtros existentes**

1. Abrir un dashboard con filtros existentes creados antes de este cambio
2. Editar uno de los filtros existentes
3. Verificar: El toggle aparece desactivado (valor por defecto false)
4. Marcarlo como obligatorio, guardar y recargar
5. Verificar: El estado se persiste correctamente
