### PR TITLE
Incidencia - General -  Proteger findRelationsRecursive en el frontend

### DIFF
--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/tables-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/tables-utils.ts
@@ -10,20 +10,25 @@ export const TableUtils = {
     * @param table  origin table to start building the path
     * @param vMap   Map() to keep tracking visited nodes -> first call is just a new Map()
   */
+  // SDA CUSTOM - Added safety checks for undefined table and missing relation targets to prevent TypeError
   findRelationsRecursive: (tables: any, table: any, vMap: any) => {
-    vMap.set(table?.table_name, table);
+    /* SDA CUSTOM */ if (!table) return vMap;
+    /* SDA CUSTOM */ vMap.set(table.table_name, table);
 
-    table?.relations.filter(r => r.visible !== false)
+    /* SDA CUSTOM */ if (table.relations) {
+    table.relations.filter(r => r.visible !== false)
       .forEach(rel => {
         const newTable = tables.find(t => t.table_name === rel.target_table);
-        if (!vMap.has(newTable.table_name)) {
+        /* SDA CUSTOM */ if (newTable && !vMap.has(newTable.table_name)) {
           TableUtils.findRelationsRecursive(tables, newTable, vMap);
-        }
+        /* SDA CUSTOM */ }
       });
+    /* SDA CUSTOM */ }
 
     return vMap;
 
   },
+  // END SDA CUSTOM
 
   /**
    * Filter and sort tables given a refference table


### PR DESCRIPTION
### Descripción:

Corrige un `TypeError: Cannot read properties of undefined (reading 'table_name')` que se producía en el frontend durante la inicialización de dashboards. El error ocurría porque findRelationsRecursive intentaba acceder a propiedades de una tabla relacionada (newTable) sin verificar si tables.find(...) la había encontrado. El backend ya contenía el mismo fix previo; esta PR lo sincroniza al frontend.

### Como probar:

- Abrir un dashboard que contenga paneles con relaciones cuyas tablas destino no existan en el modelo.
- Verificar que el dashboard carga sin errores en la consola del navegador.
- Confirmar que la lista de tablas disponibles en el panel se filtra correctamente.