### PR TITLE
Mejora - Filtros - Permitir filtrar por columnas desplegables en el modo SQL

### DIFF
--- a/eda/eda_api/lib/services/query-builder/query-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/query-builder.service.ts
@@ -996,8 +996,12 @@ export abstract class QueryBuilderService {
             /*SDA CUSTOM*/         } else {
             /*SDA CUSTOM*/             valuesStr = rawValues.map((v: any) => `'${String(v).replace(/'/g, "''")}'`).join(', ');
             /*SDA CUSTOM*/         }
-            /*SDA CUSTOM*/         // Use filter_column only (no table prefix) so sqlQuery replaces it with the mark's alias.column
-            /*SDA CUSTOM*/         formatedFilters.push({ string: `${filterCol} in (${valuesStr})`, type: filter.filter_type });
+            /*SDA CUSTOM*/         // Build "tableName.filterCol in (values)" format so that sqlQuery's indexOf('.')
+            /*SDA CUSTOM*/         // always finds the table/column separator, not a decimal dot inside the values.
+            /*SDA CUSTOM*/         // filter_table may be a child_id ("table.col.col") — take only the first segment.
+            /*SDA CUSTOM*/         // The table name is replaced by the mark's alias anyway (arr[0] = subs in sqlQuery).
+            /*SDA CUSTOM*/         const tablePrefix: string = ((filter.filter_table as string) || filterCol).split('.')[0];
+            /*SDA CUSTOM*/         formatedFilters.push({ string: `${tablePrefix}.${filterCol} in (${valuesStr})`, type: filter.filter_type });
             /*SDA CUSTOM*/     } else {
             /*SDA CUSTOM*/         formatedFilters.push({ string: this.filterToString(filter), type: filter.filter_type });
             /*SDA CUSTOM*/     }

--- a/eda/eda_api/lib/services/query-builder/query-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/query-builder.service.ts
@@ -1000,7 +1000,8 @@ export abstract class QueryBuilderService {
             /*SDA CUSTOM*/                 .filter((n: number) => !isNaN(n));
             /*SDA CUSTOM*/             valuesStr = validNums.length > 0 ? validNums.join(', ') : null;
             /*SDA CUSTOM*/         } else {
-            /*SDA CUSTOM*/             valuesStr = rawValues.map((v: any) => `'${String(v).replace(/'/g, "''")}'`).join(', ');
+            /*SDA CUSTOM*/             const mappedVals = rawValues.map((v: any) => `'${String(v).replace(/'/g, "''")}'`);
+            /*SDA CUSTOM*/             valuesStr = mappedVals.length > 0 ? mappedVals.join(', ') : null;
             /*SDA CUSTOM*/         }
             /*SDA CUSTOM*/         if (valuesStr !== null) {
             /*SDA CUSTOM*/             // Build "tableName.filterCol in (values)" so that sqlQuery's indexOf('.')

--- a/eda/eda_api/lib/services/query-builder/query-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/query-builder.service.ts
@@ -990,18 +990,37 @@ export abstract class QueryBuilderService {
             /*SDA CUSTOM*/         const rawValues: any[] = (filter.valueListSource && filter.filter_codes?.[0]?.value1?.length > 0)
             /*SDA CUSTOM*/             ? filter.filter_codes[0].value1
             /*SDA CUSTOM*/             : (filter.filter_elements?.[0]?.value1 || []);
-            /*SDA CUSTOM*/         let valuesStr: string;
+            /*SDA CUSTOM*/         let valuesStr: string | null;
             /*SDA CUSTOM*/         if (colType === 'numeric') {
-            /*SDA CUSTOM*/             valuesStr = rawValues.map((v: any) => Number(v)).join(', ');
+            /*SDA CUSTOM*/             // Filter out 'emptyString' and other non-numeric sentinels before Number() conversion.
+            /*SDA CUSTOM*/             // Number('emptyString') = NaN which produces invalid SQL "in (NaN)".
+            /*SDA CUSTOM*/             const validNums: number[] = rawValues
+            /*SDA CUSTOM*/                 .filter((v: any) => v !== 'emptyString' && v !== null && v !== undefined && v !== '')
+            /*SDA CUSTOM*/                 .map((v: any) => Number(v))
+            /*SDA CUSTOM*/                 .filter((n: number) => !isNaN(n));
+            /*SDA CUSTOM*/             valuesStr = validNums.length > 0 ? validNums.join(', ') : null;
             /*SDA CUSTOM*/         } else {
             /*SDA CUSTOM*/             valuesStr = rawValues.map((v: any) => `'${String(v).replace(/'/g, "''")}'`).join(', ');
             /*SDA CUSTOM*/         }
-            /*SDA CUSTOM*/         // Build "tableName.filterCol in (values)" format so that sqlQuery's indexOf('.')
-            /*SDA CUSTOM*/         // always finds the table/column separator, not a decimal dot inside the values.
-            /*SDA CUSTOM*/         // filter_table may be a child_id ("table.col.col") — take only the first segment.
-            /*SDA CUSTOM*/         // The table name is replaced by the mark's alias anyway (arr[0] = subs in sqlQuery).
-            /*SDA CUSTOM*/         const tablePrefix: string = ((filter.filter_table as string) || filterCol).split('.')[0];
-            /*SDA CUSTOM*/         formatedFilters.push({ string: `${tablePrefix}.${filterCol} in (${valuesStr})`, type: filter.filter_type });
+            /*SDA CUSTOM*/         if (valuesStr !== null) {
+            /*SDA CUSTOM*/             // Build "tableName.filterCol in (values)" so that sqlQuery's indexOf('.')
+            /*SDA CUSTOM*/             // always finds the table/column separator, not a decimal dot inside the values.
+            /*SDA CUSTOM*/             // filter_table may be a child_id ("table.col.col") — take only the first segment.
+            /*SDA CUSTOM*/             const tablePrefix: string = ((filter.filter_table as string) || filterCol).split('.')[0];
+            /*SDA CUSTOM*/             formatedFilters.push({ string: `${tablePrefix}.${filterCol} in (${valuesStr})`, type: filter.filter_type });
+            /*SDA CUSTOM*/         } else {
+            /*SDA CUSTOM*/             // Only non-numeric sentinels selected (e.g. 'emptyString' = NULL).
+            /*SDA CUSTOM*/             // Substitute the matching mark directly with IS NULL in the query string.
+            /*SDA CUSTOM*/             // sqlQuery will try to replace the mark but won't find it → no-op.
+            /*SDA CUSTOM*/             // We do NOT call filterToString: it also can't handle 'emptyString' for SQL panels.
+            /*SDA CUSTOM*/             for (const mark of filterMarks) {
+            /*SDA CUSTOM*/                 const subs = mark.slice(mark.indexOf('{') + 1, mark.indexOf('}'));
+            /*SDA CUSTOM*/                 const markCol = subs.slice(subs.indexOf('.') + 1);
+            /*SDA CUSTOM*/                 if (markCol.toUpperCase() === filterCol.toUpperCase()) {
+            /*SDA CUSTOM*/                     query = query.replace(mark, `${subs} IS NULL`);
+            /*SDA CUSTOM*/                 }
+            /*SDA CUSTOM*/             }
+            /*SDA CUSTOM*/         }
             /*SDA CUSTOM*/     } else {
             /*SDA CUSTOM*/         formatedFilters.push({ string: this.filterToString(filter), type: filter.filter_type });
             /*SDA CUSTOM*/     }

--- a/eda/eda_api/lib/services/query-builder/query-builder.service.ts
+++ b/eda/eda_api/lib/services/query-builder/query-builder.service.ts
@@ -969,7 +969,43 @@ export abstract class QueryBuilderService {
         //Get sql formated filters ad types
         const formatedFilters: any[] = [];
         filters.forEach(filter => {
-            formatedFilters.push({ string: this.filterToString(filter ), type: filter.filter_type });
+
+            /*SDA CUSTOM*/
+            /*SDA CUSTOM*/ // Global filter applied to a SQL panel: match filter_column directly against
+            /*SDA CUSTOM*/ // the SQL marks (e.g. filter_column="type" matches ${c.type}).
+            /*SDA CUSTOM*/ // We do NOT use filter.joins (the BFS path) for column matching because:
+            /*SDA CUSTOM*/ //   - BFS may find a "wrong" shortest path (e.g. via assigned_user_id instead
+            /*SDA CUSTOM*/ //     of via registrations) whose join columns don't include the filter column.
+            /*SDA CUSTOM*/ //   - filter_column already contains the exact column name the user selected.
+            /*SDA CUSTOM*/ // For valueListSource: use filter_codes (stored IDs) instead of filter_elements (labels).
+            /*SDA CUSTOM*/ if (filter.isGlobal === true && filter.filter_type !== 'between') {
+            /*SDA CUSTOM*/     const filterCol: string = filter.filter_column;
+            /*SDA CUSTOM*/     const markHit = filterMarks.some((mark: string) => {
+            /*SDA CUSTOM*/         const subs = mark.slice(mark.indexOf('{') + 1, mark.indexOf('}'));
+            /*SDA CUSTOM*/         const markCol = subs.slice(subs.indexOf('.') + 1);
+            /*SDA CUSTOM*/         return markCol.toUpperCase() === filterCol.toUpperCase();
+            /*SDA CUSTOM*/     });
+            /*SDA CUSTOM*/     if (markHit) {
+            /*SDA CUSTOM*/         const colType: string = filter.filter_column_type;
+            /*SDA CUSTOM*/         const rawValues: any[] = (filter.valueListSource && filter.filter_codes?.[0]?.value1?.length > 0)
+            /*SDA CUSTOM*/             ? filter.filter_codes[0].value1
+            /*SDA CUSTOM*/             : (filter.filter_elements?.[0]?.value1 || []);
+            /*SDA CUSTOM*/         let valuesStr: string;
+            /*SDA CUSTOM*/         if (colType === 'numeric') {
+            /*SDA CUSTOM*/             valuesStr = rawValues.map((v: any) => Number(v)).join(', ');
+            /*SDA CUSTOM*/         } else {
+            /*SDA CUSTOM*/             valuesStr = rawValues.map((v: any) => `'${String(v).replace(/'/g, "''")}'`).join(', ');
+            /*SDA CUSTOM*/         }
+            /*SDA CUSTOM*/         // Use filter_column only (no table prefix) so sqlQuery replaces it with the mark's alias.column
+            /*SDA CUSTOM*/         formatedFilters.push({ string: `${filterCol} in (${valuesStr})`, type: filter.filter_type });
+            /*SDA CUSTOM*/     } else {
+            /*SDA CUSTOM*/         formatedFilters.push({ string: this.filterToString(filter), type: filter.filter_type });
+            /*SDA CUSTOM*/     }
+            /*SDA CUSTOM*/
+            /*SDA CUSTOM*/ } else {
+                formatedFilters.push({ string: this.filterToString(filter ), type: filter.filter_type });
+            /*SDA CUSTOM*/ }
+
         });
 
         return this.sqlQuery(query, formatedFilters, filterMarks);

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -1044,8 +1044,10 @@ export class EdaBlankPanelComponent implements OnInit {
         const globalFilter = _.cloneDeep(_filter);
 
         if (_filter.pathList && _filter.pathList[this.panel.id]) {
-            globalFilter.joins = _filter.pathList[this.panel.id].path
-            globalFilter.filter_table = _filter.pathList[this.panel.id].table_id;
+            /*SDA CUSTOM*/ globalFilter.joins = _filter.pathList[this.panel.id].path;
+            /*SDA CUSTOM*/ if (_filter.pathList[this.panel.id].table_id) {
+            /*SDA CUSTOM*/     globalFilter.filter_table = _filter.pathList[this.panel.id].table_id;
+            /*SDA CUSTOM*/ }
         }
         const filterInx = this.globalFilters.findIndex((gf: any) => gf.filter_id === globalFilter.filter_id)
 
@@ -1063,8 +1065,10 @@ export class EdaBlankPanelComponent implements OnInit {
         const globalFilter = _.cloneDeep(_filter);
 
         if (_filter.pathList && _filter.pathList[this.panel.id]) {
-            globalFilter.joins = _filter.pathList[this.panel.id].path
-            globalFilter.filter_table = _filter.pathList[this.panel.id].table_id;
+            /*SDA CUSTOM*/ globalFilter.joins = _filter.pathList[this.panel.id].path;
+            /*SDA CUSTOM*/ if (_filter.pathList[this.panel.id].table_id) {
+            /*SDA CUSTOM*/     globalFilter.filter_table = _filter.pathList[this.panel.id].table_id;
+            /*SDA CUSTOM*/ }
         }
         const filterInx = this.globalFilters.findIndex((gf: any) => gf.filter_id === globalFilter.filter_id)
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/eda-blank-panel.component.ts
@@ -1088,14 +1088,10 @@ export class EdaBlankPanelComponent implements OnInit {
 
     public rebootGlobalFilter(_filter: any){
 
-        if(this.sortedFilters.length !==0) {
-            this.alertService.addWarning($localize`:@@globalFilterSettingsReboot:La configuración de filtros del panel involucrado se ha reiniciado`);
-        }
-
-        if(this.sortedFilters.some((sortedFilter: any) => _filter.id === sortedFilter.filter_id)){
-            this.sortedFilters = [];
-            this.savePanel(); // Panel setting saved
-        }
+        /* SDA CUSTOM  */ const filterIndex = this.sortedFilters.findIndex((sortedFilter: any) => _filter.id === sortedFilter.filter_id);
+        /* SDA CUSTOM  */ if (filterIndex !== -1) {
+        /* SDA CUSTOM  */     this.sortedFilters.splice(filterIndex, 1);
+        /* SDA CUSTOM  */ }
 
     }
 

--- a/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
+++ b/eda/eda_app/src/app/module/components/eda-panels/eda-blank-panel/panel-utils/query-utils.ts
@@ -169,12 +169,17 @@ export const QueryUtils = {
 
     if(ebp.sortedFilters === undefined) ebp.sortedFilters = []; // if it is an old report, we define the report as empty
 
-    for(let i=0; i<ebp.sortedFilters.length; i++){
-      if(ebp.sortedFilters[i].isGlobal) {
-        ebp.sortedFilters[i].filter_elements = ebp.globalFilters.find((globalFilter: any) => globalFilter.filter_id === ebp.sortedFilters[i].filter_id).filter_elements;
-        ebp.sortedFilters[i].filter_codes = ebp.globalFilters.find((globalFilter: any) => globalFilter.filter_id === ebp.sortedFilters[i].filter_id).filter_codes;
-      }
-    }
+    /* SDA CUSTOM*/ for(let i = ebp.sortedFilters.length - 1; i >= 0; i--){
+    /* SDA CUSTOM*/   if(ebp.sortedFilters[i].isGlobal) {
+    /* SDA CUSTOM*/     const matchingGlobalFilter = ebp.globalFilters.find((globalFilter: any) => globalFilter.filter_id === ebp.sortedFilters[i].filter_id);
+    /* SDA CUSTOM*/     if (matchingGlobalFilter) {
+    /* SDA CUSTOM*/       ebp.sortedFilters[i].filter_elements = matchingGlobalFilter.filter_elements;
+    /* SDA CUSTOM*/       ebp.sortedFilters[i].filter_codes = matchingGlobalFilter.filter_codes;
+    /* SDA CUSTOM*/     } else {
+    /* SDA CUSTOM*/       ebp.sortedFilters.splice(i, 1);
+    /* SDA CUSTOM*/     }
+    /* SDA CUSTOM*/   }
+    /* SDA CUSTOM*/ }
 
     /** Manages duplicate columns. If I have two columns with the same name, I add the suffix _1, _2, _3, etc. */
     let dup = [];

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.html
@@ -84,16 +84,15 @@
                                         [ngClass]="{'ui-button-selected': panel.active, 'ui-button-unselected':!panel.active, 'ui-button-unvaliable':!panel.avaliable}">
                                     </button>
                                 </td>
-                                <td style="width: 60%;">
-             <!-- SDA CUSTOM --><p-treeSelect *ngIf="globalFilter.pathList[panel.id]" [(ngModel)]="globalFilter.pathList[panel.id].selectedTableNodes" [options]="panel.content.globalFilterPaths" (onNodeExpand)="onNodeExpand(panel, $event)" (onNodeSelect)="onNodeSelect(panel, $event)" appendTo="body" [disabled]="!panel.active || !panel.avaliable || panel.content?.query?.query?.queryMode === 'SQL'">
+                                 <td style="width: 60%;">
+             <!-- SDA CUSTOM - Show SQL message directly in the cell instead of inside a disabled dropdown -->
+             <ng-container *ngIf="globalFilter.pathList[panel.id] && panel.content?.query?.query?.queryMode === 'SQL'">
+                 <span i18n="@@sqlModeFilterPathText" style="font-family: var(--DEFAULT_FONT_FAMILY); font-weight: bolder; font-size: 0.9rem; color: #495057;" [style.opacity]="!panel.active || !panel.avaliable ? 0.4 : 1">En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta</span>
+             </ng-container>
+             <!-- SDA CUSTOM --><p-treeSelect *ngIf="globalFilter.pathList[panel.id] && panel.content?.query?.query?.queryMode !== 'SQL'" [(ngModel)]="globalFilter.pathList[panel.id].selectedTableNodes" [options]="panel.content.globalFilterPaths" (onNodeExpand)="onNodeExpand(panel, $event)" (onNodeSelect)="onNodeSelect(panel, $event)" appendTo="body" [disabled]="!panel.active || !panel.avaliable">
 
                                         <ng-template pTemplate="value">
-                         <!-- SDA CUSTOM --><ng-container *ngIf="panel.content?.query?.query?.queryMode === 'SQL'; else pathTpl">
-                         <!-- SDA CUSTOM -->    <span i18n="@@sqlModeFilterPathText" style="font-family: var(--DEFAULT_FONT_FAMILY); font-weight: bolder; font-size: 0.9rem; color: #495057;">En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta</span>
-                         <!-- SDA CUSTOM --></ng-container>
-                         <!-- SDA CUSTOM --><ng-template #pathTpl>
                          <!-- SDA CUSTOM -->    <span class="d-flex align-items-center" [innerHTML]="getDisplayPathStr(globalFilter.pathList[panel.id].selectedTableNodes)"></span>
-                         <!-- SDA CUSTOM --></ng-template>
                                         </ng-template>
 
                                         <ng-template let-node pTemplate="child">

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.html
@@ -25,7 +25,7 @@
                         <div class="col-3" >
                             <input class = "d-flex justify-content-center" type="text" pInputText id="aliasName"
                             [style]="{'vertical-align' : 'bottom', width: '100%' }"
-                            [(ngModel)]="aliasValue"  
+                            [(ngModel)]="aliasValue"
                             placeholder="Alias del filtro (opcional)"
                             i18n-placeholder="@@aliasValuePh">
                         </div>
@@ -89,7 +89,7 @@
 
                                         <ng-template pTemplate="value">
                          <!-- SDA CUSTOM --><ng-container *ngIf="panel.content?.query?.query?.queryMode === 'SQL'; else pathTpl">
-                         <!-- SDA CUSTOM -->    <span i18n="@@sqlModeFilterPathText" style="font-family: var(--DEFAULT_FONT_FAMILY); font-weight: bolder; font-size: 0.9rem; color: #495057;">En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta query</span>
+                         <!-- SDA CUSTOM -->    <span i18n="@@sqlModeFilterPathText" style="font-family: var(--DEFAULT_FONT_FAMILY); font-weight: bolder; font-size: 0.9rem; color: #495057;">En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta</span>
                          <!-- SDA CUSTOM --></ng-container>
                          <!-- SDA CUSTOM --><ng-template #pathTpl>
                          <!-- SDA CUSTOM -->    <span class="d-flex align-items-center" [innerHTML]="getDisplayPathStr(globalFilter.pathList[panel.id].selectedTableNodes)"></span>

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.html
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.html
@@ -85,15 +85,15 @@
                                     </button>
                                 </td>
                                 <td style="width: 60%;">
-                                    <p-treeSelect *ngIf="globalFilter.pathList[panel.id]" 
-                                        [(ngModel)]="globalFilter.pathList[panel.id].selectedTableNodes"
-                                        [options]="panel.content.globalFilterPaths"
-                                        (onNodeExpand)="onNodeExpand(panel, $event)"
-                                        (onNodeSelect)="onNodeSelect(panel, $event)" appendTo="body"
-                                        [disabled]="!panel.active || !panel.avaliable">
+             <!-- SDA CUSTOM --><p-treeSelect *ngIf="globalFilter.pathList[panel.id]" [(ngModel)]="globalFilter.pathList[panel.id].selectedTableNodes" [options]="panel.content.globalFilterPaths" (onNodeExpand)="onNodeExpand(panel, $event)" (onNodeSelect)="onNodeSelect(panel, $event)" appendTo="body" [disabled]="!panel.active || !panel.avaliable || panel.content?.query?.query?.queryMode === 'SQL'">
 
                                         <ng-template pTemplate="value">
-                                            <span class="d-flex align-items-center" [innerHTML]="getDisplayPathStr(globalFilter.pathList[panel.id].selectedTableNodes)"></span>
+                         <!-- SDA CUSTOM --><ng-container *ngIf="panel.content?.query?.query?.queryMode === 'SQL'; else pathTpl">
+                         <!-- SDA CUSTOM -->    <span i18n="@@sqlModeFilterPathText" style="font-family: var(--DEFAULT_FONT_FAMILY); font-weight: bolder; font-size: 0.9rem; color: #495057;">En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta query</span>
+                         <!-- SDA CUSTOM --></ng-container>
+                         <!-- SDA CUSTOM --><ng-template #pathTpl>
+                         <!-- SDA CUSTOM -->    <span class="d-flex align-items-center" [innerHTML]="getDisplayPathStr(globalFilter.pathList[panel.id].selectedTableNodes)"></span>
+                         <!-- SDA CUSTOM --></ng-template>
                                         </ng-template>
 
                                         <ng-template let-node pTemplate="child">

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
@@ -379,6 +379,12 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
 
     public findPanelPathTables() {
         for (const panel of this.filteredPanels) {
+            /*SDA CUSTOM*/ if (panel.content?.query?.query?.queryMode === 'SQL') {
+            /*SDA CUSTOM*/     if (!this.globalFilter.panelList.includes(panel.id)) {
+            /*SDA CUSTOM*/         this.globalFilter.panelList.push(panel.id);
+            /*SDA CUSTOM*/     }
+            /*SDA CUSTOM*/     continue;
+            /*SDA CUSTOM*/ }
             panel.content.globalFilterPaths = this.globalFilterService.loadTablePaths(this.modelTables, panel);
 
             /*SDA CUSTOM*/ if (this.isPathStaleForPanel(panel)) {
@@ -595,6 +601,8 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
 
         if (!this.globalFilter.isdeleted) {
             for (const key in this.globalFilter.pathList) {
+                /*SDA CUSTOM*/ const panel = this.filteredPanels.find((p: any) => p.id === key);
+                /*SDA CUSTOM*/ if (panel?.content?.query?.query?.queryMode === 'SQL') continue;
                 if (availablePanels.includes(key) && _.isEmpty(this.globalFilter.pathList[key].selectedTableNodes)) {
                     valid = false;
                 }
@@ -684,6 +692,7 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
             this.display = false;
             this.close.emit(true);
         } else {
+            console.log('hola 1')
             this.alertService.addWarning($localize`:@@IncorrectForm:Formulario incorrecto. Revise los campos obligatorios.`);
         }
     }

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
@@ -168,7 +168,7 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
     }
 
     public initTablesForFilter() {
-                
+
         const queryTables = []; // si aparece
         const excludedTables = this.modelTables.filter((t: any) => t.visible === false).map((t: any) => t.table_name); // Si aparece
 
@@ -260,14 +260,14 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
     }
 
     public onChangeSelectedColumn(): void {
-        
+
         this.globalFilter.selectedItems = [];
         if (this.globalFilter.selectedColumn.column_type == 'date') {
             this.loadDatesFromFilter();
         } else {
             this.loadColumnValues();
         }
-        
+
         this.findPanelPathTables();
     }
 
@@ -311,12 +311,12 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
                 }
 
             } else {
-                
+
                 if (Array.isArray(response) && response.length > 1) {
                     const data = response[1];
                     this.columnValues = data.filter(item => !!item[0] || item[0] === '').map(item => ({ label: item[0], value: item[0] }));
                 }
-                
+
             }
 
         } catch (err) {
@@ -326,7 +326,7 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
     }
 
     onSelectedItemsChange(event: any) {
-        
+
         if(this.globalFilter.selectedColumn.valueListSource !== undefined) {
             this.globalFilter.selectedIdValues = event.map((e: any) => {
                 const value = this.totalValues.find(tv => e === tv[0]);
@@ -692,7 +692,6 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
             this.display = false;
             this.close.emit(true);
         } else {
-            console.log('hola 1')
             this.alertService.addWarning($localize`:@@IncorrectForm:Formulario incorrecto. Revise los campos obligatorios.`);
         }
     }

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
@@ -377,40 +377,9 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
         }
     }
 
-    // SDA CUSTOM — Auto-fill path for SQL panels: try 0-hop (same table) then BFS to filter table.
-    /*SDA CUSTOM*/ private tryAutoFillSqlPanel(panel: any): void {
-    /*SDA CUSTOM*/     const sqlOriginTableName: string = panel.content.query.query.fields?.[0]?.table_id;
-    /*SDA CUSTOM*/     const filterTableName: string = this.globalFilter.selectedTable?.table_name;
-    /*SDA CUSTOM*/     if (!sqlOriginTableName || !filterTableName) return;
-    /*SDA CUSTOM*/     if (sqlOriginTableName === filterTableName) {
-    /*SDA CUSTOM*/         // 0-hop: SQL origin IS the filter table — point directly to the root node
-    /*SDA CUSTOM*/         const rootNode = panel.content.globalFilterPaths[0];
-    /*SDA CUSTOM*/         if (!rootNode) return;
-    /*SDA CUSTOM*/         this.globalFilter.pathList[panel.id].table_id = rootNode.table_id;
-    /*SDA CUSTOM*/         this.globalFilter.pathList[panel.id].path = [];
-    /*SDA CUSTOM*/         this.globalFilter.pathList[panel.id].selectedTableNodes = rootNode;
-    /*SDA CUSTOM*/         if (!this.globalFilter.panelList.includes(panel.id)) this.globalFilter.panelList.push(panel.id);
-    /*SDA CUSTOM*/         return;
-    /*SDA CUSTOM*/     }
-    /*SDA CUSTOM*/     // Multi-hop: BFS from SQL origin to filter table
-    /*SDA CUSTOM*/     const result = this.globalFilterService.findShortestPath(sqlOriginTableName, filterTableName, this.modelTables);
-    /*SDA CUSTOM*/     if (result) {
-    /*SDA CUSTOM*/         this.globalFilter.pathList[panel.id].table_id = result.child_id;
-    /*SDA CUSTOM*/         this.globalFilter.pathList[panel.id].path = result.joins;
-    /*SDA CUSTOM*/         this.globalFilter.pathList[panel.id].selectedTableNodes = result;
-    /*SDA CUSTOM*/         if (!this.globalFilter.panelList.includes(panel.id)) this.globalFilter.panelList.push(panel.id);
-    /*SDA CUSTOM*/     }
-    /*SDA CUSTOM*/ }
-
     public findPanelPathTables() {
         for (const panel of this.filteredPanels) {
-            /*SDA CUSTOM*/ const sqlOrigin: string = panel.content.query.query.queryMode === 'SQL'
-            /*SDA CUSTOM*/     ? panel.content.query.query.fields?.[0]?.table_id
-            /*SDA CUSTOM*/     : null;
-
-            /*SDA CUSTOM*/ panel.content.globalFilterPaths = sqlOrigin
-            /*SDA CUSTOM*/     ? this.globalFilterService.loadTablePathsFromName(this.modelTables, sqlOrigin)
-            /*SDA CUSTOM*/     : this.globalFilterService.loadTablePaths(this.modelTables, panel);
+            panel.content.globalFilterPaths = this.globalFilterService.loadTablePaths(this.modelTables, panel);
 
             /*SDA CUSTOM*/ if (this.isPathStaleForPanel(panel)) {
             /*SDA CUSTOM*/     this.globalFilter.pathList[panel.id] = { selectedTableNodes: {}, path: [] };
@@ -421,15 +390,6 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
                 const panelQuery = panel.content.query.query;
                 const rootTable = panelQuery.rootTable;
 
-                /*SDA CUSTOM*/ if (panelQuery.queryMode === 'SQL') {
-                /*SDA CUSTOM*/     const panelListBefore = this.globalFilter.panelList.length;
-                /*SDA CUSTOM*/     this.tryAutoFillSqlPanel(panel);
-                /*SDA CUSTOM*/     // If no path found, deactivate (same as tree panels marked avaliable=false)
-                /*SDA CUSTOM*/     if (!this.globalFilter.panelList.includes(panel.id) && panelListBefore === this.globalFilter.panelList.length) {
-                /*SDA CUSTOM*/         panel.active = false;
-                /*SDA CUSTOM*/         this.filteredPanels = this.allPanels.filter((p: any) => p.avaliable && p.active);
-                /*SDA CUSTOM*/     }
-                /*SDA CUSTOM*/ } else
                 if (this.globalFilter.selectedTable.table_name == rootTable) {
                     const node = panel.content.globalFilterPaths[0];
 

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
@@ -286,6 +286,8 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
             const query = this.queryBuilderService.normalQuery([this.globalFilter.selectedColumn], params);
             const response = await this.dashboardService.executeQuery(query).toPromise();
 
+            /*SDA CUSTOM*/ if (!this.globalFilter) return;
+
             // only if the value is a ValueListSource
             if(this.globalFilter.selectedColumn.valueListSource !== undefined) {
                 // Generate all the label and id values for the valueListSource filters.

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
@@ -207,7 +207,7 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
         /*SDA CUSTOM*/ // the tree-panel BFS (which returns an empty Map if any table is unreachable).
         /*SDA CUSTOM*/ for (const panel of this.allPanels) {
         /*SDA CUSTOM*/     if (panel.content?.query?.query?.queryMode !== 'SQL') continue;
-        /*SDA CUSTOM*/     const sqlOrigin: string = panel.content.query.query.fields?.[0]?.table_id;
+        /*SDA CUSTOM*/     const sqlOrigin: string = panel.content.query.query.fields?.[0]?.table_id?.split('.')[0];
         /*SDA CUSTOM*/     if (!sqlOrigin || excludedTables.includes(sqlOrigin)) continue;
         /*SDA CUSTOM*/     const sqlRelatedMap = this.globalFilterService.relatedTables([sqlOrigin], this.modelTables);
         /*SDA CUSTOM*/     sqlRelatedMap.forEach((value: any, key: string) => {

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
@@ -130,12 +130,13 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
         this.allPanels = this.globalFilterService.filterPanels(this.modelTables, this.panels);
         this.allPanels = this.allPanels.sort(this.sortByTittle);
 
-        /*SDA CUSTOM*/ // Make SQL panels activatable: override avaliable=false set by filterPanels BFS
-        /*SDA CUSTOM*/ // (BFS excludes SQL panels because their origin tables may not be reachable from rootTable).
+        /*SDA CUSTOM*/ // Override filterPanels BFS result for SQL panels: set avaliable=true and active=true
+        /*SDA CUSTOM*/ // so they appear in the dialog exactly like tree panels (highlighted, treeSelect enabled).
+        /*SDA CUSTOM*/ // Panels without a valid path get deactivated later in findPanelPathTables.
         /*SDA CUSTOM*/ for (const panel of this.allPanels) {
         /*SDA CUSTOM*/     if (panel.content?.query?.query?.queryMode === 'SQL') {
         /*SDA CUSTOM*/         panel.avaliable = true;
-        /*SDA CUSTOM*/         panel.active = false;
+        /*SDA CUSTOM*/         panel.active = true;
         /*SDA CUSTOM*/     }
         /*SDA CUSTOM*/     if (panel.content && panel.content.globalFilterPaths === undefined) {
         /*SDA CUSTOM*/         panel.content.globalFilterPaths = [];
@@ -404,7 +405,13 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
                 const rootTable = panelQuery.rootTable;
 
                 /*SDA CUSTOM*/ if (panelQuery.queryMode === 'SQL') {
+                /*SDA CUSTOM*/     const panelListBefore = this.globalFilter.panelList.length;
                 /*SDA CUSTOM*/     this.tryAutoFillSqlPanel(panel);
+                /*SDA CUSTOM*/     // If no path found, deactivate (same as tree panels marked avaliable=false)
+                /*SDA CUSTOM*/     if (!this.globalFilter.panelList.includes(panel.id) && panelListBefore === this.globalFilter.panelList.length) {
+                /*SDA CUSTOM*/         panel.active = false;
+                /*SDA CUSTOM*/         this.filteredPanels = this.allPanels.filter((p: any) => p.avaliable && p.active);
+                /*SDA CUSTOM*/     }
                 /*SDA CUSTOM*/ } else
                 if (this.globalFilter.selectedTable.table_name == rootTable) {
                     const node = panel.content.globalFilterPaths[0];

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter-dialog/global-filter-dialog.component.ts
@@ -130,14 +130,20 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
         this.allPanels = this.globalFilterService.filterPanels(this.modelTables, this.panels);
         this.allPanels = this.allPanels.sort(this.sortByTittle);
 
+        /*SDA CUSTOM*/ // Make SQL panels activatable: override avaliable=false set by filterPanels BFS
+        /*SDA CUSTOM*/ // (BFS excludes SQL panels because their origin tables may not be reachable from rootTable).
+        /*SDA CUSTOM*/ for (const panel of this.allPanels) {
+        /*SDA CUSTOM*/     if (panel.content?.query?.query?.queryMode === 'SQL') {
+        /*SDA CUSTOM*/         panel.avaliable = true;
+        /*SDA CUSTOM*/         panel.active = false;
+        /*SDA CUSTOM*/     }
+        /*SDA CUSTOM*/     if (panel.content && panel.content.globalFilterPaths === undefined) {
+        /*SDA CUSTOM*/         panel.content.globalFilterPaths = [];
+        /*SDA CUSTOM*/     }
+        /*SDA CUSTOM*/ }
+
         if (this.globalFilter.isnew) {
             for (const panel of this.allPanels) {
-
-                // Desactivando el panel en caso de que sea de modo SQL.
-                if(panel.content.query.query.queryMode === 'SQL') {
-                    panel.active = false;
-                }
-
                 this.globalFilter.pathList[panel.id] = {
                     selectedTableNodes: {},
                     path: []
@@ -164,11 +170,12 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
         const queryTables = []; // si aparece
         const excludedTables = this.modelTables.filter((t: any) => t.visible === false).map((t: any) => t.table_name); // Si aparece
 
-       // filteredPanels list is empty because all panels are disabled. 
+       // filteredPanels list is empty because all panels are disabled.
         if(this.filteredPanels.length===0){
             for (const panel of this.allPanels) {
+                /*SDA CUSTOM*/ if (panel.content?.query?.query?.queryMode === 'SQL') continue; // SQL panels handled separately below
                 const panelQuery = panel.content.query.query;
-    
+
                 for (const field of panelQuery.fields) {
                     const table_id = field.table_id.split('.')[0];
                     if (!queryTables.includes(table_id)) queryTables.push(table_id);
@@ -176,8 +183,9 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
             }
         } else {
             for (const panel of this.filteredPanels) {
+                /*SDA CUSTOM*/ if (panel.content?.query?.query?.queryMode === 'SQL') continue; // SQL panels handled separately below
                 const panelQuery = panel.content.query.query;
-    
+
                 for (const field of panelQuery.fields) {
                     const table_id = field.table_id.split('.')[0];
                     if (!queryTables.includes(table_id)) queryTables.push(table_id);
@@ -192,6 +200,21 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
             }
         });
 
+        /*SDA CUSTOM*/ // Add tables reachable from each SQL panel's origin table (BFS from that origin).
+        /*SDA CUSTOM*/ // We run a separate relatedTables call per SQL panel so SQL origins never contaminate
+        /*SDA CUSTOM*/ // the tree-panel BFS (which returns an empty Map if any table is unreachable).
+        /*SDA CUSTOM*/ for (const panel of this.allPanels) {
+        /*SDA CUSTOM*/     if (panel.content?.query?.query?.queryMode !== 'SQL') continue;
+        /*SDA CUSTOM*/     const sqlOrigin: string = panel.content.query.query.fields?.[0]?.table_id;
+        /*SDA CUSTOM*/     if (!sqlOrigin || excludedTables.includes(sqlOrigin)) continue;
+        /*SDA CUSTOM*/     const sqlRelatedMap = this.globalFilterService.relatedTables([sqlOrigin], this.modelTables);
+        /*SDA CUSTOM*/     sqlRelatedMap.forEach((value: any, key: string) => {
+        /*SDA CUSTOM*/         if (!excludedTables.includes(key) && !this.tables.some((t: any) => t.table_name === key)) {
+        /*SDA CUSTOM*/             this.tables.push(value);
+        /*SDA CUSTOM*/         }
+        /*SDA CUSTOM*/     });
+        /*SDA CUSTOM*/ }
+
         // this.tables = this.tables.slice();
         this.tables.sort((a, b) => a.display_name.default.localeCompare(b.display_name.default));
     }
@@ -199,9 +222,7 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
     public onAddPanelForFilter(panel: any) {
 
         if (panel.avaliable) {
-            if(panel.content.query.query.queryMode != 'SQL') { // los paneles SQL no se pueden activar
-                panel.active = !panel.active;
-            }
+            panel.active = !panel.active; /*SDA CUSTOM*/ // SQL panels are now activatable
             this.filteredPanels = this.allPanels.filter((p: any) => p.avaliable && p.active);
 
             if (panel.active) {
@@ -343,14 +364,48 @@ export class GlobalFilterDialogComponent implements OnInit, OnDestroy {
         }
     }
 
+    // SDA CUSTOM — Auto-fill path for SQL panels: try 0-hop (same table) then BFS to filter table.
+    /*SDA CUSTOM*/ private tryAutoFillSqlPanel(panel: any): void {
+    /*SDA CUSTOM*/     const sqlOriginTableName: string = panel.content.query.query.fields?.[0]?.table_id;
+    /*SDA CUSTOM*/     const filterTableName: string = this.globalFilter.selectedTable?.table_name;
+    /*SDA CUSTOM*/     if (!sqlOriginTableName || !filterTableName) return;
+    /*SDA CUSTOM*/     if (sqlOriginTableName === filterTableName) {
+    /*SDA CUSTOM*/         // 0-hop: SQL origin IS the filter table — point directly to the root node
+    /*SDA CUSTOM*/         const rootNode = panel.content.globalFilterPaths[0];
+    /*SDA CUSTOM*/         if (!rootNode) return;
+    /*SDA CUSTOM*/         this.globalFilter.pathList[panel.id].table_id = rootNode.table_id;
+    /*SDA CUSTOM*/         this.globalFilter.pathList[panel.id].path = [];
+    /*SDA CUSTOM*/         this.globalFilter.pathList[panel.id].selectedTableNodes = rootNode;
+    /*SDA CUSTOM*/         if (!this.globalFilter.panelList.includes(panel.id)) this.globalFilter.panelList.push(panel.id);
+    /*SDA CUSTOM*/         return;
+    /*SDA CUSTOM*/     }
+    /*SDA CUSTOM*/     // Multi-hop: BFS from SQL origin to filter table
+    /*SDA CUSTOM*/     const result = this.globalFilterService.findShortestPath(sqlOriginTableName, filterTableName, this.modelTables);
+    /*SDA CUSTOM*/     if (result) {
+    /*SDA CUSTOM*/         this.globalFilter.pathList[panel.id].table_id = result.child_id;
+    /*SDA CUSTOM*/         this.globalFilter.pathList[panel.id].path = result.joins;
+    /*SDA CUSTOM*/         this.globalFilter.pathList[panel.id].selectedTableNodes = result;
+    /*SDA CUSTOM*/         if (!this.globalFilter.panelList.includes(panel.id)) this.globalFilter.panelList.push(panel.id);
+    /*SDA CUSTOM*/     }
+    /*SDA CUSTOM*/ }
+
     public findPanelPathTables() {
         for (const panel of this.filteredPanels) {
-            panel.content.globalFilterPaths = this.globalFilterService.loadTablePaths(this.modelTables, panel);
+            /*SDA CUSTOM*/ const sqlOrigin: string = panel.content.query.query.queryMode === 'SQL'
+            /*SDA CUSTOM*/     ? panel.content.query.query.fields?.[0]?.table_id
+            /*SDA CUSTOM*/     : null;
+
+            /*SDA CUSTOM*/ panel.content.globalFilterPaths = sqlOrigin
+            /*SDA CUSTOM*/     ? this.globalFilterService.loadTablePathsFromName(this.modelTables, sqlOrigin)
+            /*SDA CUSTOM*/     : this.globalFilterService.loadTablePaths(this.modelTables, panel);
 
             if (this.globalFilter.pathList[panel.id] && this.isEmpty(this.globalFilter.pathList[panel.id].selectedTableNodes)) {
                 const panelQuery = panel.content.query.query;
                 const rootTable = panelQuery.rootTable;
 
+                /*SDA CUSTOM*/ if (panelQuery.queryMode === 'SQL') {
+                /*SDA CUSTOM*/     this.tryAutoFillSqlPanel(panel);
+                /*SDA CUSTOM*/ } else
                 if (this.globalFilter.selectedTable.table_name == rootTable) {
                     const node = panel.content.globalFilterPaths[0];
 

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
@@ -478,6 +478,10 @@ export class GlobalFilterComponent implements OnInit {
             globalFilter = this.globalFilter;
         }
 
+        /*SDA CUSTOM*/ if (!globalFilter || !this.globalFilters.find((gf: any) => gf.id == globalFilter.id)) {
+        /*SDA CUSTOM*/     return;
+        /*SDA CUSTOM*/ }
+
         let targetTable: string;
         let targetColumn: any;
 
@@ -508,9 +512,12 @@ export class GlobalFilterComponent implements OnInit {
             const res = await this.dashboardService.executeQuery(query).toPromise();
 
             if( res[0][0]=='noDataAllowed' || res[0][0]=='noFilterAllowed'){
-                this.globalFilters.find((gf: any) => gf.id == globalFilter.id).visible = 'hidden';
-                this.globalFilters.find((gf: any) => gf.id == globalFilter.id).data = false;
-                this.globalFilters;
+                /* SDA CUSTOM */ const restrictedFilter = this.globalFilters.find((gf: any) => gf.id == globalFilter.id);
+                /* SDA CUSTOM */ if (restrictedFilter) {
+                /* SDA CUSTOM */     restrictedFilter.visible = 'hidden';
+                /* SDA CUSTOM */     restrictedFilter.data = false;
+                /* SDA CUSTOM */ }
+                /* SDA CUSTOM */ return;
             }
 
             let data : any[] ;
@@ -552,7 +559,10 @@ export class GlobalFilterComponent implements OnInit {
                 })
 
 
-            this.globalFilters.find((gf: any) => gf.id == globalFilter.id).data = data;
+            /* SDA CUSTOM */ const filterRef = this.globalFilters.find((gf: any) => gf.id == globalFilter.id);
+            /* SDA CUSTOM */ if (filterRef) {
+            /* SDA CUSTOM */     filterRef.data = data;
+            /* SDA CUSTOM */ }
 
 
         } catch (err) {

--- a/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
+++ b/eda/eda_app/src/app/module/pages/dashboard/global-filter/global-filter.component.ts
@@ -214,19 +214,17 @@ export class GlobalFilterComponent implements OnInit {
     // Main Global Filter
     public onShowGlobalFilter(isnew: boolean, filter?: any): void {
         if (this.dashboard.validateDashboard('GLOBALFILTER')) {
-            const treeQueryMode = this.dashboard.edaPanels.some((panel) => panel.selectedQueryMode === 'EDA2');
-
-            if (treeQueryMode) {
-                if (isnew) this.globalFilter = { isnew: true };
-                else {
-                    filter.isnew = false;
-                    this.globalFilter = _.cloneDeep(filter);
-                }
-
-                this.dashboard.display_v.rightSidebar = false;
-            } else {
-                this.onFilterConfig(isnew, filter);
+            /*SDA CUSTOM*/ // Always open the new dialog (app-global-filter-dialog) with route support.
+            /*SDA CUSTOM*/ // Previously this checked for 'EDA2' panels and fell back to the legacy
+            /*SDA CUSTOM*/ // dashboard-filter-dialog for SQL-only dashboards. Now SQL panels are fully
+            /*SDA CUSTOM*/ // integrated into the new dialog so the legacy path is never needed.
+            if (isnew) this.globalFilter = { isnew: true };
+            else {
+                filter.isnew = false;
+                this.globalFilter = _.cloneDeep(filter);
             }
+
+            this.dashboard.display_v.rightSidebar = false;
         }
     }
 

--- a/eda/eda_app/src/app/services/api/global-filters.service.ts
+++ b/eda/eda_app/src/app/services/api/global-filters.service.ts
@@ -260,6 +260,56 @@ export class GlobalFiltersService {
         return pathsTables;
     }
 
+    // SDA CUSTOM — Builds the tree root node for a SQL panel using the given table name directly,
+    // SDA CUSTOM   instead of relying on rootTable from the panel query (which SQL panels don't have).
+    /*SDA CUSTOM*/ public loadTablePathsFromName(tables: any[], tableName: string): any[] {
+    /*SDA CUSTOM*/     const pathsTables: any[] = [];
+    /*SDA CUSTOM*/     const table = tables.find((source: any) => source.table_name === tableName);
+    /*SDA CUSTOM*/     if (table) {
+    /*SDA CUSTOM*/         const node: any = { label: table.display_name?.default || tableName, table_id: tableName };
+    /*SDA CUSTOM*/         if (table.relations && table.relations.length > 0) {
+    /*SDA CUSTOM*/             node.expandedIcon = 'pi pi-folder-open';
+    /*SDA CUSTOM*/             node.collapsedIcon = 'pi pi-folder';
+    /*SDA CUSTOM*/             node.children = [{}];
+    /*SDA CUSTOM*/         }
+    /*SDA CUSTOM*/         pathsTables.push(node);
+    /*SDA CUSTOM*/     }
+    /*SDA CUSTOM*/     return pathsTables;
+    /*SDA CUSTOM*/ }
+
+    // SDA CUSTOM — BFS over model table relations to find the shortest join path from startTable to targetTable.
+    // SDA CUSTOM   Returns a node object compatible with pathList entries, or null if no path is found.
+    /*SDA CUSTOM*/ public findShortestPath(startTable: string, targetTable: string, modelTables: any[]): any | null {
+    /*SDA CUSTOM*/     if (!startTable || !targetTable || startTable === targetTable) return null;
+    /*SDA CUSTOM*/     const queue: Array<{ tableName: string; joins: any[][] }> = [{ tableName: startTable, joins: [] }];
+    /*SDA CUSTOM*/     const visited = new Set<string>([startTable]);
+    /*SDA CUSTOM*/     while (queue.length > 0) {
+    /*SDA CUSTOM*/         const { tableName, joins } = queue.shift();
+    /*SDA CUSTOM*/         const table = modelTables.find((t: any) => t.table_name === tableName);
+    /*SDA CUSTOM*/         if (!table) continue;
+    /*SDA CUSTOM*/         const relations = (table.relations || []).filter(
+    /*SDA CUSTOM*/             (rel: any) => !rel.bridge && !rel.autorelation && rel.visible !== false
+    /*SDA CUSTOM*/         );
+    /*SDA CUSTOM*/         for (const rel of relations) {
+    /*SDA CUSTOM*/             const nextTable: string = rel.target_table;
+    /*SDA CUSTOM*/             const sourceJoin = `${rel.source_table || tableName}.${rel.source_column[0]}`;
+    /*SDA CUSTOM*/             const joinChildId = `${rel.target_table}.${rel.target_column[0]}`;
+    /*SDA CUSTOM*/             const child_id = `${joinChildId}.${rel.source_column[0]}`;
+    /*SDA CUSTOM*/             const newJoins = [...joins, [sourceJoin, joinChildId]];
+    /*SDA CUSTOM*/             const childLabel = rel.display_name?.default || `${rel.source_column[0]} - ${rel.target_table}`;
+    /*SDA CUSTOM*/             if (nextTable === targetTable) {
+    /*SDA CUSTOM*/                 return { child_id, type: 'child', label: childLabel, autorelation: false, joins: newJoins };
+    /*SDA CUSTOM*/             }
+    /*SDA CUSTOM*/             if (!visited.has(nextTable)) {
+    /*SDA CUSTOM*/                 visited.add(nextTable);
+    /*SDA CUSTOM*/                 queue.push({ tableName: nextTable, joins: newJoins });
+    /*SDA CUSTOM*/             }
+    /*SDA CUSTOM*/         }
+    /*SDA CUSTOM*/     }
+    /*SDA CUSTOM*/     return null;
+    /*SDA CUSTOM*/ }
+
+
     /**
      * Expands a node in a tree structure, adding its child nodes based on table relations.
      * Prevents duplicate paths and handles autorelations.

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -2500,6 +2500,10 @@ Ingresa ahora<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;" />
 <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
 </target>
 </trans-unit>
+<trans-unit id="sqlModeFilterPathText">
+  <source>En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta query</source>
+  <target>En mode SQL, si necessita modificar la ruta, ha de fer-ho a la consulta query</target>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -1606,7 +1606,7 @@
       </trans-unit>
       <trans-unit id="sqlModeFilterPathText">
         <source>En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta</source>
-        <target>En mode SQL, si necessita modificar la ruta, ha de fer-ho a la consulta.</target>
+        <target>En mode SQL, si necessiteu modificar la ruta, heu de fer-ho a la consulta.</target>
       </trans-unit>
       
       <!-- SECTION: SELECTOR DE FECHAS (DATEPICKER) -->

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -1604,7 +1604,11 @@
         <source>elementos seleccionados</source>
         <target>elements seleccionats</target>
       </trans-unit>
-
+      <trans-unit id="sqlModeFilterPathText">
+        <source>En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta</source>
+        <target>En mode SQL, si necessita modificar la ruta, ha de fer-ho a la consulta.</target>
+      </trans-unit>
+      
       <!-- SECTION: SELECTOR DE FECHAS (DATEPICKER) -->
       <trans-unit id="dates1">
         <source>AÑO</source>
@@ -2499,10 +2503,6 @@ Ingresa ahora<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;" />
 <target>
 <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
 </target>
-</trans-unit>
-<trans-unit id="sqlModeFilterPathText">
-  <source>En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta query</source>
-  <target>En mode SQL, si necessita modificar la ruta, ha de fer-ho a la consulta query</target>
 </trans-unit>
 </body>
 </file>

--- a/eda/eda_app/src/locale/messages.ca.xlf
+++ b/eda/eda_app/src/locale/messages.ca.xlf
@@ -599,7 +599,6 @@
         <source>Un gráfico de áreas necesita una o más categorías y una serie numérica. Además, si hay más de una serie, los datos numéricos deben agregarse.</source>
         <target>Un gràfic d'àrees necessita una o més categories i una sèrie numèrica. A més, si hi ha més d'una sèrie les dades numèriques han d'agregar-se.</target>
       </trans-unit>
-
       <trans-unit id="chartInfo8">
         <source>Un gráfico polar necesita una categoría y una serie numérica.</source>
         <target>Un gràfic polar necessita una categoria i una sèrie numèrica.</target>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -1603,6 +1603,10 @@
         <source>elementos seleccionados</source>
         <target>selected items</target>
       </trans-unit>
+      <trans-unit id="sqlModeFilterPathText">
+        <source>En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta</source>
+        <target>In SQL mode, if you need to modify the path, you must do it in the query.</target>
+      </trans-unit>
 
       <!-- SECTION: SELECTOR DE FECHAS (DATEPICKER) -->
       <trans-unit id="dates1">
@@ -2498,10 +2502,6 @@ Ingresa ahora<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;" />
 <target>
 <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
 </target>
-</trans-unit>
-<trans-unit id="sqlModeFilterPathText">
-  <source>En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta query</source>
-  <target>In SQL mode, if you need to modify the path, you must do it in the query.</target>
 </trans-unit>
 </body>
 </file>

--- a/eda/eda_app/src/locale/messages.en.xlf
+++ b/eda/eda_app/src/locale/messages.en.xlf
@@ -2499,6 +2499,10 @@ Ingresa ahora<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;" />
 <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
 </target>
 </trans-unit>
+<trans-unit id="sqlModeFilterPathText">
+  <source>En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta query</source>
+  <target>In SQL mode, if you need to modify the path, you must do it in the query.</target>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -1603,6 +1603,10 @@
         <source>elementos seleccionados</source>
         <target>elementos seleccionados</target>
       </trans-unit>
+      <trans-unit id="sqlModeFilterPathText">
+        <source>En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta</source>
+        <target>En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta.</target>
+      </trans-unit>
 
       <!-- SECTION: SELECTOR DE FECHAS (DATEPICKER) -->
       <trans-unit id="dates1">
@@ -2498,10 +2502,6 @@ Ingresa ahora<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;" />
 <target>
 <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
 </target>
-</trans-unit>
-<trans-unit id="sqlModeFilterPathText">
-  <source>En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta query</source>
-  <target>En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta query</target>
 </trans-unit>
 </body>
 </file>

--- a/eda/eda_app/src/locale/messages.es.xlf
+++ b/eda/eda_app/src/locale/messages.es.xlf
@@ -2499,6 +2499,10 @@ Ingresa ahora<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;" />
 <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
 </target>
 </trans-unit>
+<trans-unit id="sqlModeFilterPathText">
+  <source>En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta query</source>
+  <target>En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta query</target>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -1603,6 +1603,10 @@
         <source>elementos seleccionados</source>
         <target>elementos seleccionados</target>
       </trans-unit>
+      <trans-unit id="sqlModeFilterPathText">
+        <source>En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta</source>
+        <target>En modo SQL, se necesita modificar a ruta, debe facelo na consulta.</target>
+      </trans-unit>
 
       <!-- SECTION: SELECTOR DE FECHAS (DATEPICKER) -->
       <trans-unit id="dates1">
@@ -2498,10 +2502,6 @@ Ingresa ahora<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;" />
         <target>
 <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
 </target>
-      </trans-unit>
-      <trans-unit id="sqlModeFilterPathText">
-        <source>En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta query</source>
-        <target>En modo SQL, se necesita modificar a ruta, debe facelo na consulta query.</target>
       </trans-unit>
     </body>
   </file>

--- a/eda/eda_app/src/locale/messages.gl.xlf
+++ b/eda/eda_app/src/locale/messages.gl.xlf
@@ -2499,6 +2499,10 @@ Ingresa ahora<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;" />
 <x id="INTERPOLATION" equiv-text="{{getDisplayName(userSelectedTable)}" />
 </target>
       </trans-unit>
+      <trans-unit id="sqlModeFilterPathText">
+        <source>En modo SQL, si necesita modificar la ruta, debe hacerlo en la consulta query</source>
+        <target>En modo SQL, se necesita modificar a ruta, debe facelo na consulta query.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
## Descripción del Cambio
Para permitir la funcionalidad que se describe en el isue hay que:
1. Habilitat la posibilidad de filtrar los paneles SQL por los filltros globales.
2. Generar el autocompletado de la ruta. Aunque es meramente informativo.
3. Propagar el filtro hasta el panel SQL para inyectarlo en el filtro. 

## Issue(s) resuelto(s)

- solves #329

## Pruebas a realizar para validar el cambio
Hacer un informe con paneles SQL. 
Un informe con un primer panel SQL y luego uno en modo arbol.
Un informe con un primer panel arbol y luego SQL.
En el panel SQL hay que poner la consulta SQL y vincular el filtro según se describe en la ayuda contextual.
Hacer consultas sencillas y complejas.
Hacer consultas donde aplique la seguridad de acceso al dato.


